### PR TITLE
refactor: 숙소 현지 날짜와 UTC 기반 예약 흐름 정비

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,9 @@ dependencies {
 	// Commons Lang
 	implementation 'org.apache.commons:commons-lang3:3.18.0'
 
+	// Coordinate-based IANA time zone resolution
+	implementation 'net.iakovlev:timeshape:2026b.29'
+
 	// Jackson CSV
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
 

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
 	maxHeapSize = '1g'
+	systemProperty 'user.timezone', 'UTC'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,6 @@ dependencies {
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
-	maxHeapSize = '1g'
 	systemProperty 'user.timezone', 'UTC'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ dependencies {
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+	maxHeapSize = '1g'
 }
 
 

--- a/docker-compose.oci.yml
+++ b/docker-compose.oci.yml
@@ -63,7 +63,7 @@ services:
       - SPRING_PROFILES_ACTIVE=oci
       - JAVA_OPTS=-Xms512m -Xmx1536m -XX:+UseG1GC -XX:MaxGCPauseMillis=200
       # Docker 내부 서비스 주소 오버라이드
-      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/airbobdb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/airbobdb?useSSL=false&allowPublicKeyRetrieval=true
       - REDIS_HOST=redis
       - ELASTICSEARCH_URIS=http://elasticsearch:9200
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080
 
+ENV JAVA_TOOL_OPTIONS="-Duser.timezone=UTC"
 ENV JAVA_OPTS=""
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/logstash/pipeline/airbob.conf
+++ b/logstash/pipeline/airbob.conf
@@ -21,6 +21,7 @@ input {
         a.currency,
         a.type,
         a.status,
+        a.time_zone_id,
         DATE_FORMAT(a.created_at, '%Y-%m-%dT%H:%i:%s.000Z') AS created_at,
         a.thumbnail_url,
 
@@ -61,14 +62,15 @@ input {
           r.accommodation_id,
           JSON_ARRAYAGG(
             JSON_OBJECT(
-              'gte', DATE_FORMAT(DATE(r.check_in), '%Y-%m-%d'),
-              'lt', DATE_FORMAT(DATE(r.check_out), '%Y-%m-%d')
+              'gte', DATE_FORMAT(r.check_in_date, '%Y-%m-%d'),
+              'lt', DATE_FORMAT(r.check_out_date, '%Y-%m-%d')
             )
           ) AS reservation_ranges_json
-        FROM reservation r
-        WHERE r.status = 'CONFIRMED'
-          AND r.check_out >= CURRENT_TIMESTAMP(6)
-        GROUP BY r.accommodation_id
+		FROM reservation r
+		WHERE r.status IN ('CONFIRMED', 'CANCELLATION_PENDING', 'CANCELLATION_FAILED')
+		  AND r.check_in_date < DATE_ADD(DATE_ADD(UTC_DATE(), INTERVAL 1 DAY), INTERVAL 3 MONTH)
+		  AND r.check_out_date > DATE_SUB(UTC_DATE(), INTERVAL 1 DAY)
+		GROUP BY r.accommodation_id
       ) reservations ON reservations.accommodation_id = a.id
       WHERE a.status = 'PUBLISHED'
         AND a.accommodation_uid IS NOT NULL
@@ -126,6 +128,7 @@ filter {
       "accommodation_id" => "accommodationId"
       "base_price" => "basePrice"
       "created_at" => "createdAt"
+      "time_zone_id" => "timeZoneId"
       "thumbnail_url" => "thumbnailUrl"
       "address_detail" => "addressDetail"
       "postal_code" => "postalCode"

--- a/src/main/java/kr/kro/airbob/AirbobApplication.java
+++ b/src/main/java/kr/kro/airbob/AirbobApplication.java
@@ -1,5 +1,7 @@
 package kr.kro.airbob;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class AirbobApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 		SpringApplication.run(AirbobApplication.class, args);
 	}
 

--- a/src/main/java/kr/kro/airbob/AirbobApplication.java
+++ b/src/main/java/kr/kro/airbob/AirbobApplication.java
@@ -1,7 +1,5 @@
 package kr.kro.airbob;
 
-import java.util.TimeZone;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -9,7 +7,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class AirbobApplication {
 
 	public static void main(String[] args) {
-		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 		SpringApplication.run(AirbobApplication.class, args);
 	}
 

--- a/src/main/java/kr/kro/airbob/common/exception/ErrorCode.java
+++ b/src/main/java/kr/kro/airbob/common/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
 	ACCOMMODATION_INVALID_PRICE(HttpStatus.BAD_REQUEST, "A005", "숙소 가격이 유효하지 않습니다."),
 	ACCOMMODATION_IMAGE_COUNT_TOO_LOW(HttpStatus.BAD_REQUEST, "A006", "숙소 이미지가 최소 요구 개수 미만입니다."),
 	ACCOMMODATION_INVALID_AMENITY(HttpStatus.BAD_REQUEST, "A007", "편의시설 코드가 유효하지 않습니다."),
+	ACCOMMODATION_LOCATION_RESOLUTION_FAILED(HttpStatus.BAD_REQUEST, "A008", "숙소 위치의 좌표 또는 시간대를 확인할 수 없습니다."),
 	PUBLISHING_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "A003", "숙소 게시를 위한 필수 정보가 누락되거나 유효하지 않습니다."),
 
 

--- a/src/main/java/kr/kro/airbob/common/exception/ErrorCode.java
+++ b/src/main/java/kr/kro/airbob/common/exception/ErrorCode.java
@@ -15,10 +15,11 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부에서 처리할 수 없는 오류가 발생했습니다."),
 	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "유효하지 않은 타입 값입니다."),
 	CURSOR_ENCODING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C005", "커서 인코딩 중 오류가 발생했습니다."),
-	CURSOR_PAGE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "C006", "커서 페이지 크기는 1 이상이어야 합니다."),
+	CURSOR_PAGE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "C006", "유효하지 않은 커서 페이지 크기입니다."),
 	OUTBOX_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "C007", "요청을 처리하는 중 내부 이벤트 시스템에 오류가 발생했습니다."),
 	DEBEZIUM_EVENT_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C008", "Debezium 이벤트 파싱 실패"),
 	INVALID_INPUT(HttpStatus.BAD_REQUEST, "C009", "요청 ID와 리소스가 속한 ID가 일치하지 않습니다."),
+	CURSOR_DECODING_ERROR(HttpStatus.BAD_REQUEST, "C010", "유효하지 않은 커서입니다."),
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "R000", "리소스를 찾을 수 없습니다."),
 
 	// common code
@@ -60,6 +61,8 @@ public enum ErrorCode {
 	RESERVATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "R008", "해당 예약에 대한 접근 권한이 없습니다."),
 	INVALID_RESERVATION_DATE(HttpStatus.BAD_REQUEST, "R009", "체크아웃 날짜는 체크인 날짜보다 이후여야 합니다."),
 	RESERVATION_OUTSIDE_BOOKING_WINDOW(HttpStatus.BAD_REQUEST, "R010", "예약 숙박일은 오늘부터 3개월 이내만 선택할 수 있습니다."),
+	CANNOT_CONFIRM_EXPIRED_RESERVATION(HttpStatus.CONFLICT, "R011", "결제 유효 시간이 지난 예약은 확정할 수 없습니다."),
+	RESERVATION_LOCAL_TIME_INVALID(HttpStatus.BAD_REQUEST, "R012", "해당 날짜에는 숙소의 체크인 또는 체크아웃 시각이 존재하지 않습니다."),
 
 
 	// payment

--- a/src/main/java/kr/kro/airbob/common/exception/ErrorCode.java
+++ b/src/main/java/kr/kro/airbob/common/exception/ErrorCode.java
@@ -15,11 +15,10 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부에서 처리할 수 없는 오류가 발생했습니다."),
 	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "유효하지 않은 타입 값입니다."),
 	CURSOR_ENCODING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C005", "커서 인코딩 중 오류가 발생했습니다."),
-	CURSOR_PAGE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "C006", "유효하지 않은 커서 페이지 크기입니다."),
+	CURSOR_PAGE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "C006", "커서 페이지 크기는 1 이상이어야 합니다."),
 	OUTBOX_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "C007", "요청을 처리하는 중 내부 이벤트 시스템에 오류가 발생했습니다."),
 	DEBEZIUM_EVENT_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C008", "Debezium 이벤트 파싱 실패"),
 	INVALID_INPUT(HttpStatus.BAD_REQUEST, "C009", "요청 ID와 리소스가 속한 ID가 일치하지 않습니다."),
-	CURSOR_DECODING_ERROR(HttpStatus.BAD_REQUEST, "C010", "유효하지 않은 커서입니다."),
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "R000", "리소스를 찾을 수 없습니다."),
 
 	// common code

--- a/src/main/java/kr/kro/airbob/config/ClockConfig.java
+++ b/src/main/java/kr/kro/airbob/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package kr.kro.airbob.config;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+	@Bean
+	public Clock clock() {
+		return Clock.systemUTC();
+	}
+}

--- a/src/main/java/kr/kro/airbob/config/JpaAuditingConfig.java
+++ b/src/main/java/kr/kro/airbob/config/JpaAuditingConfig.java
@@ -3,6 +3,7 @@ package kr.kro.airbob.config;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import org.springframework.context.annotation.Bean;
@@ -21,8 +22,6 @@ import kr.kro.airbob.common.context.UserInfo;
 	dateTimeProviderRef = "utcDateTimeProvider"
 )
 public class JpaAuditingConfig {
-	private static final Clock UTC_CLOCK = Clock.systemUTC();
-
 	// created_by / updated_by 자동 채움: 인증된 요청이면 member.id, 아니면 비움(NULL).
 	@Bean
 	public AuditorAware<Long> auditorProvider() {
@@ -30,7 +29,7 @@ public class JpaAuditingConfig {
 	}
 
 	@Bean
-	public DateTimeProvider utcDateTimeProvider() {
-		return () -> Optional.of(LocalDateTime.now(UTC_CLOCK));
+	public DateTimeProvider utcDateTimeProvider(Clock clock) {
+		return () -> Optional.of(LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC));
 	}
 }

--- a/src/main/java/kr/kro/airbob/config/JpaAuditingConfig.java
+++ b/src/main/java/kr/kro/airbob/config/JpaAuditingConfig.java
@@ -1,11 +1,14 @@
 package kr.kro.airbob.config;
 
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import kr.kro.airbob.common.context.UserContext;
@@ -13,12 +16,21 @@ import kr.kro.airbob.common.context.UserInfo;
 
 
 @Configuration
-@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
+@EnableJpaAuditing(
+	auditorAwareRef = "auditorProvider",
+	dateTimeProviderRef = "utcDateTimeProvider"
+)
 public class JpaAuditingConfig {
+	private static final Clock UTC_CLOCK = Clock.systemUTC();
 
 	// created_by / updated_by 자동 채움: 인증된 요청이면 member.id, 아니면 비움(NULL).
 	@Bean
 	public AuditorAware<Long> auditorProvider() {
 		return () -> Optional.ofNullable(UserContext.get()).map(UserInfo::id);
+	}
+
+	@Bean
+	public DateTimeProvider utcDateTimeProvider() {
+		return () -> Optional.of(LocalDateTime.now(UTC_CLOCK));
 	}
 }

--- a/src/main/java/kr/kro/airbob/config/KafkaConfig.java
+++ b/src/main/java/kr/kro/airbob/config/KafkaConfig.java
@@ -1,30 +1,64 @@
 package kr.kro.airbob.config;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafkaRetryTopic;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.retrytopic.RetryTopicSchedulerWrapper;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.backoff.ExponentialBackOff;
 
-import kr.kro.airbob.outbox.SlackNotificationService;
-import lombok.RequiredArgsConstructor;
-
 @Configuration
-@RequiredArgsConstructor
+@EnableKafkaRetryTopic
 public class KafkaConfig {
 
-	private final KafkaTemplate<String, Object> kafkaTemplate;
-	private final SlackNotificationService slackNotificationService;
+	@Bean
+	public RetryTopicSchedulerWrapper retryTopicScheduler() {
+		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+		scheduler.setPoolSize(1);
+		scheduler.setThreadNamePrefix("kafka-retry-");
+		scheduler.setRemoveOnCancelPolicy(true);
+		return new RetryTopicSchedulerWrapper(scheduler);
+	}
 
 	@Bean
-	public DefaultErrorHandler errorHandler() {
-		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
-			(consumerRecord, exception) -> {
-				sendSlackAlert(consumerRecord, exception);
-				return null;
-			}
+	public ProducerFactory<String, String> deadLetterProducerFactory(
+		KafkaProperties kafkaProperties
+	) {
+		Map<String, Object> properties = new HashMap<>(kafkaProperties.buildProducerProperties());
+		properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		return new DefaultKafkaProducerFactory<>(properties);
+	}
+
+	@Bean
+	public KafkaTemplate<String, String> deadLetterKafkaTemplate(
+		@Qualifier("deadLetterProducerFactory") ProducerFactory<String, String> producerFactory
+	) {
+		return new KafkaTemplate<>(producerFactory);
+	}
+
+	@Bean
+	public DefaultErrorHandler errorHandler(
+		@Value("${spring.kafka.consumer.properties.spring.kafka.dead-letter-publishing.topic-name}")
+		String deadLetterTopic,
+		@Qualifier("deadLetterKafkaTemplate") KafkaTemplate<String, String> deadLetterKafkaTemplate
+	) {
+		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(deadLetterKafkaTemplate,
+			(consumerRecord, exception) -> new TopicPartition(deadLetterTopic, -1)
 		);
 
 		ExponentialBackOff backOff = new ExponentialBackOff(2000L, 2.0);
@@ -32,27 +66,5 @@ public class KafkaConfig {
 		backOff.setMaxElapsedTime(60000L);
 
 		return new DefaultErrorHandler(recoverer, backOff);
-	}
-
-	private void sendSlackAlert(ConsumerRecord<?, ?> record, Exception exception) {
-		String message = String.format(
-			"""
-			🚨 *Kafka DLQ Alert* 🚨
-			메시지 처리에 최종 실패하여 DLQ로 이동합니다.
-
-			• *Topic*: `%s`
-			• *Partition*: `%d`
-			• *Offset*: `%d`
-			• *Key*: `%s`
-			• *Exception*: `%s`
-			• *Error Message*: ```%s```""",
-			record.topic(),
-			record.partition(),
-			record.offset(),
-			record.key(),
-			exception.getClass().getSimpleName(),
-			exception.getMessage()
-		);
-		slackNotificationService.sendAlert(message);
 	}
 }

--- a/src/main/java/kr/kro/airbob/config/SchedulingConfig.java
+++ b/src/main/java/kr/kro/airbob/config/SchedulingConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration(proxyBeanMethods = false)
-@Profile("!bulk-write-benchmark")
+@Profile("!bulk-write-benchmark & !test")
 @EnableScheduling
 public class SchedulingConfig {
 }

--- a/src/main/java/kr/kro/airbob/domain/accommodation/api/AccommodationController.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/api/AccommodationController.java
@@ -109,6 +109,14 @@ public class AccommodationController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @GetMapping("/v1/accommodations/{accommodationId}/availability")
+    public ResponseEntity<ApiResponse<AccommodationResponse.Availability>> getAccommodationAvailability(
+        @PathVariable Long accommodationId) {
+        AccommodationResponse.Availability response =
+            accommodationQueryService.findAccommodationAvailability(accommodationId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
     @GetMapping("/v1/profile/host/accommodations")
     public ResponseEntity<ApiResponse<AccommodationResponse.HostAccommodationInfos>> getHostAccommodations(
         @CursorParam CursorRequest.CursorPageRequest request,

--- a/src/main/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponse.java
@@ -73,6 +73,14 @@ public class AccommodationResponse {
 	}
 
 	@Builder
+	public record Availability(
+		LocalDate bookingWindowStartInclusive,
+		LocalDate bookingWindowEndExclusive,
+		List<UnavailableDateRange> unavailableRanges
+	) {
+	}
+
+	@Builder
 	public record DetailInfo(
 		long id,
 		String name,
@@ -84,9 +92,6 @@ public class AccommodationResponse {
 		LocalTime checkOutTime,
 		String timeZoneId,
 
-		LocalDate bookingWindowStartInclusive,
-		LocalDate bookingWindowEndExclusive,
-		List<UnavailableDateRange> unavailableRanges,
 		Boolean isInWishlist,
 		AddressResponse.AddressSummaryInfo addressSummary,
 		AddressResponse.Coordinate coordinate,
@@ -103,8 +108,6 @@ public class AccommodationResponse {
 
 	) {
 		public static DetailInfo from(Accommodation accommodation,
-			LocalDate bookingWindowStartInclusive, LocalDate bookingWindowEndExclusive,
-			List<UnavailableDateRange> unavailableRanges,
 			Boolean isInWishlist, List<AmenityResponse.AmenityInfo> amenityInfos, List<ImageResponse.ImageInfo> imageInfo,
 			ReviewResponse.ReviewSummary reviewSummary) {
 
@@ -121,9 +124,6 @@ public class AccommodationResponse {
 				.checkInTime(accommodation.getCheckInTime())
 				.checkOutTime(accommodation.getCheckOutTime())
 				.timeZoneId(accommodation.getTimeZoneId())
-				.bookingWindowStartInclusive(bookingWindowStartInclusive)
-				.bookingWindowEndExclusive(bookingWindowEndExclusive)
-				.unavailableRanges(unavailableRanges)
 				.isInWishlist(isInWishlist)
 				.addressSummary(AddressResponse.AddressSummaryInfo.from(address))
 				.coordinate(AddressResponse.Coordinate.from(address))

--- a/src/main/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponse.java
@@ -1,8 +1,10 @@
 package kr.kro.airbob.domain.accommodation.dto;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import kr.kro.airbob.cursor.dto.CursorResponse;
@@ -34,7 +36,7 @@ public class AccommodationResponse {
 		AddressResponse.AddressSummaryInfo addressSummary,
 		// Integer basePrice,
 		// ReviewResponse.ReviewSummary reviewSummary,
-		LocalDateTime createdAt
+		Instant createdAt
 	) {
 		public static HostAccommodationInfo from(Accommodation accommodation) {
 			Address address = accommodation.getAddress();
@@ -45,7 +47,7 @@ public class AccommodationResponse {
 				.status(accommodation.getStatus())
 				.type(accommodation.getType())
 				.addressSummary(AddressResponse.AddressSummaryInfo.from(address))
-				.createdAt(accommodation.getCreatedAt())
+				.createdAt(toUtcInstant(accommodation.getCreatedAt()))
 				.build();
 		}
 	}
@@ -144,6 +146,7 @@ public class AccommodationResponse {
 		String currency,
 		LocalTime checkInTime,
 		LocalTime checkOutTime,
+		String timeZoneId,
 
 		AddressResponse.AddressInfo address,
 		AddressResponse.Coordinate coordinate,
@@ -176,6 +179,7 @@ public class AccommodationResponse {
 				.currency(accommodation.getCurrency())
 				.checkInTime(accommodation.getCheckInTime())
 				.checkOutTime(accommodation.getCheckOutTime())
+				.timeZoneId(accommodation.getTimeZoneId())
 				.address(AddressResponse.AddressInfo.from(address))
 				.coordinate(AddressResponse.Coordinate.from(address))
 				.host(MemberResponse.MemberInfo.from(host))
@@ -202,7 +206,7 @@ public class AccommodationResponse {
 
 	@Builder
 	public record RecentlyViewedAccommodationInfo(
-		LocalDateTime viewedAt,
+		Instant viewedAt,
 		Long accommodationId,
 		String accommodationName,
 		String thumbnailUrl,
@@ -210,7 +214,7 @@ public class AccommodationResponse {
 		ReviewResponse.ReviewSummary reviewSummary,
 		Boolean isInWishlist
 	) {
-		public static RecentlyViewedAccommodationInfo from(LocalDateTime viewedAt, Accommodation accommodation,
+		public static RecentlyViewedAccommodationInfo from(Instant viewedAt, Accommodation accommodation,
 			ReviewResponse.ReviewSummary reviewSummary, boolean isInWishlist) {
 			return RecentlyViewedAccommodationInfo.builder()
 				.viewedAt(viewedAt)
@@ -240,5 +244,9 @@ public class AccommodationResponse {
 				.thumbnailUrl(accommodation.getThumbnailUrl())
 				.build();
 		}
+	}
+
+	private static Instant toUtcInstant(LocalDateTime dateTime) {
+		return dateTime == null ? null : dateTime.toInstant(ZoneOffset.UTC);
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponse.java
@@ -80,6 +80,7 @@ public class AccommodationResponse {
 		String currency,
 		LocalTime checkInTime,
 		LocalTime checkOutTime,
+		String timeZoneId,
 
 		LocalDate bookingWindowStartInclusive,
 		LocalDate bookingWindowEndExclusive,
@@ -117,6 +118,7 @@ public class AccommodationResponse {
 				.currency(accommodation.getCurrency())
 				.checkInTime(accommodation.getCheckInTime())
 				.checkOutTime(accommodation.getCheckOutTime())
+				.timeZoneId(accommodation.getTimeZoneId())
 				.bookingWindowStartInclusive(bookingWindowStartInclusive)
 				.bookingWindowEndExclusive(bookingWindowEndExclusive)
 				.unavailableRanges(unavailableRanges)

--- a/src/main/java/kr/kro/airbob/domain/accommodation/entity/Accommodation.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/entity/Accommodation.java
@@ -1,7 +1,9 @@
 package kr.kro.airbob.domain.accommodation.entity;
 
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
@@ -61,6 +63,9 @@ public class Accommodation extends BaseEntity {
 
 	@OneToOne(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
 	private Address address;
+
+	@Column(length = 64)
+	private String timeZoneId;
 
 	@OneToOne(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
 	private OccupancyPolicy occupancyPolicy;
@@ -130,8 +135,9 @@ public class Accommodation extends BaseEntity {
 		}
 	}
 
-	public void updateAddress(Address address) {
-		this.address = address;
+	public void updateLocation(Address address, ZoneId timeZone) {
+		this.address = Objects.requireNonNull(address);
+		this.timeZoneId = Objects.requireNonNull(timeZone).getId();
 	}
 
 	public void updateOccupancyPolicy(OccupancyPolicy occupancyPolicy) {

--- a/src/main/java/kr/kro/airbob/domain/accommodation/entity/AccommodationHistory.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/entity/AccommodationHistory.java
@@ -52,6 +52,8 @@ public class AccommodationHistory extends MasterHistoryBase {
 	private LocalTime checkInTime;
 	private LocalTime checkOutTime;
 	private Long memberId;
+	@Column(length = 64)
+	private String timeZoneId;
 
 	// --- address(owned 1:1) 스냅샷 ---
 	private String addressCountry;
@@ -90,6 +92,7 @@ public class AccommodationHistory extends MasterHistoryBase {
 			.checkInTime(a.getCheckInTime())
 			.checkOutTime(a.getCheckOutTime())
 			.memberId(a.getMember() == null ? null : a.getMember().getId())
+			.timeZoneId(a.getTimeZoneId())
 			.addressCountry(addr == null ? null : addr.getCountry())
 			.addressState(addr == null ? null : addr.getState())
 			.addressCity(addr == null ? null : addr.getCity())

--- a/src/main/java/kr/kro/airbob/domain/accommodation/entity/AccommodationHistory.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/entity/AccommodationHistory.java
@@ -76,7 +76,8 @@ public class AccommodationHistory extends MasterHistoryBase {
 	private Long createdBy;
 
 	// 숙소 변경은 모두 인증된 호스트 요청 → source_system/client_ip를 요청 컨텍스트에서 채움
-	public static AccommodationHistory of(Accommodation a, ChangeType changeType, String changeReason) {
+	public static AccommodationHistory of(Accommodation a, ChangeType changeType, String changeReason,
+		LocalDateTime validFrom) {
 		Address addr = a.getAddress();
 		OccupancyPolicy occ = a.getOccupancyPolicy();
 		return AccommodationHistory.builder()
@@ -111,7 +112,7 @@ public class AccommodationHistory extends MasterHistoryBase {
 			.changeReason(changeReason)
 			.sourceSystem(UserContext.currentSourceSystem())
 			.clientIp(UserContext.currentClientIp())
-			.validFrom(LocalDateTime.now())
+			.validFrom(validFrom)
 			.validTo(HistoryConstants.FOREVER)
 			.build();
 	}

--- a/src/main/java/kr/kro/airbob/domain/accommodation/exception/AccommodationLocationResolutionException.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/exception/AccommodationLocationResolutionException.java
@@ -1,0 +1,11 @@
+package kr.kro.airbob.domain.accommodation.exception;
+
+import kr.kro.airbob.common.exception.BaseException;
+import kr.kro.airbob.common.exception.ErrorCode;
+
+public class AccommodationLocationResolutionException extends BaseException {
+
+	public AccommodationLocationResolutionException() {
+		super(ErrorCode.ACCOMMODATION_LOCATION_RESOLUTION_FAILED);
+	}
+}

--- a/src/main/java/kr/kro/airbob/domain/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/repository/AccommodationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
+import kr.kro.airbob.domain.accommodation.repository.projection.AccommodationBookingProjection;
 import kr.kro.airbob.domain.accommodation.repository.querydsl.AccommodationRepositoryCustom;
 
 public interface AccommodationRepository extends JpaRepository<Accommodation, Long>, AccommodationRepositoryCustom {
@@ -24,6 +25,17 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
 	List<ThumbnailUrlProjection> findThumbnailUrlsByIds(@Param("ids") Collection<Long> ids);
 
 	Optional<Accommodation> findByIdAndStatus(Long id, AccommodationStatus status);
+
+	@Query("""
+		SELECT new kr.kro.airbob.domain.accommodation.repository.projection.AccommodationBookingProjection(a.timeZoneId)
+		FROM Accommodation a
+		WHERE a.id = :id AND a.status = :status
+		""")
+	Optional<AccommodationBookingProjection> findBookingProjectionByIdAndStatus(
+		@Param("id") Long id,
+		@Param("status") AccommodationStatus status
+	);
+
 	Optional<Accommodation> findByIdAndMemberIdAndStatus(Long id, Long memberId, AccommodationStatus status);
 
 	List<Accommodation> findByIdInAndStatus(List<Long> accommodationIds, AccommodationStatus status);

--- a/src/main/java/kr/kro/airbob/domain/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/repository/AccommodationRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,6 +13,7 @@ import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
 import kr.kro.airbob.domain.accommodation.repository.projection.AccommodationBookingProjection;
 import kr.kro.airbob.domain.accommodation.repository.querydsl.AccommodationRepositoryCustom;
+import jakarta.persistence.LockModeType;
 
 public interface AccommodationRepository extends JpaRepository<Accommodation, Long>, AccommodationRepositoryCustom {
 
@@ -23,6 +25,13 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
 
 	@Query("SELECT a.id AS id, a.thumbnailUrl AS thumbnailUrl FROM Accommodation a WHERE a.id IN :ids")
 	List<ThumbnailUrlProjection> findThumbnailUrlsByIds(@Param("ids") Collection<Long> ids);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT a FROM Accommodation a WHERE a.id = :id AND a.status = :status")
+	Optional<Accommodation> findByIdAndStatusForUpdate(
+		@Param("id") Long id,
+		@Param("status") AccommodationStatus status
+	);
 
 	Optional<Accommodation> findByIdAndStatus(Long id, AccommodationStatus status);
 
@@ -41,6 +50,19 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
 	List<Accommodation> findByIdInAndStatus(List<Long> accommodationIds, AccommodationStatus status);
 
 	Optional<Accommodation> findByIdAndMemberId(Long accommodationId, Long memberId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+		SELECT a FROM Accommodation a
+		WHERE a.id = :accommodationId
+			AND a.member.id = :memberId
+			AND a.status <> :excludedStatus
+		""")
+	Optional<Accommodation> findByIdAndMemberIdAndStatusNotForUpdate(
+		@Param("accommodationId") Long accommodationId,
+		@Param("memberId") Long memberId,
+		@Param("excludedStatus") AccommodationStatus excludedStatus
+	);
 
 	Optional<Accommodation> findByIdAndMemberIdAndStatusNot(Long accommodationId, Long memberId, AccommodationStatus accommodationStatus);
 

--- a/src/main/java/kr/kro/airbob/domain/accommodation/repository/projection/AccommodationBookingProjection.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/repository/projection/AccommodationBookingProjection.java
@@ -1,0 +1,6 @@
+package kr.kro.airbob.domain.accommodation.repository.projection;
+
+public record AccommodationBookingProjection(
+	String timeZoneId
+) {
+}

--- a/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationAmenityDeleteBeforeBenchmarkService.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationAmenityDeleteBeforeBenchmarkService.java
@@ -1,6 +1,8 @@
 package kr.kro.airbob.domain.accommodation.service;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Locale;
@@ -36,17 +38,20 @@ public class AccommodationAmenityDeleteBeforeBenchmarkService {
 	private final AccommodationRepository accommodationRepository;
 	private final AccommodationHistoryRepository accommodationHistoryRepository;
 	private final CommonCodeService commonCodeService;
+	private final Clock clock;
 
 	public AccommodationAmenityDeleteBeforeBenchmarkService(
 		AccommodationAmenityRepository accommodationAmenityRepository,
 		AccommodationRepository accommodationRepository,
 		AccommodationHistoryRepository accommodationHistoryRepository,
-		CommonCodeService commonCodeService
+		CommonCodeService commonCodeService,
+		Clock clock
 	) {
 		this.accommodationAmenityRepository = accommodationAmenityRepository;
 		this.accommodationRepository = accommodationRepository;
 		this.accommodationHistoryRepository = accommodationHistoryRepository;
 		this.commonCodeService = commonCodeService;
+		this.clock = clock;
 	}
 
 	@Transactional
@@ -92,11 +97,12 @@ public class AccommodationAmenityDeleteBeforeBenchmarkService {
 	}
 
 	private void recordHistory(Accommodation accommodation) {
+		LocalDateTime changedAt = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
 		accommodationHistoryRepository
 			.findByAccommodationIdAndValidTo(accommodation.getId(), HistoryConstants.FOREVER)
-			.ifPresent(current -> current.close(LocalDateTime.now()));
+			.ifPresent(current -> current.close(changedAt));
 		accommodationHistoryRepository.save(
-			AccommodationHistory.of(accommodation, ChangeType.UPDATE, "숙소 정보 수정")
+			AccommodationHistory.of(accommodation, ChangeType.UPDATE, "숙소 정보 수정", changedAt)
 		);
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationAmenityDeleteBenchmarkFixtureService.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationAmenityDeleteBenchmarkFixtureService.java
@@ -2,8 +2,9 @@ package kr.kro.airbob.domain.accommodation.service;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
-import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -40,16 +41,20 @@ import kr.kro.airbob.domain.accommodation.dto.AmenityRequest;
 public class AccommodationAmenityDeleteBenchmarkFixtureService {
 
 	private static final LocalDateTime FOREVER = HistoryConstants.FOREVER;
+	private static final String FIXTURE_TIME_ZONE_ID = "UTC";
 
 	private final JdbcTemplate jdbcTemplate;
 	private final CommonCodeService commonCodeService;
+	private final Clock clock;
 
 	public AccommodationAmenityDeleteBenchmarkFixtureService(
 		JdbcTemplate jdbcTemplate,
-		CommonCodeService commonCodeService
+		CommonCodeService commonCodeService,
+		Clock clock
 	) {
 		this.jdbcTemplate = jdbcTemplate;
 		this.commonCodeService = commonCodeService;
+		this.clock = clock;
 	}
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -194,52 +199,62 @@ public class AccommodationAmenityDeleteBenchmarkFixtureService {
 	}
 
 	private long insertAccommodation(long ownerId, String name) {
+		LocalDateTime currentAt = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
 		return insertAndReturnKey("""
 			INSERT INTO accommodation (
 			  member_id, check_in_time, check_out_time, accommodation_uid, status,
-			  name, created_at, updated_at, created_by, updated_by
-			) VALUES (?, '15:00:00', '11:00:00', UUID_TO_BIN(?), 'DRAFT', ?,
-			  NOW(6), NOW(6), ?, ?)
+			  name, time_zone_id, created_at, updated_at, created_by, updated_by
+			) VALUES (?, '15:00:00', '11:00:00', UUID_TO_BIN(?), 'DRAFT', ?, ?,
+			  ?, ?, ?, ?)
 			""", statement -> {
 			statement.setLong(1, ownerId);
 			statement.setString(2, UUID.randomUUID().toString());
 			statement.setString(3, name);
-			statement.setLong(4, ownerId);
-			statement.setLong(5, ownerId);
+			statement.setString(4, FIXTURE_TIME_ZONE_ID);
+			statement.setObject(5, currentAt);
+			statement.setObject(6, currentAt);
+			statement.setLong(7, ownerId);
+			statement.setLong(8, ownerId);
 		});
 	}
 
 	private long insertAmenity(long accommodationId, String code, int count, long ownerId) {
+		LocalDateTime currentAt = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
 		return insertAndReturnKey("""
 			INSERT INTO accommodation_amenity (
 			  accommodation_id, amenity_code, count,
 			  created_at, updated_at, created_by, updated_by
-			) VALUES (?, ?, ?, NOW(6), NOW(6), ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?)
 			""", statement -> {
 			statement.setLong(1, accommodationId);
 			statement.setString(2, code);
 			statement.setInt(3, count);
-			statement.setLong(4, ownerId);
-			statement.setLong(5, ownerId);
+			statement.setObject(4, currentAt);
+			statement.setObject(5, currentAt);
+			statement.setLong(6, ownerId);
+			statement.setLong(7, ownerId);
 		});
 	}
 
 	private long insertCurrentHistory(long accommodationId, long ownerId) {
+		LocalDateTime currentAt = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
 		return insertAndReturnKey("""
 			INSERT INTO accommodation_history (
 			  accommodation_id, accommodation_uid, name, status, check_in_time, check_out_time,
-			  member_id, created_at, created_by, history_created_at, history_created_by,
+			  member_id, time_zone_id, created_at, created_by, history_created_at, history_created_by,
 			  change_type, change_reason, source_system, client_ip, valid_from, valid_to
 			)
 			SELECT id, BIN_TO_UUID(accommodation_uid), name, status, check_in_time, check_out_time,
-			       member_id, created_at, created_by, NOW(6), ?, 'CREATE',
-			       'benchmark current history', 'BENCHMARK', '127.0.0.1', NOW(6), ?
+			       member_id, time_zone_id, created_at, created_by, ?, ?, 'CREATE',
+			       'benchmark current history', 'BENCHMARK', '127.0.0.1', ?, ?
 			FROM accommodation
 			WHERE id = ?
 			""", statement -> {
-			statement.setLong(1, ownerId);
-			statement.setTimestamp(2, Timestamp.valueOf(FOREVER));
-			statement.setLong(3, accommodationId);
+			statement.setObject(1, currentAt);
+			statement.setLong(2, ownerId);
+			statement.setObject(3, currentAt);
+			statement.setObject(4, FOREVER);
+			statement.setLong(5, accommodationId);
 		});
 	}
 
@@ -270,7 +285,7 @@ public class AccommodationAmenityDeleteBenchmarkFixtureService {
 		return jdbcTemplate.query("""
 			SELECT id, BIN_TO_UUID(accommodation_uid) AS accommodation_uid, member_id, name,
 			       description, base_price, currency, thumbnail_url, type,
-			       status, check_in_time, check_out_time, address_id, occupancy_policy_id,
+			       status, check_in_time, check_out_time, time_zone_id, address_id, occupancy_policy_id,
 			       created_at, updated_at, created_by, updated_by
 			FROM accommodation
 			WHERE id = ?
@@ -288,10 +303,11 @@ public class AccommodationAmenityDeleteBenchmarkFixtureService {
 				values.put("status", resultSet.getString("status"));
 				values.put("check_in_time", resultSet.getTime("check_in_time").toLocalTime());
 				values.put("check_out_time", resultSet.getTime("check_out_time").toLocalTime());
+				values.put("time_zone_id", resultSet.getString("time_zone_id"));
 				values.put("address_id", nullableLong(resultSet, "address_id"));
 				values.put("occupancy_policy_id", nullableLong(resultSet, "occupancy_policy_id"));
-				values.put("created_at", toLocalDateTime(resultSet.getTimestamp("created_at")));
-				values.put("updated_at", toLocalDateTime(resultSet.getTimestamp("updated_at")));
+				values.put("created_at", resultSet.getObject("created_at", LocalDateTime.class));
+				values.put("updated_at", resultSet.getObject("updated_at", LocalDateTime.class));
 				values.put("created_by", nullableLong(resultSet, "created_by"));
 				values.put("updated_by", nullableLong(resultSet, "updated_by"));
 				return new ParentSnapshot(values);
@@ -302,6 +318,7 @@ public class AccommodationAmenityDeleteBenchmarkFixtureService {
 		return jdbcTemplate.query("""
 			SELECT id, accommodation_id, accommodation_uid, name, description, base_price,
 			       currency, thumbnail_url, type, status, check_in_time, check_out_time, member_id,
+			       time_zone_id,
 			       address_country, address_state, address_city, address_district, address_street,
 			       address_detail, address_postal_code, address_latitude, address_longitude,
 			       max_occupancy, infant_occupancy, pet_occupancy, created_at, created_by,
@@ -325,6 +342,7 @@ public class AccommodationAmenityDeleteBenchmarkFixtureService {
 				values.put("check_in_time", resultSet.getTime("check_in_time").toLocalTime());
 				values.put("check_out_time", resultSet.getTime("check_out_time").toLocalTime());
 				values.put("member_id", nullableLong(resultSet, "member_id"));
+				values.put("time_zone_id", resultSet.getString("time_zone_id"));
 				values.put("address_country", resultSet.getString("address_country"));
 				values.put("address_state", resultSet.getString("address_state"));
 				values.put("address_city", resultSet.getString("address_city"));
@@ -337,16 +355,16 @@ public class AccommodationAmenityDeleteBenchmarkFixtureService {
 				values.put("max_occupancy", resultSet.getObject("max_occupancy", Integer.class));
 				values.put("infant_occupancy", resultSet.getObject("infant_occupancy", Integer.class));
 				values.put("pet_occupancy", resultSet.getObject("pet_occupancy", Integer.class));
-				values.put("created_at", toLocalDateTime(resultSet.getTimestamp("created_at")));
+				values.put("created_at", resultSet.getObject("created_at", LocalDateTime.class));
 				values.put("created_by", nullableLong(resultSet, "created_by"));
-				values.put("history_created_at", toLocalDateTime(resultSet.getTimestamp("history_created_at")));
+				values.put("history_created_at", resultSet.getObject("history_created_at", LocalDateTime.class));
 				values.put("history_created_by", nullableLong(resultSet, "history_created_by"));
 				values.put("change_type", resultSet.getString("change_type"));
 				values.put("change_reason", resultSet.getString("change_reason"));
 				values.put("source_system", resultSet.getString("source_system"));
 				values.put("client_ip", resultSet.getString("client_ip"));
-				values.put("valid_from", toLocalDateTime(resultSet.getTimestamp("valid_from")));
-				values.put("valid_to", toLocalDateTime(resultSet.getTimestamp("valid_to")));
+				values.put("valid_from", resultSet.getObject("valid_from", LocalDateTime.class));
+				values.put("valid_to", resultSet.getObject("valid_to", LocalDateTime.class));
 				return new HistorySnapshot(values);
 			}, accommodationId);
 	}
@@ -461,10 +479,6 @@ public class AccommodationAmenityDeleteBenchmarkFixtureService {
 		return resultSet.getObject(column, Long.class);
 	}
 
-	private LocalDateTime toLocalDateTime(Timestamp timestamp) {
-		return timestamp == null ? null : timestamp.toLocalDateTime();
-	}
-
 	@FunctionalInterface
 	private interface StatementBinder {
 		void bind(PreparedStatement statement) throws java.sql.SQLException;
@@ -534,6 +548,7 @@ public class AccommodationAmenityDeleteBenchmarkFixtureService {
 				&& Objects.equals(values.get("check_in_time"), parentValues.get("check_in_time"))
 				&& Objects.equals(values.get("check_out_time"), parentValues.get("check_out_time"))
 				&& Objects.equals(values.get("member_id"), parentValues.get("member_id"))
+				&& Objects.equals(values.get("time_zone_id"), parentValues.get("time_zone_id"))
 				&& Objects.equals(values.get("created_at"), parentValues.get("created_at"))
 				&& Objects.equals(values.get("created_by"), parentValues.get("created_by"))
 				&& ownedSnapshotMatchesFixtureParent(parentValues);

--- a/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandService.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandService.java
@@ -2,7 +2,9 @@ package kr.kro.airbob.domain.accommodation.service;
 
 import static kr.kro.airbob.search.event.AccommodationIndexingEvents.*;
 
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Locale;
@@ -25,6 +27,7 @@ import kr.kro.airbob.domain.accommodation.entity.AccommodationHistory;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
 import kr.kro.airbob.domain.accommodation.entity.Address;
 import kr.kro.airbob.domain.accommodation.entity.OccupancyPolicy;
+import kr.kro.airbob.domain.accommodation.exception.AccommodationLocationResolutionException;
 import kr.kro.airbob.domain.accommodation.exception.AccommodationNotFoundException;
 import kr.kro.airbob.domain.accommodation.exception.AccommodationStateException;
 import kr.kro.airbob.domain.accommodation.exception.InvalidAccommodationAmenityException;
@@ -44,6 +47,7 @@ import kr.kro.airbob.domain.member.entity.MemberStatus;
 import kr.kro.airbob.domain.member.exception.MemberNotFoundException;
 import kr.kro.airbob.domain.member.repository.MemberRepository;
 import kr.kro.airbob.geo.GeocodingService;
+import kr.kro.airbob.geo.TimeZoneResolver;
 import kr.kro.airbob.geo.dto.GeocodeResult;
 import kr.kro.airbob.outbox.EventType;
 import kr.kro.airbob.outbox.OutboxEventPublisher;
@@ -63,6 +67,7 @@ public class AccommodationCommandService {
 	private final MemberRepository memberRepository;
 	private final OutboxEventPublisher outboxEventPublisher;
 	private final GeocodingService geocodingService;
+	private final TimeZoneResolver timeZoneResolver;
 
 	@Transactional
 	public AccommodationResponse.Create createAccommodation(Long memberId) {
@@ -83,8 +88,9 @@ public class AccommodationCommandService {
 
 		validateAccommodationType(request.type());
 		Map<String, Integer> amenityCountMap = getAmenityCountMap(request.amenityInfos());
+		ResolvedLocation resolvedLocation = resolveLocation(accommodation, request.addressInfo());
 		accommodation.updateAccommodation(request);
-		updateAddress(accommodation, request.addressInfo());
+		updateLocation(accommodation, resolvedLocation);
 		updateOccupancyPolicy(accommodation, request.occupancyPolicyInfo());
 		updateAmenities(accommodation, amenityCountMap);
 
@@ -175,6 +181,16 @@ public class AccommodationCommandService {
 			throw new PublishingFieldRequiredException("type");
 		}
 
+		String timeZoneId = accommodation.getTimeZoneId();
+		if (timeZoneId == null || timeZoneId.isBlank()) {
+			throw new PublishingFieldRequiredException("timeZoneId");
+		}
+		try {
+			ZoneId.of(timeZoneId);
+		} catch (DateTimeException exception) {
+			throw new PublishingFieldRequiredException("timeZoneId", "유효한 IANA 시간대 식별자가 필요합니다.");
+		}
+
 		OccupancyPolicy policy = accommodation.getOccupancyPolicy();
 		if (policy == null || policy.getMaxOccupancy() == null
 			|| policy.getInfantOccupancy() == null
@@ -262,19 +278,45 @@ public class AccommodationCommandService {
 		}
 	}
 
-	private void updateAddress(Accommodation accommodation, AddressRequest.AddressInfo addressInfo) {
+	private ResolvedLocation resolveLocation(
+		Accommodation accommodation,
+		AddressRequest.AddressInfo addressInfo
+	) {
 		if (addressInfo == null) {
-			return;
+			return null;
 		}
 
 		Address currentAddress = accommodation.getAddress();
-		if (currentAddress == null || currentAddress.isChanged(addressInfo)) {
-			String addressStr = Address.buildAddressStringForGeocoding(addressInfo);
-			GeocodeResult geocodeResult = geocodingService.getCoordinates(addressStr);
-			Address newAddress = Address.createAddress(addressInfo, geocodeResult);
-			Address savedAddress = addressRepository.save(newAddress);
-			accommodation.updateAddress(savedAddress);
+		if (currentAddress != null
+			&& !currentAddress.isChanged(addressInfo)
+			&& accommodation.getTimeZoneId() != null) {
+			return null;
 		}
+
+		String addressStr = Address.buildAddressStringForGeocoding(addressInfo);
+		GeocodeResult geocodeResult = geocodingService.getCoordinates(addressStr);
+		if (geocodeResult == null
+			|| !geocodeResult.success()
+			|| geocodeResult.latitude() == null
+			|| geocodeResult.longitude() == null) {
+			throw new AccommodationLocationResolutionException();
+		}
+
+		ZoneId timeZone = timeZoneResolver.resolve(geocodeResult.latitude(), geocodeResult.longitude())
+			.orElseThrow(AccommodationLocationResolutionException::new);
+		return new ResolvedLocation(Address.createAddress(addressInfo, geocodeResult), timeZone);
+	}
+
+	private void updateLocation(Accommodation accommodation, ResolvedLocation resolvedLocation) {
+		if (resolvedLocation == null) {
+			return;
+		}
+
+		Address savedAddress = addressRepository.save(resolvedLocation.address());
+		accommodation.updateLocation(savedAddress, resolvedLocation.timeZone());
+	}
+
+	private record ResolvedLocation(Address address, ZoneId timeZone) {
 	}
 
 	private void updateAmenities(Accommodation accommodation, Map<String, Integer> amenityCountMap) {

--- a/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandService.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandService.java
@@ -2,12 +2,16 @@ package kr.kro.airbob.domain.accommodation.service;
 
 import static kr.kro.airbob.search.event.AccommodationIndexingEvents.*;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -15,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.kro.airbob.common.history.ChangeType;
 import kr.kro.airbob.common.history.HistoryConstants;
+import kr.kro.airbob.common.exception.InvalidInputException;
 import kr.kro.airbob.domain.accommodation.dto.AccommodationRequest;
 import kr.kro.airbob.domain.accommodation.dto.AccommodationResponse;
 import kr.kro.airbob.domain.accommodation.dto.AddressRequest;
@@ -45,6 +50,7 @@ import kr.kro.airbob.domain.member.entity.Member;
 import kr.kro.airbob.domain.member.entity.MemberStatus;
 import kr.kro.airbob.domain.member.exception.MemberNotFoundException;
 import kr.kro.airbob.domain.member.repository.MemberRepository;
+import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.geo.GeocodingService;
 import kr.kro.airbob.geo.TimeZoneResolver;
 import kr.kro.airbob.geo.dto.GeocodeResult;
@@ -61,12 +67,14 @@ public class AccommodationCommandService {
 	private final AccommodationHistoryRepository accommodationHistoryRepository;
 	private final OccupancyPolicyRepository occupancyPolicyRepository;
 	private final AccommodationRepository accommodationRepository;
+	private final ReservationRepository reservationRepository;
 	private final CommonCodeService commonCodeService;
 	private final AddressRepository addressRepository;
 	private final MemberRepository memberRepository;
 	private final OutboxEventPublisher outboxEventPublisher;
 	private final GeocodingService geocodingService;
 	private final TimeZoneResolver timeZoneResolver;
+	private final Clock clock;
 
 	@Transactional
 	public AccommodationResponse.Create createAccommodation(Long memberId) {
@@ -86,8 +94,10 @@ public class AccommodationCommandService {
 		Accommodation accommodation = findByIdAndMemberIdAndStatusNot(accommodationId, memberId);
 
 		validateAccommodationType(request.type());
+		validateTurnoverTimes(accommodation, request);
 		Map<String, Integer> amenityCountMap = getAmenityCountMap(request.amenityInfos());
 		ResolvedLocation resolvedLocation = resolveLocation(accommodation, request.addressInfo());
+		validateTemporalSettingsChange(accommodation, request, resolvedLocation);
 		accommodation.updateAccommodation(request);
 		updateLocation(accommodation, resolvedLocation);
 		updateOccupancyPolicy(accommodation, request.occupancyPolicyInfo());
@@ -148,10 +158,12 @@ public class AccommodationCommandService {
 	}
 
 	private void recordHistory(Accommodation accommodation, ChangeType changeType, String reason) {
+		LocalDateTime changedAt = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
 		accommodationHistoryRepository.findByAccommodationIdAndValidTo(
 			accommodation.getId(), HistoryConstants.FOREVER
-		).ifPresent(current -> current.close(LocalDateTime.now()));
-		accommodationHistoryRepository.save(AccommodationHistory.of(accommodation, changeType, reason));
+		).ifPresent(current -> current.close(changedAt));
+		accommodationHistoryRepository.save(
+			AccommodationHistory.of(accommodation, changeType, reason, changedAt));
 	}
 
 	private void validateAccommodationForPublishing(Accommodation accommodation) {
@@ -202,12 +214,54 @@ public class AccommodationCommandService {
 				"checkInTime/checkOutTime", "체크인/체크아웃 시간은 필수입니다."
 			);
 		}
+		if (accommodation.getCheckOutTime().isAfter(accommodation.getCheckInTime())) {
+			throw new PublishingFieldRequiredException(
+				"checkInTime/checkOutTime", "체크아웃 시간은 체크인 시간보다 늦을 수 없습니다."
+			);
+		}
 
 		long imageCount = accommodationImageRepository.countByAccommodationId(accommodation.getId());
 		int minImageCount = 1;
 		if (imageCount < minImageCount) {
 			throw new InsufficientImageCountException(
 				"이미지는 최소 " + minImageCount + "개 이상 등록해야 게시할 수 있습니다. 현재: " + imageCount + "개"
+			);
+		}
+	}
+
+	private void validateTurnoverTimes(Accommodation accommodation, AccommodationRequest.Update request) {
+		if (request.checkInTime() == null && request.checkOutTime() == null) {
+			return;
+		}
+		LocalTime checkInTime = request.checkInTime() != null
+			? request.checkInTime() : accommodation.getCheckInTime();
+		LocalTime checkOutTime = request.checkOutTime() != null
+			? request.checkOutTime() : accommodation.getCheckOutTime();
+		if (checkInTime != null && checkOutTime != null && checkOutTime.isAfter(checkInTime)) {
+			throw new InvalidInputException("체크아웃 시간은 체크인 시간보다 늦을 수 없습니다.");
+		}
+	}
+
+	private void validateTemporalSettingsChange(
+		Accommodation accommodation,
+		AccommodationRequest.Update request,
+		ResolvedLocation resolvedLocation
+	) {
+		LocalTime nextCheckInTime = request.checkInTime() != null
+			? request.checkInTime() : accommodation.getCheckInTime();
+		LocalTime nextCheckOutTime = request.checkOutTime() != null
+			? request.checkOutTime() : accommodation.getCheckOutTime();
+		String nextTimeZoneId = resolvedLocation != null
+			? resolvedLocation.timeZone().getId() : accommodation.getTimeZoneId();
+		boolean temporalSettingsChanged = !Objects.equals(
+			accommodation.getCheckInTime(), nextCheckInTime)
+			|| !Objects.equals(accommodation.getCheckOutTime(), nextCheckOutTime)
+			|| !Objects.equals(accommodation.getTimeZoneId(), nextTimeZoneId);
+		if (temporalSettingsChanged
+			&& reservationRepository.existsFutureInventoryReservation(
+				accommodation.getId(), clock.instant())) {
+			throw new InvalidInputException(
+				"미래 유효 예약이 있는 숙소의 체크인 시간, 체크아웃 시간, 시간대는 변경할 수 없습니다."
 			);
 		}
 	}
@@ -334,7 +388,7 @@ public class AccommodationCommandService {
 	}
 
 	private Accommodation findByIdAndMemberIdAndStatusNot(Long accommodationId, Long memberId) {
-		return accommodationRepository.findByIdAndMemberIdAndStatusNot(
+		return accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
 			accommodationId, memberId, AccommodationStatus.DELETED
 		).orElseThrow(AccommodationNotFoundException::new);
 	}

--- a/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandService.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandService.java
@@ -2,7 +2,6 @@ package kr.kro.airbob.domain.accommodation.service;
 
 import static kr.kro.airbob.search.event.AccommodationIndexingEvents.*;
 
-import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.AbstractMap;
@@ -185,9 +184,7 @@ public class AccommodationCommandService {
 		if (timeZoneId == null || timeZoneId.isBlank()) {
 			throw new PublishingFieldRequiredException("timeZoneId");
 		}
-		try {
-			ZoneId.of(timeZoneId);
-		} catch (DateTimeException exception) {
+		if (!ZoneId.getAvailableZoneIds().contains(timeZoneId)) {
 			throw new PublishingFieldRequiredException("timeZoneId", "유효한 IANA 시간대 식별자가 필요합니다.");
 		}
 

--- a/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryService.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryService.java
@@ -29,6 +29,7 @@ import kr.kro.airbob.domain.accommodation.repository.projection.AccommodationDet
 import kr.kro.airbob.domain.image.dto.ImageResponse;
 import kr.kro.airbob.domain.reservation.dto.ReservationDateRange;
 import kr.kro.airbob.domain.reservation.policy.BookingWindow;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.domain.review.dto.ReviewResponse;
 import kr.kro.airbob.domain.review.entity.AccommodationReviewSummary;
@@ -47,6 +48,7 @@ public class AccommodationQueryService {
 	private final AccommodationRepository accommodationRepository;
 	private final ReservationRepository reservationRepository;
 	private final CursorPageInfoCreator cursorPageInfoCreator;
+	private final BookingWindowProvider bookingWindowProvider;
 
 	@Transactional(readOnly = true)
 	public AccommodationResponse.DetailInfo findAccommodation(Long accommodationId, Long viewerId) {
@@ -58,7 +60,7 @@ public class AccommodationQueryService {
 		List<AmenityResponse.AmenityInfo> amenityInfos = getAmenities(accommodationId);
 		List<ImageResponse.ImageInfo> imageInfos = getImageUrls(accommodationId);
 
-		BookingWindow bookingWindow = BookingWindow.current();
+		BookingWindow bookingWindow = bookingWindowProvider.currentFor(accommodation.getTimeZoneId());
 		LocalDate bookingWindowStart = bookingWindow.startInclusive();
 		LocalDate bookingWindowEndExclusive = bookingWindow.endExclusive();
 		List<AccommodationResponse.UnavailableDateRange> unavailableRanges = getUnavailableRanges(

--- a/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryService.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryService.java
@@ -159,10 +159,10 @@ public class AccommodationQueryService {
 		LocalDate windowEndExclusive
 	) {
 		List<ReservationDateRange> reservationRanges = reservationRepository
-			.findConfirmedReservationRangesByAccommodationId(
+			.findActiveReservationRangesByAccommodationId(
 				accommodationId,
-				windowStart.atStartOfDay(),
-				windowEndExclusive.atStartOfDay());
+				windowStart,
+				windowEndExclusive);
 
 		List<AccommodationResponse.UnavailableDateRange> clippedRanges = reservationRanges.stream()
 			.map(range -> clipUnavailableRange(range, windowStart, windowEndExclusive))
@@ -180,8 +180,8 @@ public class AccommodationQueryService {
 		LocalDate windowStart,
 		LocalDate windowEndExclusive
 	) {
-		LocalDate startDate = range.checkIn().toLocalDate();
-		LocalDate endDateExclusive = range.checkOut().toLocalDate();
+		LocalDate startDate = range.checkIn();
+		LocalDate endDateExclusive = range.checkOut();
 
 		if (startDate.isBefore(windowStart)) {
 			startDate = windowStart;

--- a/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryService.java
+++ b/src/main/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryService.java
@@ -60,12 +60,6 @@ public class AccommodationQueryService {
 		List<AmenityResponse.AmenityInfo> amenityInfos = getAmenities(accommodationId);
 		List<ImageResponse.ImageInfo> imageInfos = getImageUrls(accommodationId);
 
-		BookingWindow bookingWindow = bookingWindowProvider.currentFor(accommodation.getTimeZoneId());
-		LocalDate bookingWindowStart = bookingWindow.startInclusive();
-		LocalDate bookingWindowEndExclusive = bookingWindow.endExclusive();
-		List<AccommodationResponse.UnavailableDateRange> unavailableRanges = getUnavailableRanges(
-			accommodationId, bookingWindowStart, bookingWindowEndExclusive);
-
 		Boolean isInWishlist = checkWishlistStatus(accommodationId, viewerId);
 		ReviewResponse.ReviewSummary reviewSummary = new ReviewResponse.ReviewSummary(
 			Objects.requireNonNullElse(detailProjection.totalReviewCount(), 0),
@@ -73,8 +67,27 @@ public class AccommodationQueryService {
 		);
 
 		return AccommodationResponse.DetailInfo.from(
-			accommodation, bookingWindowStart, bookingWindowEndExclusive, unavailableRanges, isInWishlist,
+			accommodation, isInWishlist,
 			amenityInfos, imageInfos, reviewSummary);
+	}
+
+	@Transactional(readOnly = true)
+	public AccommodationResponse.Availability findAccommodationAvailability(Long accommodationId) {
+		String timeZoneId = accommodationRepository
+			.findBookingProjectionByIdAndStatus(accommodationId, AccommodationStatus.PUBLISHED)
+			.orElseThrow(AccommodationNotFoundException::new)
+			.timeZoneId();
+		BookingWindow bookingWindow = bookingWindowProvider.currentFor(timeZoneId);
+		LocalDate bookingWindowStart = bookingWindow.startInclusive();
+		LocalDate bookingWindowEndExclusive = bookingWindow.endExclusive();
+		List<AccommodationResponse.UnavailableDateRange> unavailableRanges = getUnavailableRanges(
+			accommodationId, bookingWindowStart, bookingWindowEndExclusive);
+
+		return new AccommodationResponse.Availability(
+			bookingWindowStart,
+			bookingWindowEndExclusive,
+			unavailableRanges
+		);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/kr/kro/airbob/domain/auth/filter/SessionAuthFilter.java
+++ b/src/main/java/kr/kro/airbob/domain/auth/filter/SessionAuthFilter.java
@@ -45,6 +45,7 @@ public class SessionAuthFilter extends OncePerRequestFilter {
     // GET 메서드일 때만 인증이 필요 없는 경로 목록
     private static final String[] PUBLIC_GET_PATHS = {
         "/api/v1/accommodations/*",          // 숙소 상세
+        "/api/v1/accommodations/*/availability", // 숙소 예약 가능 정보
         "/api/v1/accommodations/*/reviews",  // 리뷰 목록
         "/api/v1/accommodations/*/reviews/summary", // 리뷰 요약
         "/api/v2/accommodations/*/reviews/summary", // read model benchmark 리뷰 요약

--- a/src/main/java/kr/kro/airbob/domain/member/entity/MemberHistory.java
+++ b/src/main/java/kr/kro/airbob/domain/member/entity/MemberHistory.java
@@ -50,19 +50,20 @@ public class MemberHistory extends MasterHistoryBase {
 	private Long createdBy;
 
 	// 사용자 요청에서 비롯된 변경
-	public static MemberHistory open(Member member, ChangeType changeType, String changeReason) {
+	public static MemberHistory open(Member member, ChangeType changeType, String changeReason,
+		LocalDateTime validFrom) {
 		return build(member, changeType, changeReason,
-			UserContext.currentSourceSystem(), UserContext.currentClientIp());
+			UserContext.currentSourceSystem(), UserContext.currentClientIp(), validFrom);
 	}
 
 	// 시스템/배치에서 비롯된 변경 (예: 가입은 비인증 컨텍스트)
 	public static MemberHistory openSystem(Member member, ChangeType changeType, String changeReason,
-		String sourceSystem) {
-		return build(member, changeType, changeReason, sourceSystem, null);
+		String sourceSystem, LocalDateTime validFrom) {
+		return build(member, changeType, changeReason, sourceSystem, null, validFrom);
 	}
 
 	private static MemberHistory build(Member m, ChangeType changeType, String changeReason,
-		String sourceSystem, String clientIp) {
+		String sourceSystem, String clientIp, LocalDateTime validFrom) {
 		return MemberHistory.builder()
 			.memberId(m.getId())
 			.email(m.getEmail())
@@ -76,7 +77,7 @@ public class MemberHistory extends MasterHistoryBase {
 			.changeReason(changeReason)
 			.sourceSystem(sourceSystem)
 			.clientIp(clientIp)
-			.validFrom(LocalDateTime.now())
+			.validFrom(validFrom)
 			.validTo(HistoryConstants.FOREVER)
 			.build();
 	}

--- a/src/main/java/kr/kro/airbob/domain/member/service/MemberAdminService.java
+++ b/src/main/java/kr/kro/airbob/domain/member/service/MemberAdminService.java
@@ -5,7 +5,9 @@ import static java.util.stream.Collectors.toMap;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,7 @@ public class MemberAdminService {
 	private final MemberRepository memberRepository;
 	private final MemberHistoryRepository memberHistoryRepository;
 	private final EntityManager entityManager;
+	private final Clock clock;
 
 	@Transactional
 	public RoleChanged changeRole(Long actorId, Long targetId, ChangeRole request) {
@@ -58,10 +61,11 @@ public class MemberAdminService {
 		}
 
 		target.changeRole(request.role());
+		LocalDateTime changedAt = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
 		memberHistoryRepository.findByMemberIdAndValidTo(targetId, HistoryConstants.FOREVER)
-			.ifPresent(history -> history.close(LocalDateTime.now()));
+			.ifPresent(history -> history.close(changedAt));
 		memberHistoryRepository.save(
-			MemberHistory.open(target, ChangeType.ROLE_CHANGE, request.reason()));
+			MemberHistory.open(target, ChangeType.ROLE_CHANGE, request.reason(), changedAt));
 
 		return new RoleChanged(targetId, target.getRole());
 	}

--- a/src/main/java/kr/kro/airbob/domain/member/service/MemberService.java
+++ b/src/main/java/kr/kro/airbob/domain/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package kr.kro.airbob.domain.member.service;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import kr.kro.airbob.common.history.ChangeType;
 import kr.kro.airbob.common.history.HistoryConstants;
@@ -26,6 +28,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberHistoryRepository historyRepository;
     private final SessionInvalidator sessionInvalidator;
+    private final Clock clock;
 
     @Transactional
     public void createMember(Signup request) {
@@ -38,7 +41,8 @@ public class MemberService {
         memberRepository.save(member);
 
         // 첫 데이터(CREATE)부터 이력 기록 — 가입은 비인증 컨텍스트라 source_system 명시
-        historyRepository.save(MemberHistory.openSystem(member, ChangeType.CREATE, "신규 회원가입", "API"));
+        historyRepository.save(MemberHistory.openSystem(
+            member, ChangeType.CREATE, "신규 회원가입", "API", utcNow()));
     }
 
     @Transactional
@@ -50,9 +54,10 @@ public class MemberService {
         memberRepository.save(member);
 
         // SCD2: 직전 현재 행을 닫고 새 스냅샷 열기
+        LocalDateTime changedAt = utcNow();
         historyRepository.findByMemberIdAndValidTo(member.getId(), HistoryConstants.FOREVER)
-            .ifPresent(current -> current.close(LocalDateTime.now()));
-        historyRepository.save(MemberHistory.open(member, ChangeType.DELETE, reason));
+            .ifPresent(current -> current.close(changedAt));
+        historyRepository.save(MemberHistory.open(member, ChangeType.DELETE, reason, changedAt));
 
         sessionInvalidator.invalidateAll(memberId);
     }
@@ -63,5 +68,9 @@ public class MemberService {
             .orElseThrow(MemberNotFoundException::new);
         return new MemberResponse.MeInfo(
             member.getId(), member.getEmail(), member.getNickname(), member.getThumbnailImageUrl());
+    }
+
+    private LocalDateTime utcNow() {
+        return LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
     }
 }

--- a/src/main/java/kr/kro/airbob/domain/payment/dto/PaymentRequest.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/dto/PaymentRequest.java
@@ -3,6 +3,7 @@ package kr.kro.airbob.domain.payment.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import kr.kro.airbob.outbox.EventPayload;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class PaymentRequest {
 
 	public record Confirm(
-		@NotBlank String paymentKey,
+		@NotBlank @Size(max = 200) String paymentKey,
 		@NotBlank String orderId,
 		@NotNull @Positive Integer amount
 	)implements EventPayload {

--- a/src/main/java/kr/kro/airbob/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/dto/PaymentResponse.java
@@ -1,6 +1,8 @@
 package kr.kro.airbob.domain.payment.dto;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -24,8 +26,8 @@ public class PaymentResponse {
 		Long totalAmount,
 		Long balanceAmount,
 		PaymentStatus status,
-		LocalDateTime requestedAt,
-		LocalDateTime approvedAt,
+		Instant requestedAt,
+		Instant approvedAt,
 		List<CancelInfo> cancels,
 		VirtualAccountInfo virtualAccount
 	){
@@ -42,7 +44,7 @@ public class PaymentResponse {
 				.totalAmount(payment.getAmount())
 				.balanceAmount(payment.getBalanceAmount())
 				.status(payment.getStatus())
-				.requestedAt(payment.getCreatedAt())
+				.requestedAt(toUtcInstant(payment.getCreatedAt()))
 				.approvedAt(payment.getApprovedAt())
 				.cancels(cancelInfos)
 				.virtualAccount(null)
@@ -57,7 +59,7 @@ public class PaymentResponse {
 				.method(transaction.getMethod() != null ? transaction.getMethod().getDescription() : null)
 				.totalAmount(transaction.getAmount())
 				.status(transaction.getStatus())
-				.requestedAt(transaction.getCreatedAt())
+				.requestedAt(toUtcInstant(transaction.getCreatedAt()))
 				.virtualAccount(VirtualAccountInfo.from(transaction))
 				.build();
 		}
@@ -67,7 +69,7 @@ public class PaymentResponse {
 	public record CancelInfo(
 		Long cancelAmount,
 		String cancelReason,
-		LocalDateTime canceledAt
+		Instant canceledAt
 	) {
 		public static CancelInfo from(PaymentTransaction cancelTransaction) {
 			return CancelInfo.builder()
@@ -83,7 +85,7 @@ public class PaymentResponse {
 		String accountNumber,
 		String bankCode,
 		String customerName,
-		LocalDateTime dueDate
+		Instant dueDate
 	) {
 		public static VirtualAccountInfo from(PaymentTransaction transaction) {
 			return VirtualAccountInfo.builder()
@@ -93,5 +95,9 @@ public class PaymentResponse {
 				.dueDate(transaction.getVirtualDueDate())
 				.build();
 		}
+	}
+
+	private static Instant toUtcInstant(LocalDateTime dateTime) {
+		return dateTime == null ? null : dateTime.toInstant(ZoneOffset.UTC);
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/payment/entity/Payment.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/entity/Payment.java
@@ -1,6 +1,6 @@
 package kr.kro.airbob.domain.payment.entity;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
@@ -56,7 +56,7 @@ public class Payment extends BaseEntity {
 	private PaymentMethod method;
 
 	@Column(nullable = false)
-	private LocalDateTime approvedAt;
+	private Instant approvedAt;
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "reservation_id", nullable = false)
@@ -84,7 +84,7 @@ public class Payment extends BaseEntity {
 			.balanceAmount(response.getTotalAmount())
 			.method(PaymentMethod.fromDescription(response.getMethod()))
 			.status(PaymentStatus.from(response.getStatus()))
-			.approvedAt(response.getApprovedAt().toLocalDateTime())
+			.approvedAt(response.getApprovedAt().toInstant())
 			.reservation(reservation)
 			.build();
 	}

--- a/src/main/java/kr/kro/airbob/domain/payment/entity/PaymentTransaction.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/entity/PaymentTransaction.java
@@ -1,6 +1,6 @@
 package kr.kro.airbob.domain.payment.entity;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,6 +27,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PaymentTransaction extends BaseEntity {
+	private static final int PAYMENT_KEY_MAX_LENGTH = 200;
+	private static final int FAILURE_CODE_MAX_LENGTH = 100;
+	private static final int FAILURE_MESSAGE_MAX_LENGTH = 512;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,28 +48,30 @@ public class PaymentTransaction extends BaseEntity {
 	private PaymentStatus status; // 그 시점 PG 상태
 
 	private Long amount;
+	@Column(length = PAYMENT_KEY_MAX_LENGTH)
 	private String paymentKey;
 	private String orderId;
 	@Enumerated(EnumType.STRING)
 	private PaymentMethod method;
 
 	// 실패 정보
+	@Column(length = FAILURE_CODE_MAX_LENGTH)
 	private String failureCode;
-	@Column(length = 512)
+	@Column(length = FAILURE_MESSAGE_MAX_LENGTH)
 	private String failureMessage;
 
 	// 가상계좌 정보
 	private String virtualBankCode;
 	private String virtualAccountNumber;
 	private String virtualCustomerName;
-	private LocalDateTime virtualDueDate;
+	private Instant virtualDueDate;
 
 	// 취소 정보
 	private Long cancelAmount;
 	@Column(length = 200)
 	private String cancelReason;
 	private String transactionKey;
-	private LocalDateTime canceledAt; // PG가 알려준 취소 시각
+	private Instant canceledAt; // PG가 알려준 취소 시각
 
 	// 결제 승인 성공 (Payment 생성 직후, payment_id 연결)
 	public static PaymentTransaction confirm(TossPaymentResponse response, Reservation reservation, Payment payment) {
@@ -78,7 +83,7 @@ public class PaymentTransaction extends BaseEntity {
 			.virtualAccountNumber(virtualAccount != null ? virtualAccount.getAccountNumber() : null)
 			.virtualCustomerName(virtualAccount != null ? virtualAccount.getCustomerName() : null)
 			.virtualDueDate(virtualAccount != null && virtualAccount.getDueDate() != null
-				? virtualAccount.getDueDate().toLocalDateTime() : null)
+				? virtualAccount.getDueDate().toInstant() : null)
 			.build();
 	}
 
@@ -90,11 +95,11 @@ public class PaymentTransaction extends BaseEntity {
 			.transactionType(PaymentTransactionType.FAIL)
 			.status(PaymentStatus.ABORTED)
 			.amount(Long.valueOf(event.amount()))
-			.paymentKey(event.paymentKey())
+			.paymentKey(limitLength(event.paymentKey(), PAYMENT_KEY_MAX_LENGTH))
 			.orderId(event.orderId())
 			.method(PaymentMethod.UNKNOWN)
-			.failureCode(failureCode)
-			.failureMessage(failureMessage)
+			.failureCode(limitLength(failureCode, FAILURE_CODE_MAX_LENGTH))
+			.failureMessage(limitLength(failureMessage, FAILURE_MESSAGE_MAX_LENGTH))
 			.build();
 	}
 
@@ -107,7 +112,7 @@ public class PaymentTransaction extends BaseEntity {
 			.virtualAccountNumber(virtualAccount != null ? virtualAccount.getAccountNumber() : null)
 			.virtualCustomerName(virtualAccount != null ? virtualAccount.getCustomerName() : null)
 			.virtualDueDate(virtualAccount != null && virtualAccount.getDueDate() != null
-				? virtualAccount.getDueDate().toLocalDateTime() : null)
+				? virtualAccount.getDueDate().toInstant() : null)
 			.build();
 	}
 
@@ -127,7 +132,7 @@ public class PaymentTransaction extends BaseEntity {
 			.cancelAmount(cancelData.getCancelAmount())
 			.cancelReason(cancelData.getCancelReason())
 			.transactionKey(cancelData.getTransactionKey())
-			.canceledAt(cancelData.getCanceledAt() != null ? cancelData.getCanceledAt().toLocalDateTime() : null)
+			.canceledAt(cancelData.getCanceledAt() != null ? cancelData.getCanceledAt().toInstant() : null)
 			.build();
 	}
 
@@ -142,5 +147,12 @@ public class PaymentTransaction extends BaseEntity {
 			.method(PaymentMethod.fromDescription(response.getMethod()))
 			.failureCode(failure != null ? failure.getCode() : null)
 			.failureMessage(failure != null ? failure.getMessage() : null);
+	}
+
+	private static String limitLength(String value, int maxLength) {
+		if (value == null || value.length() <= maxLength) {
+			return value;
+		}
+		return value.substring(0, maxLength);
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/payment/event/PaymentEvent.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/event/PaymentEvent.java
@@ -30,6 +30,13 @@ public class PaymentEvent {
 		}
 	}
 
+	public record PaymentCancellationCompletedEvent(String reservationUid) implements EventPayload {
+		@Override
+		public String getId() {
+			return this.reservationUid;
+		}
+	}
+
 	public record PaymentCancellationRequestedEvent(
 		String reservationUid,
 		String cancelReason,

--- a/src/main/java/kr/kro/airbob/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/repository/PaymentRepository.java
@@ -4,13 +4,20 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 import kr.kro.airbob.domain.payment.entity.Payment;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 	Optional<Payment> findByReservationReservationUid(UUID reservationUid);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select payment from Payment payment where payment.reservation.reservationUid = :reservationUid")
+	Optional<Payment> findByReservationReservationUidWithLock(@Param("reservationUid") UUID reservationUid);
 
 	Optional<Payment> findByOrderId(String orderId);
 

--- a/src/main/java/kr/kro/airbob/domain/payment/service/PaymentApprovalService.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/service/PaymentApprovalService.java
@@ -1,0 +1,66 @@
+package kr.kro.airbob.domain.payment.service;
+
+import java.time.Clock;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.kro.airbob.common.exception.InvalidInputException;
+import kr.kro.airbob.common.history.ChangeType;
+import kr.kro.airbob.domain.payment.dto.PaymentRequest;
+import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.entity.ReservationHistory;
+import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
+import kr.kro.airbob.domain.reservation.repository.ReservationHistoryRepository;
+import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
+import kr.kro.airbob.outbox.EventType;
+import kr.kro.airbob.outbox.OutboxEventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentApprovalService {
+
+	private final ReservationRepository reservationRepository;
+	private final ReservationHistoryRepository historyRepository;
+	private final OutboxEventPublisher outboxEventPublisher;
+	private final Clock clock;
+
+	@Transactional
+	public boolean preparePgCall(PaymentRequest.Confirm request) {
+		UUID reservationUid = parseReservationUid(request.orderId());
+		Reservation reservation = reservationRepository.findByReservationUidWithLock(reservationUid)
+			.orElseThrow(ReservationNotFoundException::new);
+		validateConfirmRequest(request, reservation);
+
+		if (!reservation.startPayment(clock.instant())) {
+			log.info("[결제 승인 선점-SKIP] PG 호출을 시작할 수 없는 예약입니다. UID: {}, status: {}",
+				reservationUid, reservation.getStatus());
+			return false;
+		}
+
+		historyRepository.save(ReservationHistory.ofSystem(
+			reservation, ChangeType.STATUS_CHANGE, "결제 승인 처리 시작", "KAFKA"));
+		outboxEventPublisher.save(EventType.PG_CALL_REQUESTED, request);
+		log.info("[결제 승인 선점] 예약 상태 PAYMENT_PROCESSING 변경 및 PG 호출 이벤트 발행. UID: {}",
+			reservationUid);
+		return true;
+	}
+
+	private void validateConfirmRequest(PaymentRequest.Confirm request, Reservation reservation) {
+		if (!reservation.matchesPaymentRequest(request.orderId(), request.amount().longValue())) {
+			throw new InvalidInputException("결제 승인 요청이 예약 정보와 일치하지 않습니다.");
+		}
+	}
+
+	private UUID parseReservationUid(String orderId) {
+		try {
+			return UUID.fromString(orderId);
+		} catch (IllegalArgumentException e) {
+			throw new InvalidInputException("결제 승인 주문 번호가 UUID 형식이 아닙니다.");
+		}
+	}
+}

--- a/src/main/java/kr/kro/airbob/domain/payment/service/PaymentCancellationProcessor.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/service/PaymentCancellationProcessor.java
@@ -1,13 +1,9 @@
 package kr.kro.airbob.domain.payment.service;
 
-import java.util.UUID;
-
 import org.springframework.stereotype.Service;
 
-import kr.kro.airbob.domain.payment.entity.Payment;
 import kr.kro.airbob.domain.payment.event.PaymentEvent;
-import kr.kro.airbob.domain.payment.exception.PaymentNotFoundException;
-import kr.kro.airbob.domain.payment.repository.PaymentRepository;
+import kr.kro.airbob.domain.payment.entity.PaymentStatus;
 import kr.kro.airbob.outbox.SlackNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,15 +14,19 @@ import lombok.extern.slf4j.Slf4j;
 public class PaymentCancellationProcessor {
 
 	private final PaymentTransactionService paymentTransactionService;
-	private final PaymentRepository paymentRepository;
 	private final SlackNotificationService slackNotificationService;
 
 	public void processSuccess(PaymentEvent.PgCancelCallSucceededEvent event) {
 		String reservationUid = event.reservationUid();
-		Payment payment = paymentRepository.findByReservationReservationUid(UUID.fromString(reservationUid))
-			.orElseThrow(PaymentNotFoundException::new);
-
-		paymentTransactionService.processSuccessfulCancellation(payment, event.response());
+		paymentTransactionService.processSuccessfulCancellation(reservationUid, event.response());
+		if (PaymentStatus.from(event.response().getStatus()) != PaymentStatus.CANCELED
+			|| !Long.valueOf(0L).equals(event.response().getBalanceAmount())) {
+			String errorMessage = String.format(
+				"🚨 [FATAL] PG 취소 응답이 전액 환불 상태가 아닙니다. 수동 확인 필요! Reservation UID: %s, Status: %s, Balance: %s",
+				reservationUid, event.response().getStatus(), event.response().getBalanceAmount());
+			log.error(errorMessage);
+			slackNotificationService.sendAlert(errorMessage);
+		}
 		log.info("PG사 API 취소 성공 DB 처리 완료. Reservation UID={}", reservationUid);
 	}
 

--- a/src/main/java/kr/kro/airbob/domain/payment/service/PaymentCompensationService.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/service/PaymentCompensationService.java
@@ -11,8 +11,7 @@ import kr.kro.airbob.domain.payment.entity.PaymentStatus;
 import kr.kro.airbob.domain.payment.exception.PaymentNotFoundException;
 import kr.kro.airbob.domain.payment.exception.TossPaymentException;
 import kr.kro.airbob.domain.payment.repository.PaymentRepository;
-import kr.kro.airbob.domain.payment.service.PaymentTransactionService;
-import kr.kro.airbob.domain.payment.service.TossPaymentsAdapter;
+import kr.kro.airbob.domain.reservation.service.ReservationTransactionService;
 import kr.kro.airbob.outbox.SlackNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,11 +23,17 @@ public class PaymentCompensationService {
 	private final PaymentRepository paymentRepository;
 	private final TossPaymentsAdapter tossPaymentsAdapter;
 	private final PaymentTransactionService paymentTransactionService;
+	private final ReservationTransactionService reservationTransactionService;
 
 	private final SlackNotificationService slackNotificationService;
 
 	public void compensate(String reservationUid) {
 		log.warn("[DLQ 보상 트랜잭션 시작]: Reservation UID {}", reservationUid);
+		if (!reservationTransactionService.preparePaymentCompensationInTx(
+			reservationUid, "예약 확정 최종 실패")) {
+			log.warn("[DLQ 보상-SKIP] 예약이 이미 확정되어 정상 결제를 유지합니다. Reservation UID: {}", reservationUid);
+			return;
+		}
 
 		Payment payment = paymentRepository.findByReservationReservationUid(UUID.fromString(reservationUid))
 			.orElseThrow(() -> {
@@ -36,7 +41,8 @@ public class PaymentCompensationService {
 				return new PaymentNotFoundException();
 			});
 
-		if (payment.getStatus() == PaymentStatus.CANCELED || payment.getStatus() == PaymentStatus.PARTIAL_CANCELED) {
+		if (payment.getStatus() == PaymentStatus.CANCELED
+			&& Long.valueOf(0L).equals(payment.getBalanceAmount())) {
 			log.warn("[DLQ 보상 트랜잭션] 이미 취소된 결제. PaymentKey: {}", payment.getPaymentKey());
 			return;
 		}
@@ -48,7 +54,8 @@ public class PaymentCompensationService {
 				null
 			);
 
-			paymentTransactionService.processCompensationInTx(payment, response);
+			ensureFullyCanceled(response);
+			paymentTransactionService.processCompensationInTx(reservationUid, response);
 
 		} catch (TossPaymentException e) {
 			log.error("[DLQ-FATAL] 보상 트랜잭션(결제 취소) 중 Toss API 오류 발생. Reservation UID: {}, Code: {}. 수동 개입 필요.",
@@ -70,7 +77,9 @@ public class PaymentCompensationService {
 
 		try {
 			// 전액 환불
-			tossPaymentsAdapter.cancelPayment(paymentKey, "시스템 오류: 예약 정보 불일치", null);
+			TossPaymentResponse response = tossPaymentsAdapter.cancelPayment(
+				paymentKey, "시스템 오류: 예약 정보 불일치", null);
+			ensureFullyCanceled(response);
 
 			String successMessage = String.format(
 				"[COMPENSATION] 유령 결제 자동 환불 성공. Payment Key: %s", paymentKey
@@ -85,6 +94,14 @@ public class PaymentCompensationService {
 			);
 			log.error(failureMessage, e);
 			slackNotificationService.sendAlert(failureMessage);
+		}
+	}
+
+	private void ensureFullyCanceled(TossPaymentResponse response) {
+		if (response == null
+			|| PaymentStatus.from(response.getStatus()) != PaymentStatus.CANCELED
+			|| !Long.valueOf(0L).equals(response.getBalanceAmount())) {
+			throw new IllegalStateException("PG 보상 결과가 전액 취소 상태가 아닙니다.");
 		}
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/payment/service/PaymentTransactionService.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/service/PaymentTransactionService.java
@@ -2,6 +2,9 @@ package kr.kro.airbob.domain.payment.service;
 
 import static kr.kro.airbob.outbox.EventType.*;
 
+import java.util.Objects;
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,10 +12,14 @@ import kr.kro.airbob.domain.payment.dto.PaymentRequest;
 import kr.kro.airbob.domain.payment.dto.TossPaymentResponse;
 import kr.kro.airbob.domain.payment.entity.Payment;
 import kr.kro.airbob.domain.payment.entity.PaymentTransaction;
+import kr.kro.airbob.domain.payment.entity.PaymentStatus;
 import kr.kro.airbob.domain.payment.event.PaymentEvent;
+import kr.kro.airbob.domain.payment.exception.PaymentNotFoundException;
 import kr.kro.airbob.domain.payment.repository.PaymentRepository;
 import kr.kro.airbob.domain.payment.repository.PaymentTransactionRepository;
 import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
+import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.outbox.OutboxEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,21 +31,38 @@ public class PaymentTransactionService {
 
 	private final PaymentRepository paymentRepository;
 	private final PaymentTransactionRepository paymentTransactionRepository;
+	private final ReservationRepository reservationRepository;
 
 	private final OutboxEventPublisher outboxEventPublisher;
 
 	// 결제 성공 시 DB 작업 처리하는 트랜잭션 메서드
 	@Transactional
 	public void processSuccessfulPayment(TossPaymentResponse response, Reservation reservation) {
-		Payment payment = Payment.create(response, reservation);
+		UUID reservationUid = reservation.getReservationUid();
+		Reservation lockedReservation = reservationRepository.findByReservationUidWithLock(reservationUid)
+			.orElseThrow(ReservationNotFoundException::new);
+		validateSuccessfulPaymentResponse(response, lockedReservation);
+
+		Payment existingPayment = paymentRepository
+			.findByReservationReservationUidWithLock(reservationUid)
+			.orElse(null);
+		if (existingPayment != null) {
+			if (isSameApprovedPayment(existingPayment, response)) {
+				log.info("[결제 성공 처리-SKIP] 이미 반영된 승인 결과입니다. Reservation UID={}", reservationUid);
+				return;
+			}
+			throw new IllegalStateException("예약에 이미 다른 결제 정보가 존재합니다.");
+		}
+
+		Payment payment = Payment.create(response, lockedReservation);
 		paymentRepository.save(payment);
 
 		// 거래 원장에 승인 이벤트 기록 (payment_id 연결)
-		paymentTransactionRepository.save(PaymentTransaction.confirm(response, reservation, payment));
+		paymentTransactionRepository.save(PaymentTransaction.confirm(response, lockedReservation, payment));
 
 		outboxEventPublisher.save(
 			PAYMENT_COMPLETED,
-			new PaymentEvent.PaymentCompletedEvent(reservation.getReservationUid().toString())
+			new PaymentEvent.PaymentCompletedEvent(reservationUid.toString())
 		);
 	}
 
@@ -50,13 +74,41 @@ public class PaymentTransactionService {
 	}
 
 	@Transactional
-	public void processSuccessfulCancellation(Payment payment, TossPaymentResponse response) {
+	public void processSuccessfulCancellation(String reservationUid, TossPaymentResponse response) {
+		UUID reservationUuid = UUID.fromString(reservationUid);
+		Payment payment = paymentRepository
+			.findByReservationReservationUidWithLock(reservationUuid)
+			.orElseThrow(PaymentNotFoundException::new);
+		validateCancellationResponse(payment, response, reservationUid);
+		PaymentStatus responseStatus = PaymentStatus.from(response.getStatus());
+		if (payment.getStatus() == responseStatus
+			&& Objects.equals(payment.getBalanceAmount(), response.getBalanceAmount())) {
+			log.info("[결제 취소 처리-SKIP] 이미 반영된 취소 성공 결과입니다. Reservation UID={}", reservationUid);
+			return;
+		}
 		applyCancellation(payment, response);
+
+		if (payment.getStatus() == PaymentStatus.CANCELED
+			&& Long.valueOf(0L).equals(payment.getBalanceAmount())) {
+			outboxEventPublisher.save(
+				PAYMENT_CANCELLATION_COMPLETED,
+				new PaymentEvent.PaymentCancellationCompletedEvent(reservationUid)
+			);
+		} else {
+			outboxEventPublisher.save(
+				PAYMENT_CANCELLATION_FAILED,
+				new PaymentEvent.PaymentCancellationFailedEvent(
+					reservationUid, "예약 취소 요청이 전액 환불로 완료되지 않았습니다."));
+		}
 		log.info("[결제 취소 처리 완료]: PaymentKey {}의 상태 {} 변경 완료", payment.getPaymentKey(), payment.getStatus());
 	}
 
 	@Transactional
-	public void processCompensationInTx(Payment payment, TossPaymentResponse response) {
+	public void processCompensationInTx(String reservationUid, TossPaymentResponse response) {
+		Payment payment = paymentRepository
+			.findByReservationReservationUidWithLock(UUID.fromString(reservationUid))
+			.orElseThrow(PaymentNotFoundException::new);
+		validateCancellationResponse(payment, response, reservationUid);
 		applyCancellation(payment, response);
 		log.info("[DLQ 보상 트랜잭션 완료]: PaymentKey {} 결제 취소 DB 업데이트 완료.", payment.getPaymentKey());
 	}
@@ -76,6 +128,50 @@ public class PaymentTransactionService {
 			paymentTransactionRepository.save(
 				PaymentTransaction.cancel(response.getCancels().getLast(), payment));
 		}
+	}
+
+	private void validateCancellationResponse(
+		Payment payment,
+		TossPaymentResponse response,
+		String reservationUid
+	) {
+		boolean identityMatches = Objects.equals(payment.getPaymentKey(), response.getPaymentKey())
+			&& Objects.equals(payment.getOrderId(), response.getOrderId())
+			&& Objects.equals(reservationUid, response.getOrderId())
+			&& Objects.equals(payment.getAmount(), response.getTotalAmount());
+		Long balanceAmount = response.getBalanceAmount();
+		boolean balanceIsValid = balanceAmount != null
+			&& balanceAmount >= 0L
+			&& balanceAmount <= payment.getAmount();
+
+		if (!identityMatches || !balanceIsValid) {
+			throw new IllegalStateException("PG 취소 응답이 기존 결제 정보와 일치하지 않습니다.");
+		}
+	}
+
+	private void validateSuccessfulPaymentResponse(
+		TossPaymentResponse response,
+		Reservation reservation
+	) {
+		boolean matchesReservation = response != null
+			&& Objects.equals(reservation.getReservationUid().toString(), response.getOrderId())
+			&& Objects.equals(reservation.getTotalPrice(), response.getTotalAmount())
+			&& PaymentStatus.DONE == PaymentStatus.from(response.getStatus())
+			&& response.getPaymentKey() != null
+			&& !response.getPaymentKey().isBlank()
+			&& response.getApprovedAt() != null
+			&& response.getMethod() != null
+			&& !response.getMethod().isBlank();
+		if (!matchesReservation) {
+			throw new IllegalStateException("PG 승인 응답이 예약 정보와 일치하지 않습니다.");
+		}
+	}
+
+	private boolean isSameApprovedPayment(Payment payment, TossPaymentResponse response) {
+		return Objects.equals(payment.getPaymentKey(), response.getPaymentKey())
+			&& Objects.equals(payment.getOrderId(), response.getOrderId())
+			&& Objects.equals(payment.getAmount(), response.getTotalAmount())
+			&& payment.getStatus() == PaymentStatus.DONE;
 	}
 
 	private void handlePaymentFailure(String reservationUid, String reason) {

--- a/src/main/java/kr/kro/airbob/domain/payment/service/TossPaymentsAdapter.java
+++ b/src/main/java/kr/kro/airbob/domain/payment/service/TossPaymentsAdapter.java
@@ -1,12 +1,14 @@
 package kr.kro.airbob.domain.payment.service;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
@@ -14,6 +16,7 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kr.kro.airbob.common.exception.ErrorCode;
@@ -39,10 +42,14 @@ public class TossPaymentsAdapter {
 	public static final String CUSTOMER_NAME = "customerName";
 	public static final int VALID_HOURS_VALUE = 24;
 	public static final String UNKNOWN_ERROR = "UNKNOWN_ERROR";
+	public static final String IDEMPOTENT_REQUEST_PROCESSING = "IDEMPOTENT_REQUEST_PROCESSING";
 	public static final String PARSING_FAILED_CODE = "PARSING_FAILED";
 	public static final String CONFIRM_PATH = "/v1/payments/confirm";
 	public static final String CANCEL_PATH = "/v1/payments/{paymentKey}/cancel";
 	public static final String CANCEL_AMOUNT = "cancelAmount";
+	public static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+	public static final String CONFIRMATION_IDEMPOTENCY_KEY_PREFIX = "airbob-confirm-";
+	public static final String CANCELLATION_IDEMPOTENCY_KEY_PREFIX = "airbob-cancel-";
 	public static final String GET_PATH_BY_PAYMENT_KEY = "/v1/payments/{paymentKey}";
 	public static final String GET_PATH_BY_ORDER_ID = "/v1/payments/orders/{orderId}";
 	public static final String VALID_HOURS = "validHours";
@@ -71,24 +78,16 @@ public class TossPaymentsAdapter {
 		return Objects.requireNonNull(
 			tossPaymentsRestClient.post()
 				.uri(CONFIRM_PATH)
+				.header(IDEMPOTENCY_KEY_HEADER, CONFIRMATION_IDEMPOTENCY_KEY_PREFIX + orderId)
 				.body(payload)
 				.retrieve()
 				.onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
 					throw new ResourceAccessException(TOSS_API_SERVER_ERROR + response.getStatusCode());
 				})
 				.onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-					try {
-						String errorBody = new String(response.getBody().readAllBytes());
-						TossPaymentResponse errorResponse = parseErrorResponse(errorBody);
-
-						String errorCode = errorResponse.getFailure() != null ? errorResponse.getFailure().getCode() :
-							UNKNOWN_ERROR;
-						PaymentConfirmErrorCode confirmErrorCode = PaymentConfirmErrorCode.fromErrorCode(errorCode);
-
-						throw new TossPaymentException(confirmErrorCode);
-					} catch (IOException e) {
-						throw new TossPaymentResponseParsingException(e, ErrorCode.TOSS_PAYMENT_RESPONSE_PARSING_ERROR);
-					}
+					String errorCode = readErrorCode(response);
+					throwIfIdempotentRequestIsProcessing(errorCode);
+					throw new TossPaymentException(PaymentConfirmErrorCode.fromErrorCode(errorCode));
 				})
 				.toEntity(TossPaymentResponse.class)
 				.getBody()
@@ -111,25 +110,16 @@ public class TossPaymentsAdapter {
 		return Objects.requireNonNull(
 			tossPaymentsRestClient.post()
 				.uri(CANCEL_PATH, paymentKey)
+				.header(IDEMPOTENCY_KEY_HEADER, CANCELLATION_IDEMPOTENCY_KEY_PREFIX + paymentKey)
 				.body(payload)
 				.retrieve()
 				.onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
 					throw new ResourceAccessException(TOSS_API_SERVER_ERROR + response.getStatusCode());
 				})
 				.onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-					try {
-						String errorBody = new String(response.getBody().readAllBytes());
-						TossPaymentResponse errorResponse = parseErrorResponse(errorBody);
-
-						String errorCode = errorResponse.getFailure() != null ? errorResponse.getFailure().getCode() :
-							UNKNOWN_ERROR;
-						PaymentCancelErrorCode cancelErrorCode = PaymentCancelErrorCode.fromErrorCode(errorCode);
-
-						throw new TossPaymentException(cancelErrorCode);
-					} catch (IOException e) {
-						throw new TossPaymentResponseParsingException(e, ErrorCode.TOSS_PAYMENT_RESPONSE_PARSING_ERROR);
-					}
-
+					String errorCode = readErrorCode(response);
+					throwIfIdempotentRequestIsProcessing(errorCode);
+					throw new TossPaymentException(PaymentCancelErrorCode.fromErrorCode(errorCode));
 				})
 				.toEntity(TossPaymentResponse.class)
 				.getBody()
@@ -167,20 +157,8 @@ public class TossPaymentsAdapter {
 					throw new ResourceAccessException(TOSS_API_SERVER_ERROR + response.getStatusCode());
 				})
 				.onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-					try {
-						String errorBody = new String(response.getBody().readAllBytes());
-						TossPaymentResponse errorResponse = parseErrorResponse(errorBody);
-						String errorCode =
-							errorResponse.getFailure() != null ? errorResponse.getFailure().getCode() : UNKNOWN_ERROR;
-
-						VirtualAccountIssueErrorCode virtualAccountIssueErrorCode = VirtualAccountIssueErrorCode.fromErrorCode(
-							errorCode);
-
-						throw new TossPaymentException(virtualAccountIssueErrorCode);
-					} catch (IOException e) {
-						throw new TossPaymentResponseParsingException(e, ErrorCode.TOSS_PAYMENT_RESPONSE_PARSING_ERROR);
-					}
-
+					String errorCode = readErrorCode(response);
+					throw new TossPaymentException(VirtualAccountIssueErrorCode.fromErrorCode(errorCode));
 				})
 				.toEntity(TossPaymentResponse.class)
 				.getBody()
@@ -200,29 +178,38 @@ public class TossPaymentsAdapter {
 				throw new ResourceAccessException(TOSS_API_SERVER_ERROR + response.getStatusCode());
 			})
 			.onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-				try {
-					String errorBody = new String(response.getBody().readAllBytes());
-					TossPaymentResponse errorResponse = parseErrorResponse(errorBody);
-
-					String errorCode = errorResponse.getFailure() != null ? errorResponse.getFailure().getCode() :
-						UNKNOWN_ERROR;
-					PaymentInquiryErrorCode inquiryErrorCode = PaymentInquiryErrorCode.fromErrorCode(errorCode);
-
-					throw new TossPaymentException(inquiryErrorCode);
-				} catch (IOException e) {
-					throw new TossPaymentResponseParsingException(e, ErrorCode.TOSS_PAYMENT_RESPONSE_PARSING_ERROR);
-				}
-
+				String errorCode = readErrorCode(response);
+				throw new TossPaymentException(PaymentInquiryErrorCode.fromErrorCode(errorCode));
 			})
 			.body(TossPaymentResponse.class);
 	}
 
-	private TossPaymentResponse parseErrorResponse(String errorBody){
+	private String readErrorCode(ClientHttpResponse response) {
 		try {
-			return objectMapper.readValue(errorBody, TossPaymentResponse.class);
+			return parseErrorCode(new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8));
+		} catch (IOException e) {
+			throw new TossPaymentResponseParsingException(e, ErrorCode.TOSS_PAYMENT_RESPONSE_PARSING_ERROR);
+		}
+	}
+
+	private String parseErrorCode(String errorBody) {
+		try {
+			JsonNode root = objectMapper.readTree(errorBody);
+			String topLevelCode = root.path("code").asText(null);
+			if (topLevelCode != null) {
+				return topLevelCode;
+			}
+
+			return root.path("failure").path("code").asText(UNKNOWN_ERROR);
 		} catch (JsonProcessingException e) {
 			log.error("토스페이먼츠 에러 응답 파싱 실패", e);
 			throw new TossPaymentResponseParsingException(e, ErrorCode.TOSS_PAYMENT_RESPONSE_PARSING_ERROR);
+		}
+	}
+
+	private void throwIfIdempotentRequestIsProcessing(String errorCode) {
+		if (IDEMPOTENT_REQUEST_PROCESSING.equals(errorCode)) {
+			throw new ResourceAccessException(TOSS_API_SERVER_ERROR + errorCode);
 		}
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/recentlyViewed/service/RecentlyViewedService.java
+++ b/src/main/java/kr/kro/airbob/domain/recentlyViewed/service/RecentlyViewedService.java
@@ -2,8 +2,6 @@ package kr.kro.airbob.domain.recentlyViewed.service;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -130,9 +128,7 @@ public class RecentlyViewedService {
 					return null;
 				}
 
-				LocalDateTime viewedAt = Instant.ofEpochMilli(tuple.getScore().longValue())
-					.atZone(ZoneId.systemDefault())
-					.toLocalDateTime();
+				Instant viewedAt = Instant.ofEpochMilli(tuple.getScore().longValue());
 
 				ReviewResponse.ReviewSummary reviewSummary = reviewSummaryMap.get(accommodationId);
 
@@ -188,9 +184,7 @@ public class RecentlyViewedService {
 					return null;
 				}
 
-				LocalDateTime viewedAt = Instant.ofEpochMilli(tuple.getScore().longValue())
-					.atZone(ZoneId.systemDefault())
-					.toLocalDateTime();
+				Instant viewedAt = Instant.ofEpochMilli(tuple.getScore().longValue());
 				return AccommodationResponse.RecentlyViewedAccommodationInfo.from(
 					viewedAt,
 					accommodation,

--- a/src/main/java/kr/kro/airbob/domain/reservation/dto/ReservationDateRange.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/dto/ReservationDateRange.java
@@ -1,12 +1,12 @@
 package kr.kro.airbob.domain.reservation.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import com.querydsl.core.annotations.QueryProjection;
 
 public record ReservationDateRange(
-	LocalDateTime checkIn,
-	LocalDateTime checkOut
+	LocalDate checkIn,
+	LocalDate checkOut
 ) {
 	@QueryProjection
 	public ReservationDateRange {

--- a/src/main/java/kr/kro/airbob/domain/reservation/dto/ReservationRequest.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/dto/ReservationRequest.java
@@ -2,8 +2,6 @@ package kr.kro.airbob.domain.reservation.dto;
 
 import java.time.LocalDate;
 
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.AccessLevel;
@@ -18,11 +16,9 @@ public class ReservationRequest {
 		Long accommodationId,
 
 		@NotNull
-		@FutureOrPresent(message = "체크인 날짜는 오늘 포함 이후여야 합니다.")
 		LocalDate checkInDate,
 
 		@NotNull
-		@Future(message = "체크아웃 날짜는 오늘 이후여야 합니다.")
 		LocalDate checkOutDate,
 
 		@NotNull

--- a/src/main/java/kr/kro/airbob/domain/reservation/dto/ReservationResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/dto/ReservationResponse.java
@@ -1,8 +1,11 @@
 package kr.kro.airbob.domain.reservation.dto;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import kr.kro.airbob.cursor.dto.CursorResponse;
@@ -48,20 +51,24 @@ public class ReservationResponse {
 		String reservationUid,
 		LocalDate checkInDate,
 		LocalDate checkOutDate,
+		String timeZoneId,
+		ReservationStatus status,
 		// Integer totalPrice,
-		LocalDateTime createdAt,
+		Instant createdAt,
 
 		AccommodationResponse.AccommodationBasicInfo accommodation
-	){
+	) {
 		public static GuestReservationInfo from(Reservation reservation) {
 
 			return GuestReservationInfo.builder()
 				.reservationId(reservation.getId())
 				.reservationUid(reservation.getReservationUid().toString())
-				.checkInDate(reservation.getCheckIn().toLocalDate())
-				.checkOutDate(reservation.getCheckOut().toLocalDate())
+				.checkInDate(reservation.getCheckInDate())
+				.checkOutDate(reservation.getCheckOutDate())
+				.timeZoneId(reservation.getTimeZoneId())
+				.status(reservation.getStatus())
 				// .totalPrice(reservation.getTotalPrice())
-				.createdAt(reservation.getCreatedAt())
+				.createdAt(toUtcInstant(reservation.getCreatedAt()))
 				.accommodation(
 					AccommodationResponse.AccommodationBasicInfo.from(reservation.getAccommodation()))
 				.build();
@@ -88,10 +95,11 @@ public class ReservationResponse {
 		String reservationUid,
 		String reservationCode,
 		ReservationStatus status,
-		LocalDateTime createdAt,
+		Instant createdAt,
 		Integer guestCount,
 		LocalDateTime checkInDateTime,
 		LocalDateTime checkOutDateTime,
+		String timeZoneId,
 		LocalTime checkInTime,
 		LocalTime checkOutTime,
 		Boolean canWriteReview,
@@ -108,17 +116,21 @@ public class ReservationResponse {
 			Accommodation accommodation = reservation.getAccommodation();
 			Address address = accommodation.getAddress();
 			Member host = accommodation.getMember();
+			ZoneId timeZone = ZoneId.of(reservation.getTimeZoneId());
+			LocalDateTime checkInDateTime = LocalDateTime.ofInstant(reservation.getCheckInAt(), timeZone);
+			LocalDateTime checkOutDateTime = LocalDateTime.ofInstant(reservation.getCheckOutAt(), timeZone);
 
 			return GuestDetail.builder()
 				.reservationUid(reservation.getReservationUid().toString())
 				.reservationCode(reservation.getReservationCode())
 				.status(reservation.getStatus())
-				.createdAt(reservation.getCreatedAt())
+				.createdAt(toUtcInstant(reservation.getCreatedAt()))
 				.guestCount(reservation.getGuestCount())
-				.checkInDateTime(reservation.getCheckIn())
-				.checkOutDateTime(reservation.getCheckOut())
-				.checkInTime(reservation.getCheckIn().toLocalTime())
-				.checkOutTime(reservation.getCheckOut().toLocalTime())
+				.checkInDateTime(checkInDateTime)
+				.checkOutDateTime(checkOutDateTime)
+				.timeZoneId(reservation.getTimeZoneId())
+				.checkInTime(checkInDateTime.toLocalTime())
+				.checkOutTime(checkOutDateTime.toLocalTime())
 				.canWriteReview(canWriteReview)
 				.accommodation(AccommodationResponse.AccommodationBasicInfo.from(accommodation))
 				.address(AddressResponse.AddressInfo.from(address))
@@ -139,12 +151,13 @@ public class ReservationResponse {
 		int guestCount,
 		LocalDate checkInDate,
 		LocalDate checkOutDate,
+		String timeZoneId,
 		ReservationStatus status,
-		LocalDateTime createdAt,
+		Instant createdAt,
 
 		MemberResponse.MemberInfo guest,
 		AccommodationResponse.AccommodationBasicInfo accommodation
-	){
+	) {
 		public static HostReservationInfo from(Reservation reservation) {
 			return HostReservationInfo.builder()
 				.reservationUid(reservation.getReservationUid().toString())
@@ -152,10 +165,11 @@ public class ReservationResponse {
 				.totalPrice(reservation.getTotalPrice())
 				.currency(reservation.getCurrency())
 				.guestCount(reservation.getGuestCount())
-				.checkInDate(reservation.getCheckIn().toLocalDate())
-				.checkOutDate(reservation.getCheckOut().toLocalDate())
+				.checkInDate(reservation.getCheckInDate())
+				.checkOutDate(reservation.getCheckOutDate())
+				.timeZoneId(reservation.getTimeZoneId())
 				.status(reservation.getStatus())
-				.createdAt(reservation.getCreatedAt())
+				.createdAt(toUtcInstant(reservation.getCreatedAt()))
 				.guest(MemberResponse.MemberInfo.from(reservation.getGuest()))
 				.accommodation(
 					AccommodationResponse.AccommodationBasicInfo.from(reservation.getAccommodation()))
@@ -184,10 +198,11 @@ public class ReservationResponse {
 		String reservationUid,
 		String reservationCode,
 		ReservationStatus status,
-		LocalDateTime createdAt,
+		Instant createdAt,
 		Integer guestCount,
 		LocalDateTime checkInDateTime,
 		LocalDateTime checkOutDateTime,
+		String timeZoneId,
 
 		AccommodationResponse.AccommodationBasicInfo accommodation,
 		AddressResponse.AddressInfo address,
@@ -199,14 +214,16 @@ public class ReservationResponse {
 		public static HostDetail from(Reservation reservation, PaymentResponse.PaymentInfo paymentInfo) {
 			Accommodation accommodation = reservation.getAccommodation();
 			Address address = accommodation.getAddress();
+			ZoneId timeZone = ZoneId.of(reservation.getTimeZoneId());
 			return HostDetail.builder()
 				.reservationUid(reservation.getReservationUid().toString())
 				.reservationCode(reservation.getReservationCode())
 				.status(reservation.getStatus())
-				.createdAt(reservation.getCreatedAt())
+				.createdAt(toUtcInstant(reservation.getCreatedAt()))
 				.guestCount(reservation.getGuestCount())
-				.checkInDateTime(reservation.getCheckIn())
-				.checkOutDateTime(reservation.getCheckOut())
+				.checkInDateTime(LocalDateTime.ofInstant(reservation.getCheckInAt(), timeZone))
+				.checkOutDateTime(LocalDateTime.ofInstant(reservation.getCheckOutAt(), timeZone))
+				.timeZoneId(reservation.getTimeZoneId())
 				.accommodation(
 					AccommodationResponse.AccommodationBasicInfo.from(accommodation))
 				.address(AddressResponse.AddressInfo.from(address))
@@ -214,5 +231,9 @@ public class ReservationResponse {
 				.payment(paymentInfo)
 				.build();
 		}
+	}
+
+	private static Instant toUtcInstant(LocalDateTime dateTime) {
+		return dateTime == null ? null : dateTime.toInstant(ZoneOffset.UTC);
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/reservation/entity/Reservation.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/entity/Reservation.java
@@ -1,7 +1,13 @@
 package kr.kro.airbob.domain.reservation.entity;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
@@ -24,6 +30,7 @@ import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.member.entity.Member;
 import kr.kro.airbob.domain.reservation.dto.ReservationRequest;
 import kr.kro.airbob.domain.reservation.exception.InvalidReservationDateException;
+import kr.kro.airbob.domain.reservation.exception.InvalidReservationLocalTimeException;
 import kr.kro.airbob.domain.reservation.exception.InvalidReservationStatusException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -59,10 +66,19 @@ public class Reservation extends BaseEntity {
 	private Member guest;
 
 	@Column(nullable = false)
-	private LocalDateTime checkIn;
+	private LocalDate checkInDate;
 
 	@Column(nullable = false)
-	private LocalDateTime checkOut;
+	private LocalDate checkOutDate;
+
+	@Column(nullable = false)
+	private Instant checkInAt;
+
+	@Column(nullable = false)
+	private Instant checkOutAt;
+
+	@Column(nullable = false, length = 64)
+	private String timeZoneId;
 
 	// todo: 숙박하는 세부 정보를 넣어야 함.
 	// 성인, 어린이, 유아, 펫
@@ -87,7 +103,7 @@ public class Reservation extends BaseEntity {
 	private String message;
 
 	@Column(nullable = false)
-	private LocalDateTime expiresAt;
+	private Instant expiresAt;
 
 	@PrePersist
 	protected void onCreate() {
@@ -97,17 +113,23 @@ public class Reservation extends BaseEntity {
 	}
 
 	public static Reservation createPendingReservation(Accommodation accommodation, Member guest,
-		ReservationRequest.Create request, String reservationCode) {
+		ReservationRequest.Create request, String reservationCode, Instant now) {
 
-		LocalDateTime checkInDateTime = request.checkInDate().atTime(accommodation.getCheckInTime());
-		LocalDateTime checkOutDateTime = request.checkOutDate().atTime(accommodation.getCheckOutTime());
-		Long price = calculatePrice(accommodation.getBasePrice(), checkInDateTime, checkOutDateTime);
+		ZoneId timeZone = ZoneId.of(accommodation.getTimeZoneId());
+		Instant checkInAt = resolveStayInstant(
+			request.checkInDate(), accommodation.getCheckInTime(), timeZone);
+		Instant checkOutAt = resolveStayInstant(
+			request.checkOutDate(), accommodation.getCheckOutTime(), timeZone);
+		Long price = calculatePrice(accommodation.getBasePrice(), request.checkInDate(), request.checkOutDate());
 
 		return Reservation.builder()
 			.accommodation(accommodation)
 			.guest(guest)
-			.checkIn(checkInDateTime)
-			.checkOut(checkOutDateTime)
+			.checkInDate(request.checkInDate())
+			.checkOutDate(request.checkOutDate())
+			.checkInAt(checkInAt)
+			.checkOutAt(checkOutAt)
+			.timeZoneId(timeZone.getId())
 			.guestCount(request.guestCount())
 			.totalPrice(price)
 			// todo: 국제화를 고려하지 못하여 KRW로 하드코딩
@@ -115,9 +137,18 @@ public class Reservation extends BaseEntity {
 			.currency("KRW")
 			.status(ReservationStatus.PAYMENT_PENDING)
 			// .message(request.message())
-			.expiresAt(LocalDateTime.now().plusMinutes(15)) // 15분 후 만료
+			.expiresAt(now.plus(15, ChronoUnit.MINUTES))
 			.reservationCode(reservationCode)
 			.build();
+	}
+
+	private static Instant resolveStayInstant(LocalDate date, java.time.LocalTime time, ZoneId timeZone) {
+		LocalDateTime localDateTime = date.atTime(time);
+		List<ZoneOffset> validOffsets = timeZone.getRules().getValidOffsets(localDateTime);
+		if (validOffsets.isEmpty()) {
+			throw new InvalidReservationLocalTimeException();
+		}
+		return localDateTime.toInstant(validOffsets.getFirst());
 	}
 
 	// 쿠폰 할인 적용 — 할인액을 기록하고 결제 금액을 차감
@@ -130,8 +161,8 @@ public class Reservation extends BaseEntity {
 		this.totalPrice -= applied;
 	}
 
-	private static Long calculatePrice(Long basePrice, LocalDateTime checkIn, LocalDateTime checkOut) {
-		long nights = ChronoUnit.DAYS.between(checkIn.toLocalDate(), checkOut.toLocalDate());
+	private static Long calculatePrice(Long basePrice, LocalDate checkIn, LocalDate checkOut) {
+		long nights = ChronoUnit.DAYS.between(checkIn, checkOut);
 
 		if (nights <= 0) {
 			throw new InvalidReservationDateException();
@@ -140,29 +171,74 @@ public class Reservation extends BaseEntity {
 	}
 
 	public void confirm() {
-		if (this.status != ReservationStatus.PAYMENT_PENDING) {
+		if (this.status != ReservationStatus.PAYMENT_PROCESSING) {
 			throw new InvalidReservationStatusException(ErrorCode.CANNOT_CONFIRM_RESERVATION);
 		}
 		this.status = ReservationStatus.CONFIRMED;
 	}
 
+	public boolean startPayment(Instant now) {
+		if (this.status != ReservationStatus.PAYMENT_PENDING || isExpiredAt(now)) {
+			return false;
+		}
+		this.status = ReservationStatus.PAYMENT_PROCESSING;
+		return true;
+	}
+
+	public boolean isExpiredAt(Instant now) {
+		return !this.expiresAt.isAfter(now);
+	}
+
+	public boolean matchesPaymentRequest(String orderId, long amount) {
+		return Objects.equals(this.reservationUid.toString(), orderId)
+			&& Objects.equals(this.totalPrice, amount);
+	}
+
 	public void expire() {
-		if (this.status != ReservationStatus.PAYMENT_PENDING) {
+		if (this.status != ReservationStatus.PAYMENT_PENDING
+			&& this.status != ReservationStatus.PAYMENT_PROCESSING) {
 			throw new InvalidReservationStatusException(ErrorCode.CANNOT_EXPIRE_RESERVATION);
 		}
 		this.status = ReservationStatus.EXPIRED;
 	}
 
-	public void cancel() {
+	public boolean requestCancellation() {
+		if (this.status == ReservationStatus.CANCELLATION_PENDING) {
+			return false;
+		}
 		if (this.status != ReservationStatus.CONFIRMED) {
 			throw new InvalidReservationStatusException(ErrorCode.CANNOT_CANCEL_RESERVATION);
 		}
-		this.status = ReservationStatus.CANCELLED;
+		this.status = ReservationStatus.CANCELLATION_PENDING;
+		return true;
 	}
 
-	public void failCancellation() {
+	public boolean completeCancellation() {
+		if (this.status == ReservationStatus.CANCELLED) {
+			return false;
+		}
+		if (this.status != ReservationStatus.CANCELLATION_PENDING
+			&& this.status != ReservationStatus.CANCELLATION_FAILED) {
+			throw new InvalidReservationStatusException(ErrorCode.CANNOT_CANCEL_RESERVATION);
+		}
+		this.status = ReservationStatus.CANCELLED;
+		return true;
+	}
+
+	public boolean failCancellation() {
+		if (this.status == ReservationStatus.CANCELLATION_FAILED) {
+			return false;
+		}
+		if (this.status != ReservationStatus.CANCELLATION_PENDING) {
+			throw new InvalidReservationStatusException(ErrorCode.CANNOT_CANCEL_RESERVATION);
+		}
+		this.status = ReservationStatus.CANCELLATION_FAILED;
+		return true;
+	}
+
+	public void recoverLegacyCancellationFailure() {
 		if (this.status != ReservationStatus.CANCELLED) {
-			return;
+			throw new InvalidReservationStatusException(ErrorCode.CANNOT_CANCEL_RESERVATION);
 		}
 		this.status = ReservationStatus.CANCELLATION_FAILED;
 	}

--- a/src/main/java/kr/kro/airbob/domain/reservation/entity/ReservationHistory.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/entity/ReservationHistory.java
@@ -1,5 +1,7 @@
 package kr.kro.airbob.domain.reservation.entity;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
@@ -41,8 +43,12 @@ public class ReservationHistory extends HistoryBase {
 	private String reservationCode;
 	private Long accommodationId;
 	private Long guestId;
-	private LocalDateTime checkIn;
-	private LocalDateTime checkOut;
+	private LocalDate checkInDate;
+	private LocalDate checkOutDate;
+	private Instant checkInAt;
+	private Instant checkOutAt;
+	@Column(length = 64)
+	private String timeZoneId;
 	private Integer guestCount;
 	private Long totalPrice;
 	@Column(length = 3)
@@ -50,7 +56,7 @@ public class ReservationHistory extends HistoryBase {
 	@Enumerated(EnumType.STRING)
 	private ReservationStatus status;
 	private String message;
-	private LocalDateTime expiresAt;
+	private Instant expiresAt;
 
 	// --- 원본 최초 생성 정보(스냅샷) ---
 	private LocalDateTime createdAt;
@@ -76,8 +82,11 @@ public class ReservationHistory extends HistoryBase {
 			.reservationCode(r.getReservationCode())
 			.accommodationId(r.getAccommodation() == null ? null : r.getAccommodation().getId())
 			.guestId(r.getGuest() == null ? null : r.getGuest().getId())
-			.checkIn(r.getCheckIn())
-			.checkOut(r.getCheckOut())
+			.checkInDate(r.getCheckInDate())
+			.checkOutDate(r.getCheckOutDate())
+			.checkInAt(r.getCheckInAt())
+			.checkOutAt(r.getCheckOutAt())
+			.timeZoneId(r.getTimeZoneId())
 			.guestCount(r.getGuestCount())
 			.totalPrice(r.getTotalPrice())
 			.currency(r.getCurrency())

--- a/src/main/java/kr/kro/airbob/domain/reservation/entity/ReservationStatus.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/entity/ReservationStatus.java
@@ -1,11 +1,35 @@
 package kr.kro.airbob.domain.reservation.entity;
 
+import java.util.Set;
+
 public enum ReservationStatus {
 
-    PAYMENT_PENDING,
-    CONFIRMED,
-    CANCELLED,
-    CANCELLATION_FAILED,
-    EXPIRED
+	PAYMENT_PENDING,
+	PAYMENT_PROCESSING,
+	CONFIRMED,
+	CANCELLATION_PENDING,
+	CANCELLED,
+	CANCELLATION_FAILED,
+	EXPIRED;
+
+	private static final Set<ReservationStatus> REVIEWABLE_STATUSES = Set.of(
+		CONFIRMED,
+		CANCELLATION_FAILED
+	);
+
+	public boolean isReviewableReservation() {
+		return REVIEWABLE_STATUSES.contains(this);
+	}
+
+	public static Set<ReservationStatus> reviewableStatuses() {
+		return REVIEWABLE_STATUSES;
+	}
+
+	public boolean hasConfirmedPayment() {
+		return this == CONFIRMED
+			|| this == CANCELLATION_PENDING
+			|| this == CANCELLATION_FAILED
+			|| this == CANCELLED;
+	}
 
 }

--- a/src/main/java/kr/kro/airbob/domain/reservation/event/ReservationEvent.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/event/ReservationEvent.java
@@ -20,7 +20,7 @@ public class ReservationEvent {
 		}
 	}
 
-	public record ReservationCancelledEvent(
+	public record ReservationCancellationRequestedEvent(
 		String reservationUid,
 		String cancelReason,
 		Long cancelAmount // 전체 취소 시 null | 전체 금액
@@ -28,6 +28,18 @@ public class ReservationEvent {
 		@Override
 		public String getId() {
 			return this.reservationUid;
+		}
+	}
+
+	@Deprecated
+	public record ReservationCancelledEvent(
+		String reservationUid,
+		String cancelReason,
+		Long cancelAmount
+	) implements EventPayload {
+		@Override
+		public String getId() {
+			return reservationUid;
 		}
 	}
 
@@ -66,6 +78,15 @@ public class ReservationEvent {
 	public record ReservationCancellationRevertRequestedEvent(
 		String reservationUid,
 		String reason
+	) implements EventPayload {
+		@Override
+		public String getId() {
+			return this.reservationUid;
+		}
+	}
+
+	public record ReservationCancellationCompleteRequestedEvent(
+		String reservationUid
 	) implements EventPayload {
 		@Override
 		public String getId() {

--- a/src/main/java/kr/kro/airbob/domain/reservation/exception/ExpiredReservationConfirmationException.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/exception/ExpiredReservationConfirmationException.java
@@ -1,0 +1,11 @@
+package kr.kro.airbob.domain.reservation.exception;
+
+import kr.kro.airbob.common.exception.BaseException;
+import kr.kro.airbob.common.exception.ErrorCode;
+
+public class ExpiredReservationConfirmationException extends BaseException {
+
+	public ExpiredReservationConfirmationException() {
+		super(ErrorCode.CANNOT_CONFIRM_EXPIRED_RESERVATION);
+	}
+}

--- a/src/main/java/kr/kro/airbob/domain/reservation/exception/InvalidReservationLocalTimeException.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/exception/InvalidReservationLocalTimeException.java
@@ -1,0 +1,11 @@
+package kr.kro.airbob.domain.reservation.exception;
+
+import kr.kro.airbob.common.exception.BaseException;
+import kr.kro.airbob.common.exception.ErrorCode;
+
+public class InvalidReservationLocalTimeException extends BaseException {
+
+	public InvalidReservationLocalTimeException() {
+		super(ErrorCode.RESERVATION_LOCAL_TIME_INVALID);
+	}
+}

--- a/src/main/java/kr/kro/airbob/domain/reservation/policy/BookingWindow.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/policy/BookingWindow.java
@@ -9,10 +9,6 @@ public record BookingWindow(
 
 	private static final long BOOKING_WINDOW_MONTHS = 3L;
 
-	public static BookingWindow current() {
-		return startingOn(LocalDate.now());
-	}
-
 	public static BookingWindow startingOn(LocalDate startInclusive) {
 		return new BookingWindow(
 			startInclusive,

--- a/src/main/java/kr/kro/airbob/domain/reservation/policy/BookingWindowProvider.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/policy/BookingWindowProvider.java
@@ -1,0 +1,24 @@
+package kr.kro.airbob.domain.reservation.policy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookingWindowProvider {
+
+	private final Clock clock;
+
+	public BookingWindowProvider(Clock clock) {
+		this.clock = clock;
+	}
+
+	public BookingWindow currentFor(String timeZoneId) {
+		ZoneId zone = ZoneId.of(timeZoneId);
+		LocalDate localToday = Instant.now(clock).atZone(zone).toLocalDate();
+		return BookingWindow.startingOn(localToday);
+	}
+}

--- a/src/main/java/kr/kro/airbob/domain/reservation/policy/BookingWindowProvider.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/policy/BookingWindowProvider.java
@@ -4,11 +4,18 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class BookingWindowProvider {
+	private static final List<ZoneId> AVAILABLE_TIME_ZONES = ZoneId.getAvailableZoneIds().stream()
+		.map(ZoneId::of)
+		.toList();
 
 	private final Clock clock;
 
@@ -17,8 +24,28 @@ public class BookingWindowProvider {
 	}
 
 	public BookingWindow currentFor(String timeZoneId) {
-		ZoneId zone = ZoneId.of(timeZoneId);
-		LocalDate localToday = Instant.now(clock).atZone(zone).toLocalDate();
+		return currentFor(ZoneId.of(timeZoneId), clock.instant());
+	}
+
+	private BookingWindow currentFor(ZoneId timeZone, Instant now) {
+		LocalDate localToday = now.atZone(timeZone).toLocalDate();
 		return BookingWindow.startingOn(localToday);
+	}
+
+	public Set<String> eligibleTimeZonesForStay(LocalDate checkInDate, LocalDate checkOutDate) {
+		Instant now = clock.instant();
+		return AVAILABLE_TIME_ZONES.stream()
+			.filter(timeZone -> currentFor(timeZone, now).containsStay(checkInDate, checkOutDate))
+			.map(ZoneId::getId)
+			.collect(Collectors.toUnmodifiableSet());
+	}
+
+	public ReservationIndexingWindow currentIndexingWindow() {
+		LocalDate utcToday = clock.instant().atZone(ZoneOffset.UTC).toLocalDate();
+		BookingWindow latestLocalBookingWindow = BookingWindow.startingOn(utcToday.plusDays(1));
+		return new ReservationIndexingWindow(
+			utcToday.minusDays(1),
+			latestLocalBookingWindow.endExclusive()
+		);
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/reservation/policy/ReservationIndexingWindow.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/policy/ReservationIndexingWindow.java
@@ -1,0 +1,9 @@
+package kr.kro.airbob.domain.reservation.policy;
+
+import java.time.LocalDate;
+
+public record ReservationIndexingWindow(
+	LocalDate startInclusive,
+	LocalDate endExclusive
+) {
+}

--- a/src/main/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriter.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriter.java
@@ -1,10 +1,12 @@
 package kr.kro.airbob.domain.reservation.repository;
 
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -25,10 +27,11 @@ public class ReservationHistoryBatchWriter {
 	private static final String INSERT_SQL = """
 		INSERT INTO reservation_history (
 			reservation_id, reservation_uid, reservation_code, accommodation_id, guest_id,
-			check_in, check_out, guest_count, total_price, currency, status, message,
-			expires_at, created_at, created_by, history_created_at, history_created_by,
-			change_type, change_reason, source_system, client_ip
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				check_in_date, check_out_date, check_in_at, check_out_at, time_zone_id,
+				guest_count, total_price, currency, status, message,
+				expires_at, created_at, created_by, history_created_at, history_created_by,
+				change_type, change_reason, source_system, client_ip
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		""";
 
 	private final JdbcTemplate jdbcTemplate;
@@ -45,7 +48,7 @@ public class ReservationHistoryBatchWriter {
 		this.batchSize = batchSize;
 	}
 
-	public void writeAll(List<ReservationHistory> histories, LocalDateTime historyCreatedAt) {
+	public void writeAll(List<ReservationHistory> histories, Instant historyCreatedAt) {
 		Objects.requireNonNull(histories, "histories must not be null");
 		Objects.requireNonNull(historyCreatedAt, "historyCreatedAt must not be null");
 
@@ -61,7 +64,7 @@ public class ReservationHistoryBatchWriter {
 
 	private BatchPreparedStatementSetter batchSetter(
 		List<ReservationHistory> histories,
-		LocalDateTime historyCreatedAt
+		Instant historyCreatedAt
 	) {
 		return new BatchPreparedStatementSetter() {
 			@Override
@@ -79,29 +82,48 @@ public class ReservationHistoryBatchWriter {
 	private void bind(
 		PreparedStatement statement,
 		ReservationHistory history,
-		LocalDateTime historyCreatedAt
+		Instant historyCreatedAt
 	) throws SQLException {
 		statement.setLong(1, history.getReservationId());
 		statement.setString(2, history.getReservationUid());
 		statement.setString(3, history.getReservationCode());
 		setNullableLong(statement, 4, history.getAccommodationId());
 		setNullableLong(statement, 5, history.getGuestId());
-		setNullableTimestamp(statement, 6, history.getCheckIn());
-		setNullableTimestamp(statement, 7, history.getCheckOut());
-		setNullableInteger(statement, 8, history.getGuestCount());
-		setNullableLong(statement, 9, history.getTotalPrice());
-		statement.setString(10, history.getCurrency());
-		statement.setString(11, history.getStatus() == null ? null : history.getStatus().name());
-		statement.setString(12, history.getMessage());
-		setNullableTimestamp(statement, 13, history.getExpiresAt());
-		setNullableTimestamp(statement, 14, history.getCreatedAt());
-		setNullableLong(statement, 15, history.getCreatedBy());
-		statement.setTimestamp(16, Timestamp.valueOf(historyCreatedAt));
-		statement.setNull(17, Types.BIGINT);
-		statement.setString(18, history.getChangeType().name());
-		statement.setString(19, history.getChangeReason());
-		statement.setString(20, history.getSourceSystem());
-		statement.setString(21, history.getClientIp());
+		setNullableDate(statement, 6, history.getCheckInDate());
+		setNullableDate(statement, 7, history.getCheckOutDate());
+		setNullableInstant(statement, 8, history.getCheckInAt());
+		setNullableInstant(statement, 9, history.getCheckOutAt());
+		statement.setString(10, history.getTimeZoneId());
+		setNullableInteger(statement, 11, history.getGuestCount());
+		setNullableLong(statement, 12, history.getTotalPrice());
+		statement.setString(13, history.getCurrency());
+		statement.setString(14, history.getStatus() == null ? null : history.getStatus().name());
+		statement.setString(15, history.getMessage());
+		setNullableInstant(statement, 16, history.getExpiresAt());
+		setNullableTimestamp(statement, 17, history.getCreatedAt());
+		setNullableLong(statement, 18, history.getCreatedBy());
+		statement.setTimestamp(19, Timestamp.from(historyCreatedAt));
+		statement.setNull(20, Types.BIGINT);
+		statement.setString(21, history.getChangeType().name());
+		statement.setString(22, history.getChangeReason());
+		statement.setString(23, history.getSourceSystem());
+		statement.setString(24, history.getClientIp());
+	}
+
+	private void setNullableDate(PreparedStatement statement, int index, java.time.LocalDate value) throws SQLException {
+		if (value == null) {
+			statement.setNull(index, Types.DATE);
+		} else {
+			statement.setDate(index, Date.valueOf(value));
+		}
+	}
+
+	private void setNullableInstant(PreparedStatement statement, int index, Instant value) throws SQLException {
+		if (value == null) {
+			statement.setNull(index, Types.TIMESTAMP);
+		} else {
+			statement.setTimestamp(index, Timestamp.from(value));
+		}
 	}
 
 	private void setNullableLong(PreparedStatement statement, int index, Long value) throws SQLException {

--- a/src/main/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriter.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriter.java
@@ -1,13 +1,12 @@
 package kr.kro.airbob.domain.reservation.repository;
 
-import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
 
@@ -102,7 +101,7 @@ public class ReservationHistoryBatchWriter {
 		setNullableInstant(statement, 16, history.getExpiresAt());
 		setNullableTimestamp(statement, 17, history.getCreatedAt());
 		setNullableLong(statement, 18, history.getCreatedBy());
-		statement.setTimestamp(19, Timestamp.from(historyCreatedAt));
+		statement.setObject(19, toUtcDateTime(historyCreatedAt), Types.TIMESTAMP);
 		statement.setNull(20, Types.BIGINT);
 		statement.setString(21, history.getChangeType().name());
 		statement.setString(22, history.getChangeReason());
@@ -114,7 +113,7 @@ public class ReservationHistoryBatchWriter {
 		if (value == null) {
 			statement.setNull(index, Types.DATE);
 		} else {
-			statement.setDate(index, Date.valueOf(value));
+			statement.setObject(index, value, Types.DATE);
 		}
 	}
 
@@ -122,7 +121,7 @@ public class ReservationHistoryBatchWriter {
 		if (value == null) {
 			statement.setNull(index, Types.TIMESTAMP);
 		} else {
-			statement.setTimestamp(index, Timestamp.from(value));
+			statement.setObject(index, toUtcDateTime(value), Types.TIMESTAMP);
 		}
 	}
 
@@ -146,8 +145,12 @@ public class ReservationHistoryBatchWriter {
 		if (value == null) {
 			statement.setNull(index, Types.TIMESTAMP);
 		} else {
-			statement.setTimestamp(index, Timestamp.valueOf(value));
+			statement.setObject(index, value, Types.TIMESTAMP);
 		}
+	}
+
+	private LocalDateTime toUtcDateTime(Instant value) {
+		return LocalDateTime.ofInstant(value, ZoneOffset.UTC);
 	}
 
 	private Long affectedRows(int[] updateCounts, int submittedRows) {

--- a/src/main/java/kr/kro/airbob/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/repository/ReservationRepository.java
@@ -1,19 +1,30 @@
 package kr.kro.airbob.domain.reservation.repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 import kr.kro.airbob.domain.reservation.entity.Reservation;
 import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long>, ReservationRepositoryCustom{
 
-	List<Reservation> findAllByStatusAndExpiresAtBefore(ReservationStatus status, LocalDateTime expiresAt);
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	List<Reservation> findAllByStatusAndExpiresAtLessThanEqual(ReservationStatus status, Instant expiresAt);
+
 	Optional<Reservation> findByReservationUid(UUID reservationUid);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select reservation from Reservation reservation where reservation.reservationUid = :reservationUid")
+	Optional<Reservation> findByReservationUidWithLock(@Param("reservationUid") UUID reservationUid);
 
 	boolean existsByReservationCode(String reservationCode);
 }

--- a/src/main/java/kr/kro/airbob/domain/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/repository/ReservationRepositoryCustom.java
@@ -1,5 +1,7 @@
 package kr.kro.airbob.domain.reservation.repository;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -13,26 +15,37 @@ import kr.kro.airbob.domain.reservation.entity.Reservation;
 import kr.kro.airbob.domain.reservation.entity.ReservationFilterType;
 
 public interface ReservationRepositoryCustom {
-	boolean existsConflictingReservation(Long accommodationId, LocalDateTime checkIn, LocalDateTime checkOut);
+	boolean existsConflictingReservation(
+		Long accommodationId,
+		LocalDate checkInDate,
+		LocalDate checkOutDate,
+		Instant now
+	);
+
+	boolean existsFutureInventoryReservation(Long accommodationId, Instant now);
 
 	boolean existsCompletedReservationByGuest(Long accommodationId, Long memberId);
 
-	boolean existsPastCompletedReservationByGuest(Long accommodationId, Long memberId);
+	boolean existsPastCompletedReservationByGuest(Long accommodationId, Long memberId, Instant now);
 
-	List<ReservationDateRange> findConfirmedReservationRangesByAccommodationId(
+	List<ReservationDateRange> findActiveReservationRangesByAccommodationId(
 		Long accommodationId,
-		LocalDateTime windowStartInclusive,
-		LocalDateTime windowEndExclusive
+		LocalDate windowStartInclusive,
+		LocalDate windowEndExclusive
 	);
 
-	List<ReservationDateRange> findFutureConfirmedReservationRangesByAccommodationUid(
-		UUID accommodationUid);
+	List<ReservationDateRange> findActiveReservationRangesByAccommodationUid(
+		UUID accommodationUid,
+		LocalDate windowStartInclusive,
+		LocalDate windowEndExclusive
+	);
 
 	Slice<Reservation> findMyReservationsByGuestIdWithCursor(
 		Long guestId,
 		Long lastId,
 		LocalDateTime lastCreatedAt,
 		ReservationFilterType filterType,
+		Instant now,
 		Pageable pageable
 	);
 
@@ -41,6 +54,7 @@ public interface ReservationRepositoryCustom {
 		Long lastId,
 		LocalDateTime lastCreatedAt,
 		ReservationFilterType filterType,
+		Instant now,
 		Pageable pageable
 	);
 

--- a/src/main/java/kr/kro/airbob/domain/reservation/repository/impl/ReservationRepositoryImpl.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/repository/impl/ReservationRepositoryImpl.java
@@ -6,6 +6,8 @@ import static kr.kro.airbob.domain.member.entity.QMember.*;
 import static kr.kro.airbob.domain.reservation.entity.QReservation.reservation;
 import static kr.kro.airbob.domain.reservation.entity.ReservationStatus.*;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -35,15 +37,35 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 	private final QMember guestMember = new QMember("guestMember");
 
 	@Override
-	public boolean existsConflictingReservation(Long accommodationId, LocalDateTime checkIn, LocalDateTime checkOut) {
+	public boolean existsConflictingReservation(
+		Long accommodationId,
+		LocalDate checkInDate,
+		LocalDate checkOutDate,
+		Instant now
+	) {
 		Integer fetchFirst = queryFactory
 			.selectOne()
 			.from(reservation)
 			.where(
 				reservation.accommodation.id.eq(accommodationId),
-				reservation.status.in(CONFIRMED, PAYMENT_PENDING),
-				reservation.checkIn.lt(checkOut),
-				reservation.checkOut.gt(checkIn)
+				inventoryOccupyingReservationStatus(now),
+				reservation.checkInDate.lt(checkOutDate),
+				reservation.checkOutDate.gt(checkInDate)
+			)
+			.fetchFirst();
+
+		return fetchFirst != null;
+	}
+
+	@Override
+	public boolean existsFutureInventoryReservation(Long accommodationId, Instant now) {
+		Integer fetchFirst = queryFactory
+			.selectOne()
+			.from(reservation)
+			.where(
+				reservation.accommodation.id.eq(accommodationId),
+				reservation.checkOutAt.gt(now),
+				inventoryOccupyingReservationStatus(now)
 			)
 			.fetchFirst();
 
@@ -58,69 +80,76 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 			.where(
 				reservation.accommodation.id.eq(accommodationId),
 				reservation.guest.id.eq(memberId),
-				reservation.status.eq(ReservationStatus.CONFIRMED)
+				reviewableReservationStatus()
 			)
 			.fetchFirst();
 		return fetchFirst != null;
 	}
 
 	@Override
-	public boolean existsPastCompletedReservationByGuest(Long accommodationId, Long memberId) {
+	public boolean existsPastCompletedReservationByGuest(Long accommodationId, Long memberId, Instant now) {
 		Integer fetchFirst = queryFactory
 			.selectOne()
 			.from(reservation)
 			.where(
 				reservation.accommodation.id.eq(accommodationId),
 				reservation.guest.id.eq(memberId),
-				reservation.status.eq(CONFIRMED),
-				reservation.checkOut.before(LocalDateTime.now())
+				reviewableReservationStatus(),
+				reservation.checkOutAt.loe(now)
 			)
 			.fetchFirst();
 		return fetchFirst != null;
 	}
 
 	@Override
-	public List<ReservationDateRange> findConfirmedReservationRangesByAccommodationId(
+	public List<ReservationDateRange> findActiveReservationRangesByAccommodationId(
 		Long accommodationId,
-		LocalDateTime windowStartInclusive,
-		LocalDateTime windowEndExclusive
+		LocalDate windowStartInclusive,
+		LocalDate windowEndExclusive
 	) {
-		return queryFactory
-			.select(new QReservationDateRange(
-				reservation.checkIn,
-				reservation.checkOut
-			))
-			.from(reservation)
-			.where(
-				reservation.accommodation.id.eq(accommodationId),
-				reservation.status.eq(ReservationStatus.CONFIRMED),
-				reservation.checkIn.lt(windowEndExclusive),
-				reservation.checkOut.gt(windowStartInclusive)
-			)
-			.fetch();
+		return findActiveReservationRanges(
+			reservation.accommodation.id.eq(accommodationId),
+			windowStartInclusive,
+			windowEndExclusive
+		);
 	}
 
 	@Override
-	public List<ReservationDateRange> findFutureConfirmedReservationRangesByAccommodationUid(
-		UUID accommodationUid
+	public List<ReservationDateRange> findActiveReservationRangesByAccommodationUid(
+		UUID accommodationUid,
+		LocalDate windowStartInclusive,
+		LocalDate windowEndExclusive
+	) {
+		return findActiveReservationRanges(
+			reservation.accommodation.accommodationUid.eq(accommodationUid),
+			windowStartInclusive,
+			windowEndExclusive
+		);
+	}
+
+	private List<ReservationDateRange> findActiveReservationRanges(
+		BooleanExpression accommodationCondition,
+		LocalDate windowStartInclusive,
+		LocalDate windowEndExclusive
 	) {
 		return queryFactory
 			.select(new QReservationDateRange(
-				reservation.checkIn,
-				reservation.checkOut
+				reservation.checkInDate,
+				reservation.checkOutDate
 			))
 			.from(reservation)
 			.where(
-				reservation.accommodation.accommodationUid.eq(accommodationUid),
-				reservation.status.eq(ReservationStatus.CONFIRMED),
-				reservation.checkOut.goe(LocalDateTime.now())
+				accommodationCondition,
+				activeReservationStatus(),
+				reservation.checkInDate.lt(windowEndExclusive),
+				reservation.checkOutDate.gt(windowStartInclusive)
 			)
 			.fetch();
 	}
 
 	@Override
 	public Slice<Reservation> findMyReservationsByGuestIdWithCursor(Long guestId, Long lastId,
-		LocalDateTime lastCreatedAt, ReservationFilterType filterType, Pageable pageable) {
+		LocalDateTime lastCreatedAt, ReservationFilterType filterType, Instant now, Pageable pageable) {
 
 		List<Reservation> content = queryFactory
 			.selectFrom(reservation)
@@ -128,7 +157,7 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 			.leftJoin(accommodation.address, address).fetchJoin()
 			.where(
 				reservation.guest.id.eq(guestId),
-				buildGuestReservationFilter(filterType),
+				buildGuestReservationFilter(filterType, now),
 				cursorCondition(lastId, lastCreatedAt)
 			)
 			.orderBy(reservation.createdAt.desc(), reservation.id.desc())
@@ -172,7 +201,7 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 
 	@Override
 	public Slice<Reservation> findHostReservationsByHostIdWithCursor(Long hostId, Long lastId,
-		LocalDateTime lastCreatedAt, ReservationFilterType filterType, Pageable pageable) {
+		LocalDateTime lastCreatedAt, ReservationFilterType filterType, Instant now, Pageable pageable) {
 
 		List<Reservation> content = queryFactory
 			.selectFrom(reservation)
@@ -180,8 +209,8 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 			.innerJoin(reservation.guest, guestMember).fetchJoin()
 			.where(
 				accommodation.member.id.eq(hostId),
-				reservation.status.ne(PAYMENT_PENDING),
-				buildHostReservationFilter(filterType),
+				reservation.status.notIn(PAYMENT_PENDING, PAYMENT_PROCESSING),
+				buildHostReservationFilter(filterType, now),
 				cursorCondition(lastId, lastCreatedAt)
 			)
 			.orderBy(reservation.createdAt.desc(), reservation.id.desc())
@@ -212,42 +241,54 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 		return Optional.ofNullable(result);
 	}
 
-	private BooleanExpression buildGuestReservationFilter(ReservationFilterType filterType) {
-		LocalDateTime now = LocalDateTime.now();
-
+	private BooleanExpression buildGuestReservationFilter(ReservationFilterType filterType, Instant now) {
 		switch (filterType) {
 			case PAST:
-				// 이전 여행: CONFIRMED이면서 체크아웃이 과거
-				return reservation.status.eq(CONFIRMED)
-					.and(reservation.checkOut.before(now));
+				// 이전 여행: 유효 예약이면서 체크아웃이 과거
+				return activeReservationStatus()
+					.and(reservation.checkOutAt.loe(now));
 			case CANCELLED:
-				// 취소된: CANCELLED, CANCELLATION_FAILED, EXPIRED
-				return reservation.status.in(CANCELLED, CANCELLATION_FAILED, EXPIRED);
+				return reservation.status.in(CANCELLED, EXPIRED)
+					.or(reservation.status.eq(PAYMENT_PENDING)
+						.and(reservation.expiresAt.loe(now)));
 			case UPCOMING:
-				// 다가올 여행: PENDING이거나, CONFIRMED이면서 체크아웃이 미래
-				return reservation.status.in(PAYMENT_PENDING)
+				// 다가올 여행: 만료되지 않은 결제 대기 또는 체크아웃 전 유효 예약
+				return reservation.status.eq(PAYMENT_PENDING)
+					.and(reservation.expiresAt.gt(now))
+					.or(reservation.status.eq(PAYMENT_PROCESSING))
 					.or(
-						reservation.status.eq(CONFIRMED).and(reservation.checkOut.after(now))
+						activeReservationStatus().and(reservation.checkOutAt.gt(now))
 					);
 			default:
 				return null;
 		}
 	}
 
-	private BooleanExpression buildHostReservationFilter(ReservationFilterType filterType) {
-		LocalDateTime now = LocalDateTime.now();
+	private BooleanExpression buildHostReservationFilter(ReservationFilterType filterType, Instant now) {
 		switch (filterType) {
 			case CANCELLED:
-				// 취소된 예약: CANCELLED, CANCELLATION_FAILED, EXPIRED
-				return reservation.status.in(CANCELLED, CANCELLATION_FAILED, EXPIRED);
+				return reservation.status.in(CANCELLED, EXPIRED);
 			case PAST:
-				// 완료된: CONFIRMED이면서 체크아웃이 과거
-				return reservation.status.eq(CONFIRMED).and(reservation.checkOut.before(now));
+				return activeReservationStatus().and(reservation.checkOutAt.loe(now));
 			case UPCOMING:
-				// 다가오는 예약: CONFIRMED이면서 체크아웃이 미래
-				return reservation.status.eq(CONFIRMED).and(reservation.checkOut.after(now));
+				return activeReservationStatus().and(reservation.checkOutAt.gt(now));
 			default:
 				return null;
 		}
+	}
+
+	private BooleanExpression activeReservationStatus() {
+		return reservation.status.in(CONFIRMED, CANCELLATION_PENDING, CANCELLATION_FAILED);
+	}
+
+	private BooleanExpression inventoryOccupyingReservationStatus(Instant now) {
+		return activeReservationStatus()
+			.or(reservation.status.eq(PAYMENT_PROCESSING))
+			.or(reservation.status.eq(PAYMENT_PENDING)
+				.and(reservation.expiresAt.gt(now)));
+	}
+
+	private BooleanExpression reviewableReservationStatus() {
+		return reservation.status.in(ReservationStatus.reviewableStatuses());
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/reservation/service/ExpiredReservationCleanupService.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/service/ExpiredReservationCleanupService.java
@@ -1,6 +1,7 @@
 package kr.kro.airbob.domain.reservation.service;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -24,11 +25,12 @@ public class ExpiredReservationCleanupService {
 	private final ReservationRepository reservationRepository;
 	private final ReservationHistoryBatchWriter historyBatchWriter;
 	private final ReservationHoldService holdService;
+	private final Clock clock;
 
 	@Transactional
 	public int cleanupExpiredPendingReservations() {
-		LocalDateTime cutoff = LocalDateTime.now();
-		List<Reservation> expired = reservationRepository.findAllByStatusAndExpiresAtBefore(
+		Instant cutoff = clock.instant();
+		List<Reservation> expired = reservationRepository.findAllByStatusAndExpiresAtLessThanEqual(
 			ReservationStatus.PAYMENT_PENDING,
 			cutoff
 		);
@@ -51,8 +53,8 @@ public class ExpiredReservationCleanupService {
 		historyBatchWriter.writeAll(histories, cutoff);
 		expired.forEach(reservation -> holdService.removeHold(
 			reservation.getAccommodation().getId(),
-			reservation.getCheckIn().toLocalDate(),
-			reservation.getCheckOut().toLocalDate()
+			reservation.getCheckInDate(),
+			reservation.getCheckOutDate()
 		));
 		return expired.size();
 	}

--- a/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationHistoryInsertBeforeBenchmarkService.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationHistoryInsertBeforeBenchmarkService.java
@@ -1,6 +1,6 @@
 package kr.kro.airbob.domain.reservation.service;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
 import java.util.List;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -27,14 +27,15 @@ public class ReservationHistoryInsertBeforeBenchmarkService {
 	private final ReservationHoldService holdService;
 	private final ReservationRepository reservationRepository;
 	private final ReservationHistoryRepository historyRepository;
+	private final Clock clock;
 
 	@Transactional
 	public void cleanupExpiredPendingReservations() {
 		log.info("만료된 결제 대기 예약 정리 작업 시작");
 
-		List<Reservation> expiredList = reservationRepository.findAllByStatusAndExpiresAtBefore(
+		List<Reservation> expiredList = reservationRepository.findAllByStatusAndExpiresAtLessThanEqual(
 			ReservationStatus.PAYMENT_PENDING,
-			LocalDateTime.now()
+			clock.instant()
 		);
 
 		if (expiredList.isEmpty()) {
@@ -51,8 +52,8 @@ public class ReservationHistoryInsertBeforeBenchmarkService {
 
 			holdService.removeHold(
 				reservation.getAccommodation().getId(),
-				reservation.getCheckIn().toLocalDate(),
-				reservation.getCheckOut().toLocalDate()
+				reservation.getCheckInDate(),
+				reservation.getCheckOutDate()
 			);
 		});
 		log.info("{}건의 만료된 예약 정리 완료", expiredList.size());

--- a/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationHistoryInsertBenchmarkFixtureService.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationHistoryInsertBenchmarkFixtureService.java
@@ -4,12 +4,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Timestamp;
+import java.sql.Types;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -251,14 +252,14 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 			statement.setString(2, reservationCode);
 			statement.setLong(3, accommodationId);
 			statement.setLong(4, memberId);
-			statement.setObject(5, checkIn);
-			statement.setObject(6, checkOut);
-			statement.setTimestamp(7, Timestamp.from(checkInAt));
-			statement.setTimestamp(8, Timestamp.from(checkOutAt));
+			statement.setObject(5, checkIn, Types.DATE);
+			statement.setObject(6, checkOut, Types.DATE);
+			statement.setObject(7, toUtcDateTime(checkInAt), Types.TIMESTAMP);
+			statement.setObject(8, toUtcDateTime(checkOutAt), Types.TIMESTAMP);
 			statement.setString(9, ACCOMMODATION_ZONE.getId());
 			statement.setString(10, status);
 			statement.setString(11, message);
-			statement.setTimestamp(12, Timestamp.from(expiresAt));
+			statement.setObject(12, toUtcDateTime(expiresAt), Types.TIMESTAMP);
 			statement.setObject(13, CREATED_AT);
 			statement.setObject(14, CREATED_AT);
 			statement.setLong(15, memberId);
@@ -346,18 +347,18 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 			resultSet.getObject("guest_id", Long.class),
 			resultSet.getObject("check_in_date", LocalDate.class),
 			resultSet.getObject("check_out_date", LocalDate.class),
-			toInstant(resultSet.getTimestamp("check_in_at")),
-			toInstant(resultSet.getTimestamp("check_out_at")),
+			toInstant(resultSet.getObject("check_in_at", LocalDateTime.class)),
+			toInstant(resultSet.getObject("check_out_at", LocalDateTime.class)),
 			resultSet.getString("time_zone_id"),
 			resultSet.getObject("guest_count", Integer.class),
 			resultSet.getObject("total_price", Long.class),
 			resultSet.getString("currency"),
 			resultSet.getString("status"),
 			resultSet.getString("message"),
-			toInstant(resultSet.getTimestamp("expires_at")),
+			toInstant(resultSet.getObject("expires_at", LocalDateTime.class)),
 			resultSet.getObject("created_at", LocalDateTime.class),
 			resultSet.getObject("created_by", Long.class),
-			toInstant(resultSet.getTimestamp("history_created_at")),
+			toInstant(resultSet.getObject("history_created_at", LocalDateTime.class)),
 			resultSet.getObject("history_created_by", Long.class),
 			resultSet.getString("change_type"),
 			resultSet.getString("change_reason"),
@@ -451,7 +452,7 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		Long eligible = jdbcTemplate.queryForObject(
 			"SELECT COUNT(*) FROM reservation WHERE status = 'PAYMENT_PENDING' AND expires_at <= ?",
 			Long.class,
-			Timestamp.from(clock.instant())
+			toUtcDateTime(clock.instant())
 		);
 		if (!Objects.equals(eligible, 0L)) {
 			throw new IllegalStateException("전용 벤치마크 DB에 기존 만료 대상 예약이 있습니다.");
@@ -462,7 +463,7 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		List<Long> eligibleIds = jdbcTemplate.queryForList(
 			"SELECT id FROM reservation WHERE status = 'PAYMENT_PENDING' AND expires_at <= ? ORDER BY id",
 			Long.class,
-			Timestamp.from(clock.instant())
+			toUtcDateTime(clock.instant())
 		);
 		List<Long> targetIds = fixture.targets().stream().map(ReservationExpectation::id).sorted().toList();
 		if (!eligibleIds.equals(targetIds)) {
@@ -491,8 +492,12 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		return String.join(", ", Collections.nCopies(size, "?"));
 	}
 
-	private Instant toInstant(Timestamp timestamp) {
-		return timestamp == null ? null : timestamp.toInstant();
+	private LocalDateTime toUtcDateTime(Instant instant) {
+		return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+	}
+
+	private Instant toInstant(LocalDateTime dateTime) {
+		return dateTime == null ? null : dateTime.toInstant(ZoneOffset.UTC);
 	}
 
 	private void validateDatasetSize(int datasetSize) {

--- a/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationHistoryInsertBenchmarkFixtureService.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationHistoryInsertBenchmarkFixtureService.java
@@ -5,7 +5,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,15 +38,18 @@ import kr.kro.airbob.domain.reservation.service.ReservationHistoryInsertBenchmar
 public class ReservationHistoryInsertBenchmarkFixtureService {
 
 	private static final LocalDateTime CREATED_AT = LocalDateTime.of(2026, 1, 1, 0, 0);
-	private static final LocalDateTime CHECK_IN = LocalDateTime.of(2030, 1, 1, 15, 0);
-	private static final LocalDateTime CHECK_OUT = LocalDateTime.of(2030, 1, 3, 11, 0);
-	private static final LocalDateTime EXPIRED_AT = LocalDateTime.of(2000, 1, 1, 0, 0);
-	private static final LocalDateTime FUTURE_EXPIRES_AT = LocalDateTime.of(2099, 1, 1, 0, 0);
+	private static final LocalDate CHECK_IN = LocalDate.of(2030, 1, 1);
+	private static final LocalDate CHECK_OUT = LocalDate.of(2030, 1, 3);
+	private static final Instant EXPIRED_AT = Instant.parse("2000-01-01T00:00:00Z");
+	private static final Instant FUTURE_EXPIRES_AT = Instant.parse("2099-01-01T00:00:00Z");
+	private static final ZoneId ACCOMMODATION_ZONE = ZoneId.of("Asia/Seoul");
 
 	private final JdbcTemplate jdbcTemplate;
+	private final Clock clock;
 
-	public ReservationHistoryInsertBenchmarkFixtureService(JdbcTemplate jdbcTemplate) {
+	public ReservationHistoryInsertBenchmarkFixtureService(JdbcTemplate jdbcTemplate, Clock clock) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.clock = clock;
 	}
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -54,8 +61,8 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		long accommodationId = insertAccommodation(memberId);
 		List<ReservationExpectation> targets = new ArrayList<>(datasetSize);
 		for (int index = 0; index < datasetSize; index++) {
-			LocalDateTime targetCheckIn = CHECK_IN.plusDays(index * 3L);
-			LocalDateTime targetCheckOut = CHECK_OUT.plusDays(index * 3L);
+			LocalDate targetCheckIn = CHECK_IN.plusDays(index * 3L);
+			LocalDate targetCheckOut = CHECK_OUT.plusDays(index * 3L);
 			targets.add(insertReservation(
 				accommodationId,
 				memberId,
@@ -186,8 +193,8 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		return insertAndReturnKey(sql, statement -> {
 			statement.setString(1, "bulk-write-" + unique + "@benchmark.local");
 			statement.setString(2, "bulk-write-reservation-member");
-			statement.setTimestamp(3, Timestamp.valueOf(CREATED_AT));
-			statement.setTimestamp(4, Timestamp.valueOf(CREATED_AT));
+			statement.setObject(3, CREATED_AT);
+			statement.setObject(4, CREATED_AT);
 		});
 	}
 
@@ -195,30 +202,34 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		String sql = """
 			INSERT INTO accommodation (
 				member_id, check_in_time, check_out_time, accommodation_uid, status,
-				name, base_price, currency, created_at, updated_at, created_by, updated_by
+				name, base_price, currency, time_zone_id,
+				created_at, updated_at, created_by, updated_by
 			) VALUES (?, '15:00:00', '11:00:00', UUID_TO_BIN(?), 'PUBLISHED',
-				?, 100000, 'KRW', ?, ?, ?, ?)
+				?, 100000, 'KRW', ?, ?, ?, ?, ?)
 			""";
 		return insertAndReturnKey(sql, statement -> {
 			statement.setLong(1, memberId);
 			statement.setString(2, UUID.randomUUID().toString());
 			statement.setString(3, "bulk-write-reservation-accommodation");
-			statement.setTimestamp(4, Timestamp.valueOf(CREATED_AT));
-			statement.setTimestamp(5, Timestamp.valueOf(CREATED_AT));
-			statement.setLong(6, memberId);
+			statement.setString(4, ACCOMMODATION_ZONE.getId());
+			statement.setObject(5, CREATED_AT);
+			statement.setObject(6, CREATED_AT);
 			statement.setLong(7, memberId);
+			statement.setLong(8, memberId);
 		});
 	}
 
 	private ReservationExpectation insertReservation(
 		long accommodationId,
 		long memberId,
-		LocalDateTime checkIn,
-		LocalDateTime checkOut,
+		LocalDate checkIn,
+		LocalDate checkOut,
 		String status,
 		String message,
-		LocalDateTime expiresAt
+		Instant expiresAt
 	) {
+		Instant checkInAt = checkIn.atTime(15, 0).atZone(ACCOMMODATION_ZONE).toInstant();
+		Instant checkOutAt = checkOut.atTime(11, 0).atZone(ACCOMMODATION_ZONE).toInstant();
 		String reservationUid = UUID.randomUUID().toString();
 		String reservationCode = UUID.randomUUID().toString()
 			.replace("-", "")
@@ -227,10 +238,11 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		String sql = """
 			INSERT INTO reservation (
 				reservation_uid, reservation_code, accommodation_id, guest_id,
-				check_in, check_out, guest_count, total_price, discount_amount,
+				check_in_date, check_out_date, check_in_at, check_out_at, time_zone_id,
+				guest_count, total_price, discount_amount,
 				currency, status, message, expires_at, created_at, updated_at, created_by, updated_by
 			) VALUES (
-				UUID_TO_BIN(?), ?, ?, ?, ?, ?, 2, 200000, 0,
+				UUID_TO_BIN(?), ?, ?, ?, ?, ?, ?, ?, ?, 2, 200000, 0,
 				'KRW', ?, ?, ?, ?, ?, ?, ?
 			)
 			""";
@@ -239,15 +251,18 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 			statement.setString(2, reservationCode);
 			statement.setLong(3, accommodationId);
 			statement.setLong(4, memberId);
-			statement.setTimestamp(5, Timestamp.valueOf(checkIn));
-			statement.setTimestamp(6, Timestamp.valueOf(checkOut));
-			statement.setString(7, status);
-			statement.setString(8, message);
-			statement.setTimestamp(9, Timestamp.valueOf(expiresAt));
-			statement.setTimestamp(10, Timestamp.valueOf(CREATED_AT));
-			statement.setTimestamp(11, Timestamp.valueOf(CREATED_AT));
-			statement.setLong(12, memberId);
-			statement.setLong(13, memberId);
+			statement.setObject(5, checkIn);
+			statement.setObject(6, checkOut);
+			statement.setTimestamp(7, Timestamp.from(checkInAt));
+			statement.setTimestamp(8, Timestamp.from(checkOutAt));
+			statement.setString(9, ACCOMMODATION_ZONE.getId());
+			statement.setString(10, status);
+			statement.setString(11, message);
+			statement.setTimestamp(12, Timestamp.from(expiresAt));
+			statement.setObject(13, CREATED_AT);
+			statement.setObject(14, CREATED_AT);
+			statement.setLong(15, memberId);
+			statement.setLong(16, memberId);
 		});
 
 		return new ReservationExpectation(
@@ -258,6 +273,9 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 			memberId,
 			checkIn,
 			checkOut,
+			checkInAt,
+			checkOutAt,
+			ACCOMMODATION_ZONE.getId(),
 			2,
 			200_000L,
 			"KRW",
@@ -294,7 +312,7 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 			ReservationRow row = new ReservationRow(
 				resultSet.getLong("id"),
 				resultSet.getString("status"),
-				toLocalDateTime(resultSet.getTimestamp("updated_at"))
+				resultSet.getObject("updated_at", LocalDateTime.class)
 			);
 			rows.put(row.id(), row);
 		}, reservationIds.toArray());
@@ -307,7 +325,8 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		}
 		String sql = """
 			SELECT id, reservation_id, reservation_uid, reservation_code, accommodation_id, guest_id,
-			       check_in, check_out, guest_count, total_price, currency, status, message, expires_at,
+			       check_in_date, check_out_date, check_in_at, check_out_at, time_zone_id,
+			       guest_count, total_price, currency, status, message, expires_at,
 			       created_at, created_by, history_created_at, history_created_by,
 			       change_type, change_reason, source_system, client_ip
 			FROM reservation_history
@@ -325,17 +344,20 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 			resultSet.getString("reservation_code"),
 			resultSet.getObject("accommodation_id", Long.class),
 			resultSet.getObject("guest_id", Long.class),
-			toLocalDateTime(resultSet.getTimestamp("check_in")),
-			toLocalDateTime(resultSet.getTimestamp("check_out")),
+			resultSet.getObject("check_in_date", LocalDate.class),
+			resultSet.getObject("check_out_date", LocalDate.class),
+			toInstant(resultSet.getTimestamp("check_in_at")),
+			toInstant(resultSet.getTimestamp("check_out_at")),
+			resultSet.getString("time_zone_id"),
 			resultSet.getObject("guest_count", Integer.class),
 			resultSet.getObject("total_price", Long.class),
 			resultSet.getString("currency"),
 			resultSet.getString("status"),
 			resultSet.getString("message"),
-			toLocalDateTime(resultSet.getTimestamp("expires_at")),
-			toLocalDateTime(resultSet.getTimestamp("created_at")),
+			toInstant(resultSet.getTimestamp("expires_at")),
+			resultSet.getObject("created_at", LocalDateTime.class),
 			resultSet.getObject("created_by", Long.class),
-			toLocalDateTime(resultSet.getTimestamp("history_created_at")),
+			toInstant(resultSet.getTimestamp("history_created_at")),
 			resultSet.getObject("history_created_by", Long.class),
 			resultSet.getString("change_type"),
 			resultSet.getString("change_reason"),
@@ -365,6 +387,9 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 			&& Objects.equals(history.guestId(), expected.guestId())
 			&& Objects.equals(history.checkIn(), expected.checkIn())
 			&& Objects.equals(history.checkOut(), expected.checkOut())
+			&& Objects.equals(history.checkInAt(), expected.checkInAt())
+			&& Objects.equals(history.checkOutAt(), expected.checkOutAt())
+			&& Objects.equals(history.timeZoneId(), expected.timeZoneId())
 			&& Objects.equals(history.guestCount(), expected.guestCount())
 			&& Objects.equals(history.totalPrice(), expected.totalPrice())
 			&& Objects.equals(history.currency(), expected.currency())
@@ -392,8 +417,8 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		return fixture.targets().stream()
 			.map(target -> new HoldRemoval(
 				target.accommodationId(),
-				target.checkIn().toLocalDate(),
-				target.checkOut().toLocalDate()
+				target.checkIn(),
+				target.checkOut()
 			))
 			.toList();
 	}
@@ -424,8 +449,9 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 
 	private void assertNoExistingEligibleReservation() {
 		Long eligible = jdbcTemplate.queryForObject(
-			"SELECT COUNT(*) FROM reservation WHERE status = 'PAYMENT_PENDING' AND expires_at < NOW(6)",
-			Long.class
+			"SELECT COUNT(*) FROM reservation WHERE status = 'PAYMENT_PENDING' AND expires_at <= ?",
+			Long.class,
+			Timestamp.from(clock.instant())
 		);
 		if (!Objects.equals(eligible, 0L)) {
 			throw new IllegalStateException("전용 벤치마크 DB에 기존 만료 대상 예약이 있습니다.");
@@ -434,8 +460,9 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 
 	private void assertOnlyFixtureTargetsAreEligible(Fixture fixture) {
 		List<Long> eligibleIds = jdbcTemplate.queryForList(
-			"SELECT id FROM reservation WHERE status = 'PAYMENT_PENDING' AND expires_at < NOW(6) ORDER BY id",
-			Long.class
+			"SELECT id FROM reservation WHERE status = 'PAYMENT_PENDING' AND expires_at <= ? ORDER BY id",
+			Long.class,
+			Timestamp.from(clock.instant())
 		);
 		List<Long> targetIds = fixture.targets().stream().map(ReservationExpectation::id).sorted().toList();
 		if (!eligibleIds.equals(targetIds)) {
@@ -464,8 +491,8 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		return String.join(", ", Collections.nCopies(size, "?"));
 	}
 
-	private LocalDateTime toLocalDateTime(Timestamp timestamp) {
-		return timestamp == null ? null : timestamp.toLocalDateTime();
+	private Instant toInstant(Timestamp timestamp) {
+		return timestamp == null ? null : timestamp.toInstant();
 	}
 
 	private void validateDatasetSize(int datasetSize) {
@@ -490,17 +517,20 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		String reservationCode,
 		Long accommodationId,
 		Long guestId,
-		LocalDateTime checkIn,
-		LocalDateTime checkOut,
+		LocalDate checkIn,
+		LocalDate checkOut,
+		Instant checkInAt,
+		Instant checkOutAt,
+		String timeZoneId,
 		Integer guestCount,
 		Long totalPrice,
 		String currency,
 		String status,
 		String message,
-		LocalDateTime expiresAt,
+		Instant expiresAt,
 		LocalDateTime createdAt,
 		Long createdBy,
-		LocalDateTime historyCreatedAt,
+		Instant historyCreatedAt,
 		Long historyCreatedBy,
 		String changeType,
 		String changeReason,
@@ -515,13 +545,16 @@ public class ReservationHistoryInsertBenchmarkFixtureService {
 		String reservationCode,
 		long accommodationId,
 		long guestId,
-		LocalDateTime checkIn,
-		LocalDateTime checkOut,
+		LocalDate checkIn,
+		LocalDate checkOut,
+		Instant checkInAt,
+		Instant checkOutAt,
+		String timeZoneId,
 		int guestCount,
 		long totalPrice,
 		String currency,
 		String message,
-		LocalDateTime expiresAt,
+		Instant expiresAt,
 		LocalDateTime createdAt,
 		long createdBy
 	) {

--- a/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationService.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationService.java
@@ -6,6 +6,10 @@ import org.redisson.api.RLock;
 import org.springframework.stereotype.Service;
 
 import kr.kro.airbob.cursor.dto.CursorRequest;
+import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
+import kr.kro.airbob.domain.accommodation.exception.AccommodationNotFoundException;
+import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
+import kr.kro.airbob.domain.accommodation.repository.projection.AccommodationBookingProjection;
 import kr.kro.airbob.domain.payment.dto.PaymentRequest;
 import kr.kro.airbob.domain.payment.event.PaymentEvent;
 import kr.kro.airbob.domain.reservation.dto.ReservationRequest;
@@ -17,6 +21,7 @@ import kr.kro.airbob.domain.reservation.exception.InvalidReservationDateExceptio
 import kr.kro.airbob.domain.reservation.exception.ReservationLockException;
 import kr.kro.airbob.domain.reservation.exception.ReservationOutsideBookingWindowException;
 import kr.kro.airbob.domain.reservation.policy.BookingWindow;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,13 +34,18 @@ public class ReservationService {
 	private final ReservationLockManager lockManager;
 
 	private final ReservationTransactionService transactionService;
+	private final AccommodationRepository accommodationRepository;
+	private final BookingWindowProvider bookingWindowProvider;
 
 	public ReservationResponse.Ready createPendingReservation(ReservationRequest.Create request, Long memberId) {
 		if (!request.checkOutDate().isAfter(request.checkInDate())) {
 			throw new InvalidReservationDateException();
 		}
 
-		BookingWindow bookingWindow = BookingWindow.current();
+		AccommodationBookingProjection accommodation = accommodationRepository
+			.findBookingProjectionByIdAndStatus(request.accommodationId(), AccommodationStatus.PUBLISHED)
+			.orElseThrow(AccommodationNotFoundException::new);
+		BookingWindow bookingWindow = bookingWindowProvider.currentFor(accommodation.timeZoneId());
 		if (!bookingWindow.containsStay(request.checkInDate(), request.checkOutDate())) {
 			throw new ReservationOutsideBookingWindowException();
 		}

--- a/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationService.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationService.java
@@ -94,6 +94,10 @@ public class ReservationService {
 		transactionService.revertCancellationInTx(event.reservationUid(), event.reason());
 	}
 
+	public void completeCancellation(ReservationEvent.ReservationCancellationCompleteRequestedEvent event) {
+		transactionService.completeCancellationInTx(event.reservationUid());
+	}
+
 	public ReservationResponse.GuestReservationInfos findMyReservations(Long memberId, CursorRequest.CursorPageRequest cursorRequest, ReservationFilterType filterType) {
 		return transactionService.findMyReservations(memberId, cursorRequest, filterType);
 	}

--- a/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationTransactionService.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationTransactionService.java
@@ -43,7 +43,11 @@ import kr.kro.airbob.domain.reservation.entity.ReservationHistory;
 import kr.kro.airbob.domain.reservation.event.ReservationEvent;
 import kr.kro.airbob.domain.reservation.exception.ReservationAccessDeniedException;
 import kr.kro.airbob.domain.reservation.exception.ReservationConflictException;
+import kr.kro.airbob.domain.reservation.exception.InvalidReservationDateException;
 import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
+import kr.kro.airbob.domain.reservation.exception.ReservationOutsideBookingWindowException;
+import kr.kro.airbob.domain.reservation.policy.BookingWindow;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.domain.reservation.repository.ReservationHistoryRepository;
 import kr.kro.airbob.domain.review.entity.ReviewStatus;
@@ -70,12 +74,20 @@ public class ReservationTransactionService {
 	private final PaymentTransactionRepository paymentTransactionRepository;
 	private final ReservationHistoryRepository historyRepository;
 	private final CouponUsageService couponUsageService;
+	private final BookingWindowProvider bookingWindowProvider;
 
 	@Transactional
 	public Reservation createPendingReservationInTx(ReservationRequest.Create request, Long memberId, String reason) {
 		Member guest = memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE).orElseThrow(MemberNotFoundException::new);
 		Accommodation accommodation = accommodationRepository.findByIdAndStatus(request.accommodationId(), AccommodationStatus.PUBLISHED)
 			.orElseThrow(AccommodationNotFoundException::new);
+		if (!request.checkOutDate().isAfter(request.checkInDate())) {
+			throw new InvalidReservationDateException();
+		}
+		BookingWindow bookingWindow = bookingWindowProvider.currentFor(accommodation.getTimeZoneId());
+		if (!bookingWindow.containsStay(request.checkInDate(), request.checkOutDate())) {
+			throw new ReservationOutsideBookingWindowException();
+		}
 
 		LocalDateTime checkInDateTime = request.checkInDate().atTime(accommodation.getCheckInTime());
 		LocalDateTime checkOutDateTime = request.checkOutDate().atTime(accommodation.getCheckOutTime());

--- a/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationTransactionService.java
+++ b/src/main/java/kr/kro/airbob/domain/reservation/service/ReservationTransactionService.java
@@ -1,6 +1,7 @@
 package kr.kro.airbob.domain.reservation.service;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import kr.kro.airbob.cursor.dto.CursorRequest;
 import kr.kro.airbob.cursor.dto.CursorResponse;
 import kr.kro.airbob.cursor.util.CursorPageInfoCreator;
+import kr.kro.airbob.common.exception.InvalidInputException;
 import kr.kro.airbob.domain.accommodation.dto.AddressResponse;
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
@@ -28,8 +30,10 @@ import kr.kro.airbob.domain.member.repository.MemberRepository;
 import kr.kro.airbob.domain.payment.dto.PaymentRequest;
 import kr.kro.airbob.domain.payment.dto.PaymentResponse;
 import kr.kro.airbob.domain.payment.entity.Payment;
+import kr.kro.airbob.domain.payment.entity.PaymentStatus;
 import kr.kro.airbob.domain.payment.entity.PaymentTransaction;
 import kr.kro.airbob.domain.payment.entity.PaymentTransactionType;
+import kr.kro.airbob.domain.payment.exception.PaymentNotFoundException;
 import kr.kro.airbob.domain.payment.repository.PaymentRepository;
 import kr.kro.airbob.domain.payment.repository.PaymentTransactionRepository;
 import kr.kro.airbob.domain.reservation.dto.ReservationRequest;
@@ -43,6 +47,7 @@ import kr.kro.airbob.domain.reservation.entity.ReservationHistory;
 import kr.kro.airbob.domain.reservation.event.ReservationEvent;
 import kr.kro.airbob.domain.reservation.exception.ReservationAccessDeniedException;
 import kr.kro.airbob.domain.reservation.exception.ReservationConflictException;
+import kr.kro.airbob.domain.reservation.exception.ExpiredReservationConfirmationException;
 import kr.kro.airbob.domain.reservation.exception.InvalidReservationDateException;
 import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
 import kr.kro.airbob.domain.reservation.exception.ReservationOutsideBookingWindowException;
@@ -75,11 +80,13 @@ public class ReservationTransactionService {
 	private final ReservationHistoryRepository historyRepository;
 	private final CouponUsageService couponUsageService;
 	private final BookingWindowProvider bookingWindowProvider;
+	private final Clock clock;
 
 	@Transactional
 	public Reservation createPendingReservationInTx(ReservationRequest.Create request, Long memberId, String reason) {
 		Member guest = memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE).orElseThrow(MemberNotFoundException::new);
-		Accommodation accommodation = accommodationRepository.findByIdAndStatus(request.accommodationId(), AccommodationStatus.PUBLISHED)
+		Accommodation accommodation = accommodationRepository.findByIdAndStatusForUpdate(
+			request.accommodationId(), AccommodationStatus.PUBLISHED)
 			.orElseThrow(AccommodationNotFoundException::new);
 		if (!request.checkOutDate().isAfter(request.checkInDate())) {
 			throw new InvalidReservationDateException();
@@ -89,16 +96,17 @@ public class ReservationTransactionService {
 			throw new ReservationOutsideBookingWindowException();
 		}
 
-		LocalDateTime checkInDateTime = request.checkInDate().atTime(accommodation.getCheckInTime());
-		LocalDateTime checkOutDateTime = request.checkOutDate().atTime(accommodation.getCheckOutTime());
+		Instant now = clock.instant();
 
-		if (reservationRepository.existsConflictingReservation(request.accommodationId(), checkInDateTime, checkOutDateTime)) {
+		if (reservationRepository.existsConflictingReservation(
+			request.accommodationId(), request.checkInDate(), request.checkOutDate(), now)) {
 			throw new ReservationConflictException();
 		}
 
 		String reservationCode = createReservationCode();
 
-		Reservation pendingReservation = Reservation.createPendingReservation(accommodation, guest, request, reservationCode);
+		Reservation pendingReservation = Reservation.createPendingReservation(
+			accommodation, guest, request, reservationCode, now);
 		reservationRepository.save(pendingReservation);
 
 		// 쿠폰 적용 (선택) — 같은 트랜잭션에서 사용 처리(중복 사용 방지) 후 결제 금액 차감
@@ -126,7 +134,7 @@ public class ReservationTransactionService {
 
 	@Transactional
 	public void cancelReservationInTx(String reservationUid, PaymentRequest.Cancel request, Long memberId) {
-		Reservation reservation = reservationRepository.findByReservationUid(UUID.fromString(reservationUid))
+		Reservation reservation = reservationRepository.findByReservationUidWithLock(UUID.fromString(reservationUid))
 			.orElseThrow(ReservationNotFoundException::new);
 
 		// todo: 추가 쿼리 발생 -> member까지 같이 조회 필요
@@ -134,33 +142,47 @@ public class ReservationTransactionService {
 			throw new ReservationAccessDeniedException();
 		}
 
-		reservation.cancel();
+		if (reservation.getStatus() == ReservationStatus.CANCELLATION_PENDING) {
+			log.info("[예약 취소 요청-SKIP] 이미 취소 처리 중인 예약입니다. UID: {}", reservationUid);
+			return;
+		}
 
-		// 예약에 사용된 쿠폰 복원 (취소 실패 보상 시 reuse 로 되돌림)
-		couponUsageService.restore(reservation.getId());
+		validateFullCancellationAmount(reservation.getReservationUid(), request.cancelAmount());
+		reservation.requestCancellation();
 
-		historyRepository.save(ReservationHistory.of(reservation, ChangeType.CANCEL, request.cancelReason()));
+		historyRepository.save(ReservationHistory.of(
+			reservation, ChangeType.STATUS_CHANGE, request.cancelReason()));
 
 		outboxEventPublisher.save(
-			EventType.RESERVATION_CANCELLED,
-			new ReservationEvent.ReservationCancelledEvent(
+			EventType.RESERVATION_CANCELLATION_REQUESTED,
+			new ReservationEvent.ReservationCancellationRequestedEvent(
 				reservationUid,
 				request.cancelReason(),
 				request.cancelAmount()
 			)
 		);
-		log.info("[예약 취소 완료]: Reservation UID {} 상태 변경 및 이벤트 발행 완료", reservationUid);
+		log.info("[예약 취소 요청]: Reservation UID {} 상태 CANCELLATION_PENDING 변경 및 이벤트 발행 완료", reservationUid);
 	}
 
 	@Transactional
 	public void confirmReservationInTx(String reservationUid) {
 
-		Reservation reservation = reservationRepository.findByReservationUid(UUID.fromString(reservationUid))
+		Reservation reservation = reservationRepository.findByReservationUidWithLock(UUID.fromString(reservationUid))
 			.orElseThrow(ReservationNotFoundException::new);
 
-		if (reservation.getStatus() == ReservationStatus.CONFIRMED) {
-			log.info("[결제 성공 확인] 이미 확정 처리된 예약: {}", reservation.getId());
+		if (reservation.getStatus().hasConfirmedPayment()) {
+			log.info("[결제 성공 확인-SKIP] 이미 결제가 확정된 예약: {}, status: {}",
+				reservation.getId(), reservation.getStatus());
 			return;
+		}
+		if (reservation.getStatus() != ReservationStatus.PAYMENT_PROCESSING) {
+			throw new ExpiredReservationConfirmationException();
+		}
+		Payment payment = paymentRepository.findByReservationReservationUidWithLock(
+			reservation.getReservationUid())
+			.orElseThrow(PaymentNotFoundException::new);
+		if (reservation.isExpiredAt(payment.getApprovedAt())) {
+			throw new ExpiredReservationConfirmationException();
 		}
 
 		reservation.confirm();
@@ -171,8 +193,8 @@ public class ReservationTransactionService {
 			EventType.RESERVATION_CONFIRMED,
 			new ReservationEvent.ReservationConfirmedEvent(
 				reservation.getAccommodation().getId(),
-				reservation.getCheckIn().toLocalDate(),
-				reservation.getCheckOut().toLocalDate()
+				reservation.getCheckInDate(),
+				reservation.getCheckOutDate()
 			)
 		);
 
@@ -189,7 +211,7 @@ public class ReservationTransactionService {
 
 	@Transactional
 	public void expireReservationInTx(String reservationUid, String reason) {
-		Reservation reservation = reservationRepository.findByReservationUid(UUID.fromString(reservationUid))
+		Reservation reservation = reservationRepository.findByReservationUidWithLock(UUID.fromString(reservationUid))
 			.orElseThrow(ReservationNotFoundException::new);
 
 		if (reservation.getStatus() == ReservationStatus.EXPIRED) {
@@ -205,8 +227,8 @@ public class ReservationTransactionService {
 			EventType.RESERVATION_EXPIRED,
 			new ReservationEvent.ReservationExpiredEvent(
 				reservation.getAccommodation().getId(),
-				reservation.getCheckIn().toLocalDate(),
-				reservation.getCheckOut().toLocalDate()
+				reservation.getCheckInDate(),
+				reservation.getCheckOutDate()
 			)
 		);
 
@@ -214,25 +236,140 @@ public class ReservationTransactionService {
 	}
 
 	@Transactional
-	public void revertCancellationInTx(String reservationUid, String reason) {
-		Reservation reservation = reservationRepository.findByReservationUid(UUID.fromString(reservationUid))
+	public boolean preparePaymentCompensationInTx(String reservationUid, String reason) {
+		Reservation reservation = reservationRepository.findByReservationUidWithLock(
+			UUID.fromString(reservationUid))
 			.orElseThrow(ReservationNotFoundException::new);
 
-		// 이미 CANCELLATION_FAILED 상태라면 중복 처리 방지
-		if (reservation.getStatus() == ReservationStatus.CANCELLATION_FAILED) {
-			log.warn("[보상-SKIP] 이미 취소 실패 처리된 예약입니다. UID: {}", reservationUid);
-			return;
+		if (reservation.getStatus() == ReservationStatus.EXPIRED) {
+			log.info("[결제 보상 준비-SKIP] 이미 만료된 예약입니다. UID: {}", reservationUid);
+			return true;
+		}
+		if (reservation.getStatus() != ReservationStatus.PAYMENT_PENDING
+			&& reservation.getStatus() != ReservationStatus.PAYMENT_PROCESSING) {
+			log.warn("[결제 보상 차단] 이미 결제가 확정된 예약은 취소하지 않습니다. UID: {}, status: {}",
+				reservationUid, reservation.getStatus());
+			return false;
 		}
 
+		reservation.expire();
+		historyRepository.save(ReservationHistory.ofSystem(
+			reservation, ChangeType.STATUS_CHANGE, reason, "DLQ"));
+		outboxEventPublisher.save(
+			EventType.RESERVATION_EXPIRED,
+			new ReservationEvent.ReservationExpiredEvent(
+				reservation.getAccommodation().getId(),
+				reservation.getCheckInDate(),
+				reservation.getCheckOutDate()
+			)
+		);
+		log.warn("[결제 보상 준비] 예약을 EXPIRED로 고정했습니다. UID: {}", reservationUid);
+		return true;
+	}
+
+	@Transactional
+	public void completeCancellationInTx(String reservationUid) {
+		UUID reservationUuid = UUID.fromString(reservationUid);
+		Reservation reservation = reservationRepository.findByReservationUidWithLock(reservationUuid)
+			.orElseThrow(ReservationNotFoundException::new);
+
+		Payment payment = paymentRepository.findByReservationReservationUidWithLock(reservationUuid)
+			.orElseThrow(PaymentNotFoundException::new);
+		validateFullyCancelledPayment(payment);
+
+		if (reservation.getStatus() == ReservationStatus.CANCELLED) {
+			publishReservationChanged(reservation);
+			log.info("[예약 취소 성공-SKIP] 이미 취소 완료된 예약입니다. ES 갱신 이벤트를 재발행합니다. UID: {}",
+				reservationUid);
+			return;
+		}
+		reservation.completeCancellation();
+
+		couponUsageService.restore(reservation.getId());
+		historyRepository.save(ReservationHistory.ofSystem(
+			reservation, ChangeType.CANCEL, "PG 결제 취소 성공", "KAFKA"));
+		publishReservationChanged(reservation);
+		log.info("[예약 취소 성공] 예약 상태 CANCELLED 확정 완료. UID: {}", reservationUid);
+	}
+
+	private void validateFullyCancelledPayment(Payment payment) {
+		if (payment.getStatus() != PaymentStatus.CANCELED
+			|| !Long.valueOf(0L).equals(payment.getBalanceAmount())) {
+			throw new IllegalStateException("전액 환불이 확인되지 않은 예약은 취소 완료할 수 없습니다.");
+		}
+	}
+
+	private void publishReservationChanged(Reservation reservation) {
+		outboxEventPublisher.save(
+			EventType.RESERVATION_CHANGED,
+			new AccommodationIndexingEvents.ReservationChangedEvent(
+				reservation.getAccommodation().getAccommodationUid().toString()
+			)
+		);
+	}
+
+	@Transactional
+	public void revertCancellationInTx(String reservationUid, String reason) {
+		UUID reservationUuid = UUID.fromString(reservationUid);
+		Reservation reservation = reservationRepository.findByReservationUidWithLock(reservationUuid)
+			.orElseThrow(ReservationNotFoundException::new);
+
+		if (reservation.getStatus() == ReservationStatus.CANCELLATION_FAILED) {
+			log.info("[취소 실패-SKIP] 이미 취소 실패가 확정된 예약입니다. UID: {}", reservationUid);
+			return;
+		}
+		if (reservation.getStatus() == ReservationStatus.CANCELLED) {
+			recoverLegacyCancellationFailure(reservation, reservationUuid, reason);
+			return;
+		}
 		reservation.failCancellation();
 
-		// 취소가 되돌려졌으므로(예약 유효), 복원했던 쿠폰을 다시 사용 처리
+		recordCancellationFailure(reservation, reason);
+	}
+
+	private void recoverLegacyCancellationFailure(
+		Reservation reservation,
+		UUID reservationUid,
+		String reason
+	) {
+		Payment payment = paymentRepository.findByReservationReservationUidWithLock(reservationUid)
+			.orElseThrow(PaymentNotFoundException::new);
+		if (payment.getStatus() == PaymentStatus.CANCELED
+			&& Long.valueOf(0L).equals(payment.getBalanceAmount())) {
+			log.info("[레거시 취소 실패-SKIP] 전액 환불이 이미 확정된 예약입니다. UID: {}", reservationUid);
+			return;
+		}
+		boolean paymentStillActive = payment.getBalanceAmount() != null
+			&& payment.getBalanceAmount() > 0L
+			&& (payment.getStatus() == PaymentStatus.DONE
+				|| payment.getStatus() == PaymentStatus.PARTIAL_CANCELED);
+		if (!paymentStillActive) {
+			throw new IllegalStateException("레거시 예약 취소 실패의 결제 상태가 일관되지 않습니다.");
+		}
+
+		reservation.recoverLegacyCancellationFailure();
 		couponUsageService.reuse(reservation.getId());
+		recordCancellationFailure(reservation, reason);
+	}
+
+	private void recordCancellationFailure(Reservation reservation, String reason) {
 
 		historyRepository.save(ReservationHistory.ofSystem(reservation, ChangeType.STATUS_CHANGE,
-			"결제 취소 실패 보상 트랜잭션: " + reason, "KAFKA"));
+			"PG 결제 취소 실패: " + reason, "KAFKA"));
 
-		log.info("[보상-SUCCESS] 예약 취소 실패 보상 처리 완료. 예약 상태 CANCELLATION_FAILED로 변경. UID: {}", reservationUid);
+		log.info("[예약 취소 실패] 예약 상태 CANCELLATION_FAILED로 변경. UID: {}",
+			reservation.getReservationUid());
+	}
+
+	private void validateFullCancellationAmount(UUID reservationUid, Long cancelAmount) {
+		if (cancelAmount == null) {
+			return;
+		}
+		Payment payment = paymentRepository.findByReservationReservationUid(reservationUid)
+			.orElseThrow(PaymentNotFoundException::new);
+		if (!cancelAmount.equals(payment.getBalanceAmount())) {
+			throw new InvalidInputException("예약 취소는 현재 결제 잔액 전액만 가능합니다.");
+		}
 	}
 
 	@Transactional(readOnly = true)
@@ -244,6 +381,7 @@ public class ReservationTransactionService {
 			cursorRequest.lastId(),
 			cursorRequest.lastCreatedAt(),
 			filterType,
+			clock.instant(),
 			PageRequest.of(0, cursorRequest.size())
 		);
 
@@ -285,6 +423,7 @@ public class ReservationTransactionService {
 			cursorRequest.lastId(),
 			cursorRequest.lastCreatedAt(),
 			filterType,
+			clock.instant(),
 			PageRequest.of(0, cursorRequest.size())
 		);
 
@@ -324,7 +463,8 @@ public class ReservationTransactionService {
 
 		if (payment != null) { // 결제 완료된 예약
 			paymentInfo = PaymentResponse.PaymentInfo.from(payment, findCancelTransactions(payment));
-		} else if (reservation.getStatus() == ReservationStatus.PAYMENT_PENDING) { // 결제 대기중인 예약(가상계좌)
+		} else if (reservation.getStatus() == ReservationStatus.PAYMENT_PENDING
+			|| reservation.getStatus() == ReservationStatus.PAYMENT_PROCESSING) { // 결제 대기중인 예약(가상계좌)
 			paymentInfo = paymentTransactionRepository
 				.findByOrderIdOrderByCreatedAtDesc(reservationUidStr)
 				.stream()
@@ -343,8 +483,8 @@ public class ReservationTransactionService {
 
 	private boolean isCanWriteReview(Long memberId, Reservation reservation) {
 		boolean canWriteReview = false;
-		if (reservation.getStatus() == ReservationStatus.CONFIRMED &&
-			reservation.getCheckOut().isBefore(LocalDateTime.now())) {
+		if (reservation.getStatus().isReviewableReservation() &&
+			!reservation.getCheckOutAt().isAfter(clock.instant())) {
 
 			// 아직 작성한 리뷰가 없는지 확인
 			canWriteReview = !reviewRepository.existsByAccommodationIdAndAuthorIdAndStatus(

--- a/src/main/java/kr/kro/airbob/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/review/dto/ReviewResponse.java
@@ -1,7 +1,9 @@
 package kr.kro.airbob.domain.review.dto;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +41,7 @@ public class ReviewResponse {
 		long id,
 		int rating,
 		String content,
-		LocalDateTime reviewedAt,
+		Instant reviewedAt,
 		MemberResponse.MemberInfo reviewer,
 		List<ImageResponse.ImageInfo> images
 	) {
@@ -55,7 +57,7 @@ public class ReviewResponse {
 				id,
 				rating,
 				content,
-				reviewedAt,
+				reviewedAt == null ? null : reviewedAt.toInstant(ZoneOffset.UTC),
 				reviewer,
 				new ArrayList<>()
 			);

--- a/src/main/java/kr/kro/airbob/domain/review/service/ReviewService.java
+++ b/src/main/java/kr/kro/airbob/domain/review/service/ReviewService.java
@@ -3,7 +3,9 @@ package kr.kro.airbob.domain.review.service;
 import static kr.kro.airbob.search.event.AccommodationIndexingEvents.*;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +74,7 @@ public class ReviewService {
 	private final CursorPageInfoCreator cursorPageInfoCreator;
 	private final OutboxEventPublisher outboxEventPublisher;
 	private final S3ImageUploader s3ImageUploader;
+	private final Clock clock;
 
 	@Transactional
 	public ReviewResponse.Create createReview(Long accommodationId, ReviewRequest.Create request, Long memberId) {
@@ -197,7 +200,7 @@ public class ReviewService {
 			reviewSlice.getContent(),
 			reviewSlice.hasNext(),
 			ReviewResponse.ReviewInfo::id,
-			ReviewResponse.ReviewInfo::reviewedAt,
+			reviewInfo -> LocalDateTime.ofInstant(reviewInfo.reviewedAt(), ZoneOffset.UTC),
 			ReviewResponse.ReviewInfo::rating
 		);
 
@@ -286,7 +289,8 @@ public class ReviewService {
 
 	private void validateReviewCreation(Long accommodationId, Long memberId) {
 		// 예약한 사용자인지와 체크아웃까지 완료했는지 확인
-		if (!reservationRepository.existsPastCompletedReservationByGuest(accommodationId, memberId)) {
+		if (!reservationRepository.existsPastCompletedReservationByGuest(
+			accommodationId, memberId, clock.instant())) {
 			throw new ReviewCreationForbiddenException();
 		}
 		// 이미 리뷰를 작성했는지 확인

--- a/src/main/java/kr/kro/airbob/domain/settlement/dto/SettlementResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/settlement/dto/SettlementResponse.java
@@ -1,8 +1,8 @@
 package kr.kro.airbob.domain.settlement.dto;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import kr.kro.airbob.domain.settlement.entity.Settlement;
@@ -20,7 +20,7 @@ public class SettlementResponse {
 		long commissionAmount,
 		long payoutAmount,
 		SettlementStatus status,
-		LocalDateTime settledAt
+		Instant settledAt
 	) {
 		public static HostSettlement from(Settlement s) {
 			return new HostSettlement(
@@ -50,7 +50,7 @@ public class SettlementResponse {
 		long commissionAmount,
 		long payoutAmount,
 		SettlementStatus status,
-		LocalDateTime settledAt,
+		Instant settledAt,
 		List<LineItem> items
 	) {
 		public static SettlementDetail of(Settlement s, List<LineItem> items) {
@@ -103,7 +103,7 @@ public class SettlementResponse {
 		long commissionAmount,
 		long payoutAmount,
 		SettlementStatus status,
-		LocalDateTime settledAt
+		Instant settledAt
 	) {
 		public static AdminSettlement from(Settlement s) {
 			return new AdminSettlement(

--- a/src/main/java/kr/kro/airbob/domain/settlement/entity/Settlement.java
+++ b/src/main/java/kr/kro/airbob/domain/settlement/entity/Settlement.java
@@ -2,8 +2,8 @@ package kr.kro.airbob.domain.settlement.entity;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -58,7 +58,7 @@ public class Settlement extends BaseEntity {
 	@Column(nullable = false)
 	private SettlementStatus status;
 
-	private LocalDateTime settledAt;
+	private Instant settledAt;
 
 	// net/rate로 commission·payout을 계산해 PENDING 정산을 생성
 	public static Settlement createPending(Long hostId, LocalDate settlementMonth,
@@ -90,9 +90,9 @@ public class Settlement extends BaseEntity {
 		this.payoutAmount = net - commission;
 	}
 
-	public void markPaid() {
+	public void markPaid(Instant settledAt) {
 		this.status = SettlementStatus.PAID;
-		this.settledAt = LocalDateTime.now();
+		this.settledAt = settledAt;
 	}
 
 	public boolean isPaid() {

--- a/src/main/java/kr/kro/airbob/domain/settlement/scheduler/SettlementScheduler.java
+++ b/src/main/java/kr/kro/airbob/domain/settlement/scheduler/SettlementScheduler.java
@@ -1,5 +1,6 @@
 package kr.kro.airbob.domain.settlement.scheduler;
 
+import java.time.Clock;
 import java.time.YearMonth;
 
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,10 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 public class SettlementScheduler {
 
 	private final SettlementService settlementService;
+	private final Clock clock;
 
-	@Scheduled(cron = "0 0 4 1 * *")
+	@Scheduled(cron = "0 0 4 1 * *", zone = "UTC")
 	public void generatePreviousMonthSettlement() {
-		YearMonth previousMonth = YearMonth.now().minusMonths(1);
+		YearMonth previousMonth = YearMonth.now(clock).minusMonths(1);
 		log.info("월 정산 배치 시작: month={}", previousMonth);
 		settlementService.generateMonth(previousMonth);
 		log.info("월 정산 배치 완료: month={}", previousMonth);

--- a/src/main/java/kr/kro/airbob/domain/settlement/service/SettlementService.java
+++ b/src/main/java/kr/kro/airbob/domain/settlement/service/SettlementService.java
@@ -1,6 +1,7 @@
 package kr.kro.airbob.domain.settlement.service;
 
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
@@ -44,6 +45,7 @@ public class SettlementService {
 	private final SettlementHistoryRepository settlementHistoryRepository;
 	private final RedissonClient redissonClient;
 	private final PlatformTransactionManager transactionManager;
+	private final Clock clock;
 
 	@Value("${settlement.commission-rate:0.03}")
 	private BigDecimal commissionRate;
@@ -100,7 +102,7 @@ public class SettlementService {
 		if (!isMonthClosed(settlement.getSettlementMonth())) {
 			throw new SettlementMonthNotClosedException();
 		}
-		settlement.markPaid();
+		settlement.markPaid(clock.instant());
 		settlementHistoryRepository.save(
 			SettlementHistory.of(settlement, ChangeType.STATUS_CHANGE, "정산 지급 완료"));
 	}
@@ -118,8 +120,8 @@ public class SettlementService {
 	}
 
 	// settlement_month(월초)가 속한 달이 이미 끝났는지(= 현재 월보다 이전)
-	private static boolean isMonthClosed(LocalDate settlementMonth) {
-		return YearMonth.from(settlementMonth).isBefore(YearMonth.now());
+	private boolean isMonthClosed(LocalDate settlementMonth) {
+		return YearMonth.from(settlementMonth).isBefore(YearMonth.now(clock));
 	}
 
 	// 정산 상세(숙소별 내역). 호스트 본인 정산만 조회 가능.

--- a/src/main/java/kr/kro/airbob/domain/statistics/scheduler/StatisticsScheduler.java
+++ b/src/main/java/kr/kro/airbob/domain/statistics/scheduler/StatisticsScheduler.java
@@ -1,5 +1,6 @@
 package kr.kro.airbob.domain.statistics.scheduler;
 
+import java.time.Clock;
 import java.time.LocalDate;
 
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,10 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 public class StatisticsScheduler {
 
 	private final RevenueStatsService revenueStatsService;
+	private final Clock clock;
 
-	@Scheduled(cron = "0 0 4 * * *")
+	@Scheduled(cron = "0 0 4 * * *", zone = "UTC")
 	public void aggregateDailyRevenue() {
-		LocalDate target = LocalDate.now().minusDays(1);
+		LocalDate target = LocalDate.now(clock).minusDays(1);
 		log.info("일일 매출 사전집계 시작: stat_date={}", target);
 		revenueStatsService.recompute(target);
 		log.info("일일 매출 사전집계 완료: stat_date={}", target);

--- a/src/main/java/kr/kro/airbob/domain/wishlist/dto/WishlistAccommodationResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/wishlist/dto/WishlistAccommodationResponse.java
@@ -1,7 +1,9 @@
 package kr.kro.airbob.domain.wishlist.dto;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import com.querydsl.core.annotations.QueryProjection;
@@ -37,7 +39,7 @@ public class WishlistAccommodationResponse {
 	public record WishlistAccommodationInfo(
 		long wishlistAccommodationId,
 		String memo,
-		LocalDateTime createdAt,
+		Instant createdAt,
 		AccommodationResponse.AccommodationBasicInfo accommodation,
 		AddressResponse.AddressSummaryInfo addressSummary,
 		ReviewResponse.ReviewSummary reviewSummary,
@@ -55,7 +57,7 @@ public class WishlistAccommodationResponse {
 			this(
 				wishlistAccommodationId,
 				memo,
-				createdAt,
+				createdAt == null ? null : createdAt.toInstant(ZoneOffset.UTC),
 				AccommodationResponse.AccommodationBasicInfo.from(accommodation),
 				AddressResponse.AddressSummaryInfo.from(accommodation.getAddress()),
 				ReviewResponse.ReviewSummary.builder()

--- a/src/main/java/kr/kro/airbob/domain/wishlist/dto/WishlistResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/wishlist/dto/WishlistResponse.java
@@ -1,6 +1,6 @@
 package kr.kro.airbob.domain.wishlist.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import kr.kro.airbob.cursor.dto.CursorResponse;
@@ -33,7 +33,7 @@ public class WishlistResponse {
 	public record WishlistInfo(
 		long id,
 		String name,
-		LocalDateTime createdAt,
+		Instant createdAt,
 		Long wishlistItemCount,
 		String thumbnailImageUrl,
 		Boolean isContained,

--- a/src/main/java/kr/kro/airbob/domain/wishlist/repository/querydsl/WishlistRepositoryImpl.java
+++ b/src/main/java/kr/kro/airbob/domain/wishlist/repository/querydsl/WishlistRepositoryImpl.java
@@ -3,6 +3,7 @@ package kr.kro.airbob.domain.wishlist.repository.querydsl;
 import static kr.kro.airbob.domain.wishlist.entity.QWishlist.*;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -26,7 +27,7 @@ public class WishlistRepositoryImpl implements WishlistRepositoryCustom {
 		queryFactory.update(wishlist)
 			.set(wishlist.accommodationCount, wishlist.accommodationCount.add(1))
 			.set(wishlist.representativeAccommodationId, accommodationId)
-			.set(wishlist.updatedAt, LocalDateTime.now())
+			.set(wishlist.updatedAt, LocalDateTime.now(ZoneOffset.UTC))
 			.where(wishlist.id.eq(wishlistId))
 			.execute();
 	}
@@ -35,7 +36,7 @@ public class WishlistRepositoryImpl implements WishlistRepositoryCustom {
 	public void decrementCount(Long wishlistId) {
 		queryFactory.update(wishlist)
 			.set(wishlist.accommodationCount, wishlist.accommodationCount.subtract(1))
-			.set(wishlist.updatedAt, LocalDateTime.now())
+			.set(wishlist.updatedAt, LocalDateTime.now(ZoneOffset.UTC))
 			.where(wishlist.id.eq(wishlistId))
 			.execute();
 	}
@@ -43,7 +44,7 @@ public class WishlistRepositoryImpl implements WishlistRepositoryCustom {
 	@Override
 	public void updateRepresentative(Long wishlistId, Long accommodationId) {
 		JPAUpdateClause clause = queryFactory.update(wishlist)
-			.set(wishlist.updatedAt, LocalDateTime.now())
+			.set(wishlist.updatedAt, LocalDateTime.now(ZoneOffset.UTC))
 			.where(wishlist.id.eq(wishlistId));
 
 		if (accommodationId == null) {

--- a/src/main/java/kr/kro/airbob/domain/wishlist/service/WishlistBenchmarkService.java
+++ b/src/main/java/kr/kro/airbob/domain/wishlist/service/WishlistBenchmarkService.java
@@ -1,6 +1,8 @@
 package kr.kro.airbob.domain.wishlist.service;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -110,11 +112,15 @@ public class WishlistBenchmarkService {
 		return new WishlistResponse.WishlistInfo(
 			wishlistId,
 			wishlist.getName(),
-			wishlist.getCreatedAt(),
+			toUtcInstant(wishlist.getCreatedAt()),
 			wishlistItemCounts.getOrDefault(wishlistId, 0L),
 			thumbnailUrls.get(wishlistId),
 			includeAccommodationStatus ? wishlistAccommodationId != null : null,
 			includeAccommodationStatus ? wishlistAccommodationId : null
 		);
+	}
+
+	private static Instant toUtcInstant(LocalDateTime dateTime) {
+		return dateTime == null ? null : dateTime.toInstant(ZoneOffset.UTC);
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/wishlist/service/WishlistDeleteBenchmarkFixtureService.java
+++ b/src/main/java/kr/kro/airbob/domain/wishlist/service/WishlistDeleteBenchmarkFixtureService.java
@@ -2,7 +2,6 @@ package kr.kro.airbob.domain.wishlist.service;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
-import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -245,7 +244,7 @@ public class WishlistDeleteBenchmarkFixtureService {
 			WishlistStatus.valueOf(resultSet.getString("status")),
 			resultSet.getInt("accommodation_count"),
 			resultSet.getObject("representative_accommodation_id", Long.class),
-			toLocalDateTime(resultSet.getTimestamp("updated_at")),
+			resultSet.getObject("updated_at", LocalDateTime.class),
 			resultSet.getObject("updated_by", Long.class)
 		), wishlistId).stream().findFirst().orElse(null);
 	}
@@ -280,10 +279,6 @@ public class WishlistDeleteBenchmarkFixtureService {
 
 	private String placeholders(int size) {
 		return String.join(", ", Collections.nCopies(size, "?"));
-	}
-
-	private LocalDateTime toLocalDateTime(Timestamp timestamp) {
-		return timestamp == null ? null : timestamp.toLocalDateTime();
 	}
 
 	private void validateDatasetSize(int datasetSize) {

--- a/src/main/java/kr/kro/airbob/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/kr/kro/airbob/domain/wishlist/service/WishlistService.java
@@ -1,6 +1,8 @@
 package kr.kro.airbob.domain.wishlist.service;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -151,7 +153,7 @@ public class WishlistService {
 					return new WishlistResponse.WishlistInfo(
 						currentWishlistId,
 						wishlist.getName(),
-						wishlist.getCreatedAt(),
+						toUtcInstant(wishlist.getCreatedAt()),
 						wishlist.getAccommodationCount().longValue(),
 						thumbnailUrls.get(wishlist.getRepresentativeAccommodationId()),
 						isContained,
@@ -164,7 +166,7 @@ public class WishlistService {
 					new WishlistResponse.WishlistInfo(
 						wishlist.getId(),
 						wishlist.getName(),
-						wishlist.getCreatedAt(),
+						toUtcInstant(wishlist.getCreatedAt()),
 						wishlist.getAccommodationCount().longValue(),
 						thumbnailUrls.get(wishlist.getRepresentativeAccommodationId()),
 						null,
@@ -260,7 +262,7 @@ public class WishlistService {
 				infos,
 				slice.hasNext(),
 				WishlistAccommodationResponse.WishlistAccommodationInfo::wishlistAccommodationId,
-				WishlistAccommodationResponse.WishlistAccommodationInfo::createdAt
+				info -> toUtcDateTime(info.createdAt())
 			);
 			return new WishlistAccommodationResponse.WishlistAccommodationInfos(List.of(), pageInfo);
 		}
@@ -269,7 +271,7 @@ public class WishlistService {
 			infos,
 			slice.hasNext(),
 			WishlistAccommodationResponse.WishlistAccommodationInfo::wishlistAccommodationId,
-			WishlistAccommodationResponse.WishlistAccommodationInfo::createdAt
+			info -> toUtcDateTime(info.createdAt())
 		);
 
 		return new WishlistAccommodationResponse.WishlistAccommodationInfos(infos, pageInfo);
@@ -302,5 +304,13 @@ public class WishlistService {
 	private WishlistAccommodation findWishlistAccommodationForMember(Long wishlistAccommodationId, Long memberId) {
 		return wishlistAccommodationRepository.findByIdAndWishlistMemberId(wishlistAccommodationId, memberId)
 			.orElseThrow(WishlistAccommodationAccessDeniedException::new);
+	}
+
+	private static Instant toUtcInstant(LocalDateTime dateTime) {
+		return dateTime == null ? null : dateTime.toInstant(ZoneOffset.UTC);
+	}
+
+	private static LocalDateTime toUtcDateTime(Instant instant) {
+		return instant == null ? null : LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
 	}
 }

--- a/src/main/java/kr/kro/airbob/geo/TimeZoneResolver.java
+++ b/src/main/java/kr/kro/airbob/geo/TimeZoneResolver.java
@@ -1,0 +1,9 @@
+package kr.kro.airbob.geo;
+
+import java.time.ZoneId;
+import java.util.Optional;
+
+public interface TimeZoneResolver {
+
+	Optional<ZoneId> resolve(double latitude, double longitude);
+}

--- a/src/main/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolver.java
+++ b/src/main/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolver.java
@@ -1,0 +1,24 @@
+package kr.kro.airbob.geo.impl;
+
+import java.time.ZoneId;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import kr.kro.airbob.geo.TimeZoneResolver;
+import net.iakovlev.timeshape.TimeZoneEngine;
+
+@Component
+public final class TimeShapeTimeZoneResolver implements TimeZoneResolver {
+
+	private final TimeZoneEngine engine = TimeZoneEngine.initialize();
+
+	@Override
+	public Optional<ZoneId> resolve(double latitude, double longitude) {
+		if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+			return Optional.empty();
+		}
+
+		return engine.query(latitude, longitude);
+	}
+}

--- a/src/main/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolver.java
+++ b/src/main/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolver.java
@@ -1,6 +1,7 @@
 package kr.kro.airbob.geo.impl;
 
 import java.time.ZoneId;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -11,7 +12,15 @@ import net.iakovlev.timeshape.TimeZoneEngine;
 @Component
 public final class TimeShapeTimeZoneResolver implements TimeZoneResolver {
 
-	private final TimeZoneEngine engine = TimeZoneEngine.initialize();
+	private final TimeZoneEngine engine;
+
+	public TimeShapeTimeZoneResolver() {
+		this(EngineHolder.INSTANCE);
+	}
+
+	TimeShapeTimeZoneResolver(TimeZoneEngine engine) {
+		this.engine = Objects.requireNonNull(engine);
+	}
 
 	@Override
 	public Optional<ZoneId> resolve(double latitude, double longitude) {
@@ -21,5 +30,10 @@ public final class TimeShapeTimeZoneResolver implements TimeZoneResolver {
 		}
 
 		return engine.query(latitude, longitude);
+	}
+
+	private static final class EngineHolder {
+
+		private static final TimeZoneEngine INSTANCE = TimeZoneEngine.initialize();
 	}
 }

--- a/src/main/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolver.java
+++ b/src/main/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolver.java
@@ -15,7 +15,8 @@ public final class TimeShapeTimeZoneResolver implements TimeZoneResolver {
 
 	@Override
 	public Optional<ZoneId> resolve(double latitude, double longitude) {
-		if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+		if (!Double.isFinite(latitude) || !Double.isFinite(longitude)
+			|| latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
 			return Optional.empty();
 		}
 

--- a/src/main/java/kr/kro/airbob/kafka/consumer/AccommodationIndexingConsumer.java
+++ b/src/main/java/kr/kro/airbob/kafka/consumer/AccommodationIndexingConsumer.java
@@ -51,7 +51,7 @@ public class AccommodationIndexingConsumer {
 				}
 				case RESERVATION_CHANGED -> {
 					EventEnvelope<ReservationChangedEvent> envelope = debeziumEventParser.parse(message, ReservationChangedEvent.class);
-					indexingService.updateReservedDatesInIndex(envelope.payload());
+					indexingService.updateReservationRangesInIndex(envelope.payload());
 				}
 				default -> log.warn("알 수 없는 색인 이벤트 타입입니다: {}", eventType);
 			}

--- a/src/main/java/kr/kro/airbob/kafka/consumer/DlqConsumer.java
+++ b/src/main/java/kr/kro/airbob/kafka/consumer/DlqConsumer.java
@@ -1,15 +1,33 @@
 package kr.kro.airbob.kafka.consumer;
 
+import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.DltStrategy;
+import org.springframework.kafka.retrytopic.SameIntervalTopicReuseStrategy;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Component;
 
+import kr.kro.airbob.common.exception.InvalidInputException;
+import kr.kro.airbob.domain.payment.dto.PaymentRequest;
 import kr.kro.airbob.domain.payment.event.PaymentEvent;
+import kr.kro.airbob.domain.payment.service.PaymentApprovalService;
+import kr.kro.airbob.domain.payment.service.PaymentCancellationProcessor;
 import kr.kro.airbob.domain.payment.service.PaymentCompensationService;
+import kr.kro.airbob.domain.payment.service.PaymentConfirmationProcessor;
+import kr.kro.airbob.domain.reservation.event.ReservationEvent;
+import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
+import kr.kro.airbob.domain.reservation.service.ReservationService;
 import kr.kro.airbob.outbox.DebeziumEventParser;
+import kr.kro.airbob.outbox.EventPayload;
 import kr.kro.airbob.outbox.EventType;
+import kr.kro.airbob.outbox.OutboxEventPublisher;
 import kr.kro.airbob.outbox.SlackNotificationService;
+import kr.kro.airbob.outbox.exception.DebeziumEventParsingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class DlqConsumer {
-
 	private static final String ALERT_MESSAGE = """
 		🚨 *[DLQ-FATAL]* 🚨
 		DLQ 메시지 자동 보상 처리 중 최종 실패! *수동 개입*이 필요합니다.
@@ -31,39 +48,166 @@ public class DlqConsumer {
 	private final DebeziumEventParser debeziumEventParser;
 	private final SlackNotificationService slackNotificationService;
 	private final PaymentCompensationService paymentCompensationService;
+	private final PaymentApprovalService paymentApprovalService;
+	private final PaymentCancellationProcessor paymentCancellationProcessor;
+	private final PaymentConfirmationProcessor paymentConfirmationProcessor;
+	private final ReservationService reservationService;
+	private final OutboxEventPublisher outboxEventPublisher;
+	private final PaymentGatewayWorker paymentGatewayWorker;
 
-	@KafkaListener(topics = "${spring.kafka.consumer.properties.spring.kafka.dead-letter-publishing.topic-name}", groupId = "dlq-group")
+	@RetryableTopic(
+		attempts = "4",
+		backoff = @Backoff(delay = 30_000),
+		kafkaTemplate = "deadLetterKafkaTemplate",
+		retryTopicSuffix = ".RETRY",
+		dltTopicSuffix = ".PARKING",
+		exclude = {
+			InvalidInputException.class,
+			ReservationNotFoundException.class
+		},
+		sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.SINGLE_TOPIC,
+		dltStrategy = DltStrategy.FAIL_ON_ERROR
+	)
+	@KafkaListener(
+		topics = "${spring.kafka.consumer.properties.spring.kafka.dead-letter-publishing.topic-name}",
+		groupId = "dlq-group"
+	)
 	public void consumeDlqEvents(@Payload String message, Acknowledgment ack) {
 		log.warn("[DLQ-CONSUME] DLQ 메시지 수신: {}", message);
 
-		String eventType = "UNKNOWN"; // 예외 발생 시를 대비한 초기화
+		EventType eventType = EventType.UNKNOWN;
 		try {
-			eventType = debeziumEventParser.getEventType(message);
+			eventType = EventType.from(debeziumEventParser.getEventType(message));
 
-			if (EventType.PAYMENT_COMPLETED.name().equals(eventType)) {
-				PaymentEvent.PaymentCompletedEvent event = debeziumEventParser.parse(message, PaymentEvent.PaymentCompletedEvent.class).payload();
-
-				log.warn("[DLQ-COMPENSATION] 예약 확정 실패에 대한 결제 보상 트랜잭션 시작. ReservationUID: {}", event.reservationUid());
-				paymentCompensationService.compensate(event.reservationUid());
-			} else {
-				log.warn("[DLQ-IGNORE] 처리 로직이 존재하지 않는 DLQ 메시지. EventType: {}", eventType);
-			}
+			recoverEvent(eventType, message);
 
 			ack.acknowledge();
 			log.info("[DLQ-ACK] 메시지 처리 성공. DLQ에서 메시지 제거.");
 
-		} catch (Exception e) {
-			log.error("[DLQ-FATAL] DLQ 메시지 자동 처리 중 심각한 오류 발생. 수동 개입 필요. Message: {}", message, e);
-
-			String alertMessage = String.format(ALERT_MESSAGE,
-				eventType,
-				e.getClass().getSimpleName(),
-				e.getMessage(),
-				message);
-			slackNotificationService.sendAlert(alertMessage);
-
+		} catch (DebeziumEventParsingException e) {
+			handleFailureAlert(eventType.name(), message, e);
 			ack.acknowledge();
-			log.warn("[DLQ-ACK] 처리 실패했으나, 무한 재시도 방지를 위해 메시지 제거.");
+			log.warn("[DLQ-ACK] 파싱할 수 없는 메시지를 무한 재시도하지 않고 제거합니다.");
+		} catch (RuntimeException e) {
+			if (eventType != EventType.UNKNOWN) {
+				log.warn("[DLQ-FORWARD] 자동 복구 실패. 비차단 재시도 토픽으로 전달합니다. EventType: {}", eventType, e);
+				throw e;
+			}
+
+			handleFailureAlert(eventType.name(), message, e);
+			ack.acknowledge();
+			log.warn("[DLQ-ACK] 지원하지 않는 이벤트의 처리 실패를 무한 재시도하지 않고 제거합니다.");
+		}
+	}
+
+	@DltHandler
+	public void handleExhaustedRecovery(
+		@Payload String message,
+		@Header(name = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String errorMessage,
+		Acknowledgment ack
+	) {
+		String eventType = EventType.UNKNOWN.name();
+		Exception failure = new IllegalStateException(
+			errorMessage != null ? errorMessage : "DLQ 자동 복구 횟수를 초과했습니다."
+		);
+
+		try {
+			eventType = debeziumEventParser.getEventType(message);
+		} catch (Exception parsingException) {
+			failure = parsingException;
+		}
+
+		try {
+			handleFailureAlert(eventType, message, failure);
+		} finally {
+			ack.acknowledge();
+			log.warn("[DLQ-PARKED] 자동 복구를 소진한 메시지를 보관 토픽에 남깁니다. EventType: {}", eventType);
+		}
+	}
+
+	private void recoverEvent(EventType eventType, String message) {
+		switch (eventType) {
+			case PAYMENT_CONFIRM_REQUESTED ->
+				paymentApprovalService.preparePgCall(parsePayload(message, PaymentRequest.Confirm.class));
+			case PAYMENT_COMPLETED, RESERVATION_CONFIRM_REQUESTED -> {
+				PaymentEvent.PaymentCompletedEvent event = parsePayload(
+					message, PaymentEvent.PaymentCompletedEvent.class);
+				log.warn(
+					"[DLQ-COMPENSATION] 예약 확정 실패에 대한 결제 보상 트랜잭션 시작. ReservationUID: {}",
+					event.reservationUid()
+				);
+				paymentCompensationService.compensate(event.reservationUid());
+			}
+			case PG_CALL_REQUESTED ->
+				paymentGatewayWorker.processConfirmRequest(parsePayload(message, PaymentRequest.Confirm.class));
+			case PG_CALL_SUCCEEDED -> paymentConfirmationProcessor.processSuccess(
+				parsePayload(message, PaymentEvent.PgCallSucceededEvent.class));
+			case PG_CALL_FAILED -> paymentConfirmationProcessor.processFailure(
+				parsePayload(message, PaymentEvent.PgCallFailedEvent.class));
+			case PAYMENT_FAILED, RESERVATION_EXPIRE_REQUESTED -> reservationService.expireReservation(
+				parsePayload(message, PaymentEvent.PaymentFailedEvent.class));
+			case PG_CANCEL_CALL_SUCCEEDED -> paymentCancellationProcessor.processSuccess(
+				parsePayload(message, PaymentEvent.PgCancelCallSucceededEvent.class));
+			case PG_CANCEL_CALL_FAILED -> paymentCancellationProcessor.processFailure(
+				parsePayload(message, PaymentEvent.PgCancelCallFailedEvent.class));
+			case RESERVATION_CANCELLATION_REQUESTED -> {
+				ReservationEvent.ReservationCancellationRequestedEvent event = parsePayload(
+					message, ReservationEvent.ReservationCancellationRequestedEvent.class);
+				publishPaymentCancellationRequest(
+					event.reservationUid(), event.cancelReason(), event.cancelAmount());
+			}
+			case RESERVATION_CANCELLED -> {
+				ReservationEvent.ReservationCancelledEvent event = parsePayload(
+					message, ReservationEvent.ReservationCancelledEvent.class);
+				publishPaymentCancellationRequest(
+					event.reservationUid(), event.cancelReason(), event.cancelAmount());
+			}
+			case PG_CANCEL_CALL_REQUESTED -> paymentGatewayWorker.processCancelRequest(
+				parsePayload(message, PaymentEvent.PaymentCancellationRequestedEvent.class));
+			case PAYMENT_CANCELLATION_COMPLETED -> {
+				PaymentEvent.PaymentCancellationCompletedEvent event = parsePayload(
+					message, PaymentEvent.PaymentCancellationCompletedEvent.class);
+				reservationService.completeCancellation(
+					new ReservationEvent.ReservationCancellationCompleteRequestedEvent(event.reservationUid()));
+			}
+			case RESERVATION_CANCELLATION_COMPLETE_REQUESTED -> reservationService.completeCancellation(
+				parsePayload(message, ReservationEvent.ReservationCancellationCompleteRequestedEvent.class));
+			case PAYMENT_CANCELLATION_FAILED -> {
+				PaymentEvent.PaymentCancellationFailedEvent event = parsePayload(
+					message, PaymentEvent.PaymentCancellationFailedEvent.class);
+				reservationService.revertCancellation(
+					new ReservationEvent.ReservationCancellationRevertRequestedEvent(
+						event.reservationUid(), event.reason()));
+			}
+			case RESERVATION_CANCELLATION_REVERT_REQUESTED -> reservationService.revertCancellation(
+				parsePayload(message, ReservationEvent.ReservationCancellationRevertRequestedEvent.class));
+			default -> log.warn("[DLQ-IGNORE] 처리 로직이 존재하지 않는 DLQ 메시지. EventType: {}", eventType);
+		}
+	}
+
+	private <T extends EventPayload> T parsePayload(String message, Class<T> payloadType) {
+		return debeziumEventParser.parse(message, payloadType).payload();
+	}
+
+	private void publishPaymentCancellationRequest(String reservationUid, String cancelReason, Long cancelAmount) {
+		outboxEventPublisher.save(
+			EventType.PG_CANCEL_CALL_REQUESTED,
+			new PaymentEvent.PaymentCancellationRequestedEvent(reservationUid, cancelReason, cancelAmount)
+		);
+	}
+
+	private void handleFailureAlert(String eventType, String message, Exception e) {
+		log.error("[DLQ-FATAL] DLQ 메시지 자동 처리 중 심각한 오류 발생. 수동 개입 필요. Message: {}", message, e);
+
+		String alertMessage = String.format(ALERT_MESSAGE,
+			eventType,
+			e.getClass().getSimpleName(),
+			e.getMessage(),
+			message);
+		try {
+			slackNotificationService.sendAlert(alertMessage);
+		} catch (Exception alertException) {
+			log.error("[DLQ-ALERT-FAILED] DLQ 처리 실패 알림 전송 실패.", alertException);
 		}
 	}
 }

--- a/src/main/java/kr/kro/airbob/kafka/consumer/PaymentEventTranslator.java
+++ b/src/main/java/kr/kro/airbob/kafka/consumer/PaymentEventTranslator.java
@@ -48,7 +48,16 @@ public class PaymentEventTranslator {
 					envelope.payload()
 				);
 				log.info("[TRANSLATOR] PAYMENT_FAILED -> RESERVATION_EXPIRE_REQUESTED 발행. UID: {}", envelope.payload().reservationUid());
-			}else if (type == EventType.PAYMENT_CANCELLATION_FAILED) {
+			} else if (type == EventType.PAYMENT_CANCELLATION_COMPLETED) {
+				EventEnvelope<PaymentEvent.PaymentCancellationCompletedEvent> envelope =
+					debeziumEventParser.parse(message, PaymentEvent.PaymentCancellationCompletedEvent.class);
+				PaymentEvent.PaymentCancellationCompletedEvent payload = envelope.payload();
+				outboxEventPublisher.save(
+					EventType.RESERVATION_CANCELLATION_COMPLETE_REQUESTED,
+					new ReservationEvent.ReservationCancellationCompleteRequestedEvent(payload.reservationUid())
+				);
+				log.info("[TRANSLATOR] PAYMENT_CANCELLATION_COMPLETED -> RESERVATION_CANCELLATION_COMPLETE_REQUESTED 발행. UID: {}", payload.reservationUid());
+			} else if (type == EventType.PAYMENT_CANCELLATION_FAILED) {
 				EventEnvelope<PaymentEvent.PaymentCancellationFailedEvent> envelope =
 					debeziumEventParser.parse(message, PaymentEvent.PaymentCancellationFailedEvent.class);
 				PaymentEvent.PaymentCancellationFailedEvent payload = envelope.payload();

--- a/src/main/java/kr/kro/airbob/kafka/consumer/PaymentEventsConsumer.java
+++ b/src/main/java/kr/kro/airbob/kafka/consumer/PaymentEventsConsumer.java
@@ -7,12 +7,12 @@ import org.springframework.stereotype.Component;
 
 import kr.kro.airbob.domain.payment.dto.PaymentRequest;
 import kr.kro.airbob.domain.payment.event.PaymentEvent;
+import kr.kro.airbob.domain.payment.service.PaymentApprovalService;
 import kr.kro.airbob.domain.payment.service.PaymentCancellationProcessor;
 import kr.kro.airbob.domain.payment.service.PaymentConfirmationProcessor;
 import kr.kro.airbob.outbox.DebeziumEventParser;
 import kr.kro.airbob.outbox.EventEnvelope;
 import kr.kro.airbob.outbox.EventType;
-import kr.kro.airbob.outbox.OutboxEventPublisher;
 import kr.kro.airbob.outbox.exception.DebeziumEventParsingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PaymentEventsConsumer {
 
 	private final DebeziumEventParser debeziumEventParser;
-	private final OutboxEventPublisher outboxEventPublisher;
+	private final PaymentApprovalService paymentApprovalService;
 	private final PaymentConfirmationProcessor confirmationProcessor;
 	private final PaymentCancellationProcessor cancellationProcessor;
 	@KafkaListener(topics = "PAYMENT.events", groupId = "payment-group")
@@ -36,11 +36,10 @@ public class PaymentEventsConsumer {
 					EventEnvelope<PaymentRequest.Confirm> envelope =
 						debeziumEventParser.parse(message, PaymentRequest.Confirm.class);
 
-					outboxEventPublisher.save(
-						EventType.PG_CALL_REQUESTED,
-						envelope.payload()
-					);
-					log.info("[KAFKA] PG사 결제 승인 API 호출 요청 이벤트 발행. Order ID={}", envelope.payload().orderId());
+					if (paymentApprovalService.preparePgCall(envelope.payload())) {
+						log.info("[KAFKA] PG사 결제 승인 API 호출 요청 선점 처리. Order ID={}",
+							envelope.payload().orderId());
+					}
 				}
 				case PG_CALL_SUCCEEDED -> {
 					EventEnvelope<PaymentEvent.PgCallSucceededEvent> envelope =

--- a/src/main/java/kr/kro/airbob/kafka/consumer/PaymentGatewayWorker.java
+++ b/src/main/java/kr/kro/airbob/kafka/consumer/PaymentGatewayWorker.java
@@ -1,5 +1,7 @@
 package kr.kro.airbob.kafka.consumer;
 
+import java.time.Clock;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.springframework.kafka.annotation.KafkaListener;
@@ -10,11 +12,18 @@ import org.springframework.stereotype.Component;
 import kr.kro.airbob.domain.payment.dto.PaymentRequest;
 import kr.kro.airbob.domain.payment.dto.TossPaymentResponse;
 import kr.kro.airbob.domain.payment.entity.Payment;
+import kr.kro.airbob.domain.payment.entity.PaymentStatus;
 import kr.kro.airbob.domain.payment.event.PaymentEvent;
 import kr.kro.airbob.domain.payment.exception.PaymentNotFoundException;
 import kr.kro.airbob.domain.payment.exception.TossPaymentException;
+import kr.kro.airbob.domain.payment.exception.code.PaymentInquiryErrorCode;
 import kr.kro.airbob.domain.payment.repository.PaymentRepository;
+import kr.kro.airbob.domain.payment.service.PaymentCompensationService;
 import kr.kro.airbob.domain.payment.service.TossPaymentsAdapter;
+import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
+import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
+import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.outbox.DebeziumEventParser;
 import kr.kro.airbob.outbox.EventEnvelope;
 import kr.kro.airbob.outbox.EventType;
@@ -33,6 +42,9 @@ public class PaymentGatewayWorker {
 	private final OutboxEventPublisher outboxEventPublisher;
 
 	private final PaymentRepository paymentRepository;
+	private final ReservationRepository reservationRepository;
+	private final PaymentCompensationService paymentCompensationService;
+	private final Clock clock;
 
 	@KafkaListener(topics = "PAYMENT.events", groupId = "payment-gateway-worker-group")
 	public void handlePgCallRequest(@Payload String message, Acknowledgment ack) {
@@ -59,74 +71,186 @@ public class PaymentGatewayWorker {
 
 	private void handleConfirmRequest(String message) {
 		EventEnvelope<PaymentRequest.Confirm> envelope = debeziumEventParser.parse(message, PaymentRequest.Confirm.class);
-		PaymentRequest.Confirm request = envelope.payload();
+		processConfirmRequest(envelope.payload());
+	}
+
+	void processConfirmRequest(PaymentRequest.Confirm request) {
+		UUID reservationUid = UUID.fromString(request.orderId());
+		Reservation reservation = reservationRepository.findByReservationUid(reservationUid)
+			.orElseThrow(ReservationNotFoundException::new);
+		validateConfirmRequest(request, reservation);
+
 		String orderId = request.orderId();
+		if (reservation.getStatus().hasConfirmedPayment()) {
+			log.info("[PG-WORKER-SKIP] 이미 결제가 확정된 예약의 중복 승인 요청입니다. Order ID: {}", orderId);
+			return;
+		}
+		if (reservation.getStatus() == ReservationStatus.EXPIRED) {
+			recoverOrExpireDelayedConfirmRequest(request, orderId, true);
+			return;
+		}
+		if (reservation.getStatus() != ReservationStatus.PAYMENT_PROCESSING) {
+			throw new IllegalStateException("결제 처리 상태가 아닌 예약은 PG 승인을 요청할 수 없습니다.");
+		}
+		if (reservation.isExpiredAt(clock.instant())) {
+			recoverOrExpireDelayedConfirmRequest(request, orderId, false);
+			return;
+		}
 
 		log.info("[PG-WORKER] Toss API 승인 호출 시작. Order ID: {}", orderId);
 
+		TossPaymentResponse response;
 		try {
-			TossPaymentResponse response = tossPaymentsAdapter.confirmPayment(
+			response = tossPaymentsAdapter.confirmPayment(
 				request.paymentKey(),
 				orderId,
 				request.amount()
 			);
-
-			outboxEventPublisher.save(
-				EventType.PG_CALL_SUCCEEDED,
-				new PaymentEvent.PgCallSucceededEvent(response, orderId)
-			);
-			log.info("[PG-WORKER] Toss API 승인 호출 성공. Order ID: {}", orderId);
 		} catch (TossPaymentException e) {
 			outboxEventPublisher.save(
 				EventType.PG_CALL_FAILED,
 				new PaymentEvent.PgCallFailedEvent(request, orderId, e.getErrorCode().name(), e.getMessage())
 			);
 			log.error("[PG-WORKER] Toss API 승인 호출 실패. Order ID: {}, Code: {}", orderId, e.getErrorCode().name(), e);
-		} catch (Exception e) {
+			return;
+		}
+		validateConfirmResponse(request, response);
+
+		outboxEventPublisher.save(
+			EventType.PG_CALL_SUCCEEDED,
+			new PaymentEvent.PgCallSucceededEvent(response, orderId)
+		);
+		log.info("[PG-WORKER] Toss API 승인 호출 성공. Order ID: {}", orderId);
+	}
+
+	private void recoverOrExpireDelayedConfirmRequest(
+		PaymentRequest.Confirm request,
+		String orderId,
+		boolean reservationAlreadyExpired
+	) {
+		try {
+			TossPaymentResponse existingPayment = tossPaymentsAdapter.getPaymentByPaymentKey(request.paymentKey());
+			if (isCorrelatedFullyCanceledPayment(request, existingPayment)) {
+				if (!reservationAlreadyExpired) {
+					publishExpiredFailure(request, orderId);
+				}
+				log.info("[PG-WORKER-SKIP] 이미 전액 환불된 결제의 중복 승인 요청입니다. Order ID: {}", orderId);
+				return;
+			}
+			if (isCorrelatedPartiallyCanceledPayment(request, existingPayment)) {
+				paymentCompensationService.compensate(orderId);
+				log.warn("[PG-WORKER-COMPENSATE] 부분 환불 잔액의 보상 취소를 완료했습니다. Order ID: {}", orderId);
+				return;
+			}
+			validateConfirmResponse(request, existingPayment);
 			outboxEventPublisher.save(
-				EventType.PG_CALL_FAILED,
-				new PaymentEvent.PgCallFailedEvent(request, orderId, "UNKNOWN_WORKER_ERROR", e.getMessage())
+				EventType.PG_CALL_SUCCEEDED,
+				new PaymentEvent.PgCallSucceededEvent(existingPayment, orderId)
 			);
-			log.error("[PG-WORKER] Toss API 승인 호출 중 알 수 없는 예외 발생. Order ID: {}", orderId, e);
+			log.warn("[PG-WORKER-RECOVER] 만료 후 재처리에서 기존 승인 결제를 조회해 복구합니다. Order ID: {}", orderId);
+		} catch (TossPaymentException e) {
+			if (e.getErrorCode() != PaymentInquiryErrorCode.NOT_FOUND_PAYMENT
+				&& e.getErrorCode() != PaymentInquiryErrorCode.NOT_FOUND) {
+				throw e;
+			}
+			publishExpiredFailure(request, orderId);
+			log.warn("[PG-WORKER-SKIP] 예약 만료 후 도착했고 승인된 결제도 없습니다. Order ID: {}", orderId);
+		}
+	}
+
+	private boolean isCorrelatedFullyCanceledPayment(
+		PaymentRequest.Confirm request,
+		TossPaymentResponse response
+	) {
+		return response != null
+			&& Objects.equals(request.paymentKey(), response.getPaymentKey())
+			&& Objects.equals(request.orderId(), response.getOrderId())
+			&& Objects.equals(request.amount().longValue(), response.getTotalAmount())
+			&& PaymentStatus.CANCELED.name().equalsIgnoreCase(response.getStatus())
+			&& Objects.equals(0L, response.getBalanceAmount());
+	}
+
+	private boolean isCorrelatedPartiallyCanceledPayment(
+		PaymentRequest.Confirm request,
+		TossPaymentResponse response
+	) {
+		return response != null
+			&& Objects.equals(request.paymentKey(), response.getPaymentKey())
+			&& Objects.equals(request.orderId(), response.getOrderId())
+			&& Objects.equals(request.amount().longValue(), response.getTotalAmount())
+			&& PaymentStatus.PARTIAL_CANCELED.name().equalsIgnoreCase(response.getStatus())
+			&& response.getBalanceAmount() != null
+			&& response.getBalanceAmount() > 0L;
+	}
+
+	private void publishExpiredFailure(PaymentRequest.Confirm request, String orderId) {
+		outboxEventPublisher.save(
+			EventType.PG_CALL_FAILED,
+			new PaymentEvent.PgCallFailedEvent(
+				request,
+				orderId,
+				"RESERVATION_EXPIRED",
+				"결제 승인 요청 처리 전에 예약 유효 시간이 만료되었습니다."
+			)
+		);
+	}
+
+	private void validateConfirmRequest(PaymentRequest.Confirm request, Reservation reservation) {
+		if (!reservation.matchesPaymentRequest(request.orderId(), request.amount().longValue())) {
+			throw new IllegalStateException("결제 승인 요청이 예약 정보와 일치하지 않습니다.");
+		}
+	}
+
+	private void validateConfirmResponse(
+		PaymentRequest.Confirm request,
+		TossPaymentResponse response
+	) {
+		boolean correlated = response != null
+			&& Objects.equals(request.paymentKey(), response.getPaymentKey())
+			&& Objects.equals(request.orderId(), response.getOrderId())
+			&& Objects.equals(request.amount().longValue(), response.getTotalAmount())
+			&& PaymentStatus.DONE == PaymentStatus.from(response.getStatus())
+			&& response.getApprovedAt() != null
+			&& response.getMethod() != null
+			&& !response.getMethod().isBlank();
+		if (!correlated) {
+			throw new IllegalStateException("PG 승인 응답이 원 결제 요청과 일치하지 않습니다.");
 		}
 	}
 
 	private void handleCancelRequest(String message) {
 		EventEnvelope<PaymentEvent.PaymentCancellationRequestedEvent> envelope =
 			debeziumEventParser.parse(message, PaymentEvent.PaymentCancellationRequestedEvent.class);
-		PaymentEvent.PaymentCancellationRequestedEvent request = envelope.payload();
+		processCancelRequest(envelope.payload());
+	}
+
+	void processCancelRequest(PaymentEvent.PaymentCancellationRequestedEvent request) {
 		String reservationUid = request.reservationUid();
 
 		log.info("[PG-WORKER] Toss API 취소 호출 시작. Reservation UID: {}", reservationUid);
 
+		Payment payment = paymentRepository.findByReservationReservationUid(UUID.fromString(reservationUid))
+			.orElseThrow(PaymentNotFoundException::new);
+		TossPaymentResponse response;
 		try {
-			Payment payment = paymentRepository.findByReservationReservationUid(UUID.fromString(reservationUid))
-				.orElseThrow(PaymentNotFoundException::new);
-
-			TossPaymentResponse response = tossPaymentsAdapter.cancelPayment(
+			response = tossPaymentsAdapter.cancelPayment(
 				payment.getPaymentKey(),
 				request.cancelReason(),
 				request.cancelAmount()
 			);
-
-			outboxEventPublisher.save(
-				EventType.PG_CANCEL_CALL_SUCCEEDED,
-				new PaymentEvent.PgCancelCallSucceededEvent(response, reservationUid)
-			);
-			log.info("[PG-WORKER] Toss API 취소 호출 성공. Reservation UID: {}", reservationUid);
-
 		} catch (TossPaymentException e) {
 			outboxEventPublisher.save(
 				EventType.PG_CANCEL_CALL_FAILED,
 				new PaymentEvent.PgCancelCallFailedEvent(request, reservationUid, e.getErrorCode().name(), e.getMessage())
 			);
 			log.error("[PG-WORKER] Toss API 취소 호출 실패. Reservation UID: {}, Code: {}", reservationUid, e.getErrorCode().name(), e);
-		} catch (Exception e) {
-			outboxEventPublisher.save(
-				EventType.PG_CANCEL_CALL_FAILED,
-				new PaymentEvent.PgCancelCallFailedEvent(request, reservationUid, "UNKNOWN_WORKER_ERROR", e.getMessage())
-			);
-			log.error("[PG-WORKER] Toss API 취소 호출 중 알 수 없는 예외 발생. Reservation UID: {}", reservationUid, e);
+			return;
 		}
+
+		outboxEventPublisher.save(
+			EventType.PG_CANCEL_CALL_SUCCEEDED,
+			new PaymentEvent.PgCancelCallSucceededEvent(response, reservationUid)
+		);
+		log.info("[PG-WORKER] Toss API 취소 호출 성공. Reservation UID: {}", reservationUid);
 	}
 }

--- a/src/main/java/kr/kro/airbob/kafka/consumer/ReservationEventTranslator.java
+++ b/src/main/java/kr/kro/airbob/kafka/consumer/ReservationEventTranslator.java
@@ -28,10 +28,10 @@ public class ReservationEventTranslator {
 		try {
 			String eventType = debeziumEventParser.getEventType(message);
 
-			if (EventType.RESERVATION_CANCELLED.name().equals(eventType)) {
-				EventEnvelope<ReservationEvent.ReservationCancelledEvent> envelope =
-					debeziumEventParser.parse(message, ReservationEvent.ReservationCancelledEvent.class);
-				ReservationEvent.ReservationCancelledEvent payload = envelope.payload();
+			if (EventType.RESERVATION_CANCELLATION_REQUESTED.name().equals(eventType)) {
+				EventEnvelope<ReservationEvent.ReservationCancellationRequestedEvent> envelope =
+					debeziumEventParser.parse(message, ReservationEvent.ReservationCancellationRequestedEvent.class);
+				ReservationEvent.ReservationCancellationRequestedEvent payload = envelope.payload();
 
 				// PG 취소 API 호출 이벤트 발행
 				outboxEventPublisher.save(
@@ -42,7 +42,18 @@ public class ReservationEventTranslator {
 						payload.cancelAmount()
 					)
 				);
-				log.info("[TRANSLATOR] RESERVATION_CANCELLED -> PG_CANCEL_CALL_REQUESTED 발행. UID: {}", payload.reservationUid());
+				log.info("[TRANSLATOR] RESERVATION_CANCELLATION_REQUESTED -> PG_CANCEL_CALL_REQUESTED 발행. UID: {}", payload.reservationUid());
+			} else if (EventType.RESERVATION_CANCELLED.name().equals(eventType)) {
+				EventEnvelope<ReservationEvent.ReservationCancelledEvent> envelope =
+					debeziumEventParser.parse(message, ReservationEvent.ReservationCancelledEvent.class);
+				ReservationEvent.ReservationCancelledEvent payload = envelope.payload();
+				outboxEventPublisher.save(
+					EventType.PG_CANCEL_CALL_REQUESTED,
+					new PaymentEvent.PaymentCancellationRequestedEvent(
+						payload.reservationUid(), payload.cancelReason(), payload.cancelAmount())
+				);
+				log.info("[TRANSLATOR] legacy RESERVATION_CANCELLED -> PG_CANCEL_CALL_REQUESTED 발행. UID: {}",
+					payload.reservationUid());
 			}
 			ack.acknowledge();
 		} catch (DebeziumEventParsingException e) {

--- a/src/main/java/kr/kro/airbob/kafka/consumer/ReservationEventsConsumer.java
+++ b/src/main/java/kr/kro/airbob/kafka/consumer/ReservationEventsConsumer.java
@@ -61,6 +61,12 @@ public class ReservationEventsConsumer {
 					ReservationEvent.ReservationCancellationRevertRequestedEvent event = envelope.payload();
 					reservationService.revertCancellation(event);
 				}
+				case RESERVATION_CANCELLATION_COMPLETE_REQUESTED -> {
+					EventEnvelope<ReservationEvent.ReservationCancellationCompleteRequestedEvent> envelope =
+						debeziumEventParser.parse(
+							message, ReservationEvent.ReservationCancellationCompleteRequestedEvent.class);
+					reservationService.completeCancellation(envelope.payload());
+				}
 				/*case RESERVATION_PENDING -> {
 					// 추후 알림과 같은 기능 생기면 로직 추가
 				}*/

--- a/src/main/java/kr/kro/airbob/outbox/EventEnvelope.java
+++ b/src/main/java/kr/kro/airbob/outbox/EventEnvelope.java
@@ -1,24 +1,32 @@
 package kr.kro.airbob.outbox;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public record EventEnvelope<T extends EventPayload>(
 	UUID eventId, // 이벤트 고유 ID
 	String traceId, // 전체 요청 추적 ID
 	String eventType,
 	String eventVersion, // 이벤트 스키마 버전
-	LocalDateTime timestamp,
+	@JsonSerialize(using = EventTimestampSerializer.class)
+	@JsonDeserialize(using = EventTimestampDeserializer.class)
+	Instant timestamp,
 	T payload
 ) {
-
-	public static <T extends EventPayload> EventEnvelope<T> of(EventType eventType, T payload) {
+	public static <T extends EventPayload> EventEnvelope<T> of(
+		EventType eventType,
+		T payload,
+		Instant timestamp
+	) {
 		return new EventEnvelope<>(
 			UUID.randomUUID(),
 			payload.getId(), // 임시로 Aggregate ID를 Trace ID로 사용
 			eventType.name(),
 			"1.0",
-			LocalDateTime.now(),
+			timestamp,
 			payload
 		);
 	}

--- a/src/main/java/kr/kro/airbob/outbox/EventTimestampDeserializer.java
+++ b/src/main/java/kr/kro/airbob/outbox/EventTimestampDeserializer.java
@@ -1,0 +1,61 @@
+package kr.kro.airbob.outbox;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+
+public class EventTimestampDeserializer extends JsonDeserializer<Instant> {
+
+	@Override
+	public Instant deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+		if (!parser.hasToken(JsonToken.VALUE_STRING)) {
+			return (Instant) context.handleUnexpectedToken(Instant.class, parser);
+		}
+
+		String timestamp = parser.getText().trim();
+		if (timestamp.isEmpty()) {
+			throw InvalidFormatException.from(parser, "timestamp must not be blank", timestamp, Instant.class);
+		}
+
+		try {
+			return OffsetDateTime.parse(timestamp, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant();
+		} catch (DateTimeParseException ignored) {
+			return parseLegacyUtcTimestamp(parser, timestamp);
+		}
+	}
+
+	@Override
+	public Instant getNullValue(DeserializationContext context) throws JsonMappingException {
+		throw MismatchedInputException.from(
+			context.getParser(),
+			Instant.class,
+			"timestamp must not be null"
+		);
+	}
+
+	private Instant parseLegacyUtcTimestamp(JsonParser parser, String timestamp) throws InvalidFormatException {
+		try {
+			return LocalDateTime.parse(timestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+				.toInstant(ZoneOffset.UTC);
+		} catch (DateTimeParseException e) {
+			throw InvalidFormatException.from(
+				parser,
+				"timestamp must be ISO-8601 local UTC, Z, or offset date-time",
+				timestamp,
+				Instant.class
+			);
+		}
+	}
+}

--- a/src/main/java/kr/kro/airbob/outbox/EventTimestampSerializer.java
+++ b/src/main/java/kr/kro/airbob/outbox/EventTimestampSerializer.java
@@ -1,0 +1,20 @@
+package kr.kro.airbob.outbox;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class EventTimestampSerializer extends JsonSerializer<Instant> {
+
+	@Override
+	public void serialize(Instant value, JsonGenerator generator, SerializerProvider serializers) throws IOException {
+		LocalDateTime utcDateTime = LocalDateTime.ofInstant(value, ZoneOffset.UTC);
+		generator.writeString(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(utcDateTime));
+	}
+}

--- a/src/main/java/kr/kro/airbob/outbox/EventType.java
+++ b/src/main/java/kr/kro/airbob/outbox/EventType.java
@@ -15,13 +15,17 @@ public enum EventType {
 	RESERVATION_EXPIRE_REQUESTED("RESERVATION", "reservation-events"), // 예약 만료 요청
 	RESERVATION_EXPIRED("RESERVATION", "reservation-events"),   // 예약 만료 완료
 	RESERVATION_PENDING("RESERVATION", "reservation-events"), // 예약 보류
-	RESERVATION_CANCELLED("RESERVATION", "reservation-events"), // 예약 취소
+	@Deprecated
+	RESERVATION_CANCELLED("RESERVATION", "reservation-events"), // 구 취소 요청 이벤트 호환
+	RESERVATION_CANCELLATION_REQUESTED("RESERVATION", "reservation-events"), // 예약 취소 요청
+	RESERVATION_CANCELLATION_COMPLETE_REQUESTED("RESERVATION", "reservation-events"), // 예약 취소 완료 반영 요청
 	RESERVATION_CANCELLATION_REVERT_REQUESTED("RESERVATION", "reservation-events"), // 예약 취소 실패 보상 요청
 
 	// 결제 이벤트
 	PAYMENT_CONFIRM_REQUESTED("PAYMENT", "payment-events"), // 결제 승인 요청
 	PAYMENT_COMPLETED("PAYMENT", "payment-events"), // 결제 완료
 	PAYMENT_CANCELLATION_REQUESTED("PAYMENT", "payment-events"), // 결제 취소 요청
+	PAYMENT_CANCELLATION_COMPLETED("PAYMENT", "payment-events"), // 결제 취소 완료
 	PAYMENT_FAILED("PAYMENT", "payment-events"),
 	PAYMENT_CANCELLATION_FAILED("PAYMENT", "payment-events"),
 

--- a/src/main/java/kr/kro/airbob/outbox/OutboxEventPublisher.java
+++ b/src/main/java/kr/kro/airbob/outbox/OutboxEventPublisher.java
@@ -1,5 +1,7 @@
 package kr.kro.airbob.outbox;
 
+import java.time.Clock;
+
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,10 +19,11 @@ public class OutboxEventPublisher {
 
 	private final OutboxRepository outboxRepository;
 	private final ObjectMapper objectMapper;
+	private final Clock clock;
 
 	public void save(EventType eventType, EventPayload payload) {
 		try {
-			EventEnvelope<?> envelope = EventEnvelope.of(eventType, payload);
+			EventEnvelope<?> envelope = EventEnvelope.of(eventType, payload, clock.instant());
 			String serializedEnvelope = objectMapper.writeValueAsString(envelope);
 
 			Outbox outboxEvent = Outbox.create(

--- a/src/main/java/kr/kro/airbob/search/document/AccommodationDocument.java
+++ b/src/main/java/kr/kro/airbob/search/document/AccommodationDocument.java
@@ -59,6 +59,9 @@ public record AccommodationDocument(
 	@Field(type = FieldType.Keyword)
 	String status,
 
+	@Field(type = FieldType.Keyword)
+	String timeZoneId,
+
 	@Field(type = FieldType.Date, format = {DateFormat.date_time})
 	Instant createdAt,
 
@@ -170,4 +173,3 @@ public record AccommodationDocument(
 		LocalDate lt
 	) {}
 }
-

--- a/src/main/java/kr/kro/airbob/search/dto/AccommodationSearchRequest.java
+++ b/src/main/java/kr/kro/airbob/search/dto/AccommodationSearchRequest.java
@@ -4,8 +4,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AccessLevel;
@@ -30,9 +28,7 @@ public class AccommodationSearchRequest {
 		private Integer maxPrice;
 
 		// 날짜
-		@FutureOrPresent
 		private LocalDate checkIn;
-		@Future
 		private LocalDate checkOut;
 
 		// 인원 수
@@ -51,12 +47,10 @@ public class AccommodationSearchRequest {
 		// 숙소 타입
 		private List<String> accommodationTypes;
 
-		@AssertTrue(message = "체크아웃 날짜는 체크인 날짜 다음날 이상이어야 합니다.")
+		@AssertTrue(message = "체크인과 체크아웃 날짜는 함께 입력해야 하며, 체크아웃은 체크인보다 뒤여야 합니다.")
 		public boolean isValidDateRange() {
-			if (checkIn != null && checkOut != null) {
-				return checkOut.isAfter(checkIn);
-			}
-			return true;
+			return (checkIn == null && checkOut == null)
+				|| (checkIn != null && checkOut != null && checkOut.isAfter(checkIn));
 		}
 
 		@AssertTrue(message = "최대 가격은 최소 가격보다 크거나 같아야 합니다.")

--- a/src/main/java/kr/kro/airbob/search/dto/AccommodationSearchResponse.java
+++ b/src/main/java/kr/kro/airbob/search/dto/AccommodationSearchResponse.java
@@ -78,10 +78,10 @@ public class AccommodationSearchResponse {
 				.currentPage(pageNumber)
 				.totalPages(0)
 				.totalElements(0)
-				.isFirst(true)
+				.isFirst(pageNumber == 0)
 				.isLast(true)
 				.hasNext(false)
-				.hasPrevious(false)
+				.hasPrevious(pageNumber > 0)
 				.build();
 		}
 	}

--- a/src/main/java/kr/kro/airbob/search/service/AccommodationDocumentBuilder.java
+++ b/src/main/java/kr/kro/airbob/search/service/AccommodationDocumentBuilder.java
@@ -1,6 +1,6 @@
 package kr.kro.airbob.search.service;
 
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -16,6 +16,8 @@ import kr.kro.airbob.domain.accommodation.exception.AccommodationNotFoundExcepti
 import kr.kro.airbob.domain.accommodation.repository.AccommodationAmenityRepository;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
+import kr.kro.airbob.domain.reservation.policy.ReservationIndexingWindow;
 import kr.kro.airbob.domain.review.entity.AccommodationReviewSummary;
 import kr.kro.airbob.domain.review.repository.AccommodationReviewSummaryRepository;
 import kr.kro.airbob.search.document.AccommodationDocument;
@@ -29,6 +31,7 @@ public class AccommodationDocumentBuilder {
 	private final AccommodationAmenityRepository amenityRepository;
 	private final ReservationRepository reservationRepository;
 	private final AccommodationReviewSummaryRepository reviewSummaryRepository;
+	private final BookingWindowProvider bookingWindowProvider;
 
 	public AccommodationDocument buildAccommodationDocument(String accommodationUidStr) {
 		UUID accommodationUid = UUID.fromString(accommodationUidStr);
@@ -38,7 +41,7 @@ public class AccommodationDocumentBuilder {
 
 		List<String> amenityTypes = getAccommodationAmenities(accommodationUid);
 		// List<String> imageUrls = getAccommodationImages(accommodationUid, accommodation.getThumbnailUrl());
-		List<AccommodationDocument.DateRange> reservationRanges = getReservationRanges(accommodationUid);
+		List<AccommodationDocument.DateRange> reservationRanges = getReservationRanges(accommodation.getId());
 		AccommodationReviewSummary reviewSummary = getReviewSummary(accommodationUid);
 
 		return AccommodationDocument.builder()
@@ -50,7 +53,8 @@ public class AccommodationDocumentBuilder {
 			.currency(accommodation.getCurrency())
 			.type(accommodation.getType())
 			.status(accommodation.getStatus().name())
-			.createdAt(accommodation.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant())
+			.timeZoneId(accommodation.getTimeZoneId())
+			.createdAt(accommodation.getCreatedAt().toInstant(ZoneOffset.UTC))
 			.location(AccommodationDocument.Location.builder()
 				.lat(accommodation.getAddress().getLatitude())
 				.lon(accommodation.getAddress().getLongitude())
@@ -82,13 +86,18 @@ public class AccommodationDocumentBuilder {
 			.orElse(null);
 	}
 
-	private List<AccommodationDocument.DateRange> getReservationRanges(UUID accommodationUid) {
+	private List<AccommodationDocument.DateRange> getReservationRanges(Long accommodationId) {
+		ReservationIndexingWindow window = bookingWindowProvider.currentIndexingWindow();
 		return reservationRepository
-			.findFutureConfirmedReservationRangesByAccommodationUid(accommodationUid)
+			.findActiveReservationRangesByAccommodationId(
+				accommodationId,
+				window.startInclusive(),
+				window.endExclusive()
+			)
 			.stream()
 			.map(dateRange -> AccommodationDocument.DateRange.builder()
-				.gte(dateRange.checkIn().toLocalDate()) // Check-in (gte)
-				.lt(dateRange.checkOut().toLocalDate()) // Check-out (lt)
+				.gte(dateRange.checkIn()) // Check-in (gte)
+				.lt(dateRange.checkOut()) // Check-out (lt)
 				.build()
 			)
 			.toList();
@@ -121,7 +130,8 @@ public class AccommodationDocumentBuilder {
 			.thumbnailUrl(accommodation.getThumbnailUrl())
 			.type(accommodation.getType())
 			.status(accommodation.getStatus().name())
-			.createdAt(accommodation.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant());
+			.timeZoneId(accommodation.getTimeZoneId())
+			.createdAt(accommodation.getCreatedAt().toInstant(ZoneOffset.UTC));
 
 		Address address = accommodation.getAddress();
 		if (address != null) {

--- a/src/main/java/kr/kro/airbob/search/service/AccommodationIndexUpdater.java
+++ b/src/main/java/kr/kro/airbob/search/service/AccommodationIndexUpdater.java
@@ -1,6 +1,5 @@
 package kr.kro.airbob.search.service;
 
-import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +12,8 @@ import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Component;
 
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
+import kr.kro.airbob.domain.reservation.policy.ReservationIndexingWindow;
 import kr.kro.airbob.domain.review.entity.AccommodationReviewSummary;
 import kr.kro.airbob.domain.review.repository.AccommodationReviewSummaryRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class AccommodationIndexUpdater {
 	private final ElasticsearchOperations elasticsearchOperations;
 	private final AccommodationReviewSummaryRepository reviewSummaryRepository;
 	private final ReservationRepository reservationRepository;
+	private final BookingWindowProvider bookingWindowProvider;
 	public void updateReviewSummaryInIndex(String accommodationUid) {
 		AccommodationReviewSummary reviewSummary = reviewSummaryRepository.findByAccommodation_AccommodationUid(UUID.fromString(accommodationUid))
 			.orElse(null);
@@ -49,37 +51,34 @@ public class AccommodationIndexUpdater {
 		elasticsearchOperations.update(updateQuery, IndexCoordinates.of(ACCOMMODATIONS));
 	}
 
-	public void updateReservedDatesInIndex(String accommodationUid) {
-		List<LocalDate> reservedDates = getReservedDates(accommodationUid);
-
-		List<String> reservedDateStrings = reservedDates.stream()
-			.map(LocalDate::toString)
-			.toList();
+	public void updateReservationRangesInIndex(String accommodationUid) {
+		List<Map<String, String>> reservationRanges = getReservationRanges(accommodationUid);
 
 		Map<String, Object> params = new HashMap<>();
-		params.put("reservedDates", reservedDateStrings);
+		params.put("reservationRanges", reservationRanges);
 
 		UpdateQuery updateQuery = UpdateQuery.builder(accommodationUid)
 			.withScriptType(ScriptType.INLINE)
-			.withScript("ctx._source.reservedDates = params.reservedDates")
+			.withScript("ctx._source.reservationRanges = params.reservationRanges")
 			.withParams(params)
 			.build();
 
 		elasticsearchOperations.update(updateQuery, IndexCoordinates.of(ACCOMMODATIONS));
 	}
 
-	private List<LocalDate> getReservedDates(String accommodationUid) {
+	private List<Map<String, String>> getReservationRanges(String accommodationUid) {
+		ReservationIndexingWindow window = bookingWindowProvider.currentIndexingWindow();
 		return reservationRepository
-			.findFutureConfirmedReservationRangesByAccommodationUid(UUID.fromString(accommodationUid))
+			.findActiveReservationRangesByAccommodationUid(
+				UUID.fromString(accommodationUid),
+				window.startInclusive(),
+				window.endExclusive()
+			)
 			.stream()
-			.flatMap(dateRange -> {
-				LocalDate checkInDate = dateRange.checkIn().toLocalDate();
-				LocalDate checkOutDate = dateRange.checkOut().toLocalDate();
-				// checkOutDate는 숙박일에 포함되지 않으므로 datesUntil 사용
-				return checkInDate.datesUntil(checkOutDate);
-			})
-			.distinct()
-			.sorted()
+			.map(dateRange -> Map.of(
+				"gte", dateRange.checkIn().toString(),
+				"lt", dateRange.checkOut().toString()
+			))
 			.toList();
 	}
 }

--- a/src/main/java/kr/kro/airbob/search/service/AccommodationIndexingService.java
+++ b/src/main/java/kr/kro/airbob/search/service/AccommodationIndexingService.java
@@ -34,8 +34,8 @@ public class AccommodationIndexingService {
 		log.info("[ES-INDEX] 리뷰 요약 업데이트: {}", event.accommodationUid());
 	}
 
-	public void updateReservedDatesInIndex(ReservationChangedEvent event) {
-		indexUpdater.updateReservedDatesInIndex(event.accommodationUid());
-		log.info("[ES-INDEX] 예약 날짜 업데이트: {}", event.accommodationUid());
+	public void updateReservationRangesInIndex(ReservationChangedEvent event) {
+		indexUpdater.updateReservationRangesInIndex(event.accommodationUid());
+		log.info("[ES-INDEX] 예약 범위 업데이트: {}", event.accommodationUid());
 	}
 }

--- a/src/main/java/kr/kro/airbob/search/service/AccommodationSearchService.java
+++ b/src/main/java/kr/kro/airbob/search/service/AccommodationSearchService.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.GeoLocation;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
@@ -21,6 +22,7 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonGeneratorFactory;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 import kr.kro.airbob.domain.wishlist.repository.WishlistAccommodationRepository;
 import kr.kro.airbob.search.document.AccommodationDocument;
 import kr.kro.airbob.search.dto.AccommodationSearchRequest;
@@ -37,6 +39,7 @@ public class AccommodationSearchService {
 
     private final ElasticsearchClient esClient;
     private final WishlistAccommodationRepository wishlistRepository;
+    private final BookingWindowProvider bookingWindowProvider;
 
     private static final String INDEX = "accommodations";
 
@@ -56,7 +59,12 @@ public class AccommodationSearchService {
             return createEmpty(pageable);
         }
 
-        Query query = buildQuery(req, viewport);
+        Set<String> eligibleTimeZones = eligibleTimeZones(req);
+        if (hasDateRange(req) && eligibleTimeZones.isEmpty()) {
+            return createEmpty(pageable);
+        }
+
+        Query query = buildQuery(req, viewport, eligibleTimeZones);
 
         /*//
         JsonGeneratorFactory factory = esClient._transport()
@@ -118,9 +126,10 @@ public class AccommodationSearchService {
                 .build();
     }
 
-    private Query buildQuery(
+    Query buildQuery(
             AccommodationSearchRequest.AccommodationSearchRequestDto req,
-            Viewport viewport
+            Viewport viewport,
+            Set<String> eligibleTimeZones
     ) {
 
         BoolQuery.Builder b = new BoolQuery.Builder();
@@ -206,6 +215,14 @@ public class AccommodationSearchService {
         }
 
         if (req.getCheckIn() != null && req.getCheckOut() != null) {
+            List<FieldValue> timeZoneValues = eligibleTimeZones.stream()
+                .sorted()
+                .map(FieldValue::of)
+                .toList();
+            b.filter(f -> f.terms(t -> t
+                .field("timeZoneId")
+                .terms(values -> values.value(timeZoneValues))
+            ));
             b.mustNot(mn -> mn.range(r -> r
                 .date(d -> d
                     .field("reservationRanges")
@@ -220,6 +237,20 @@ public class AccommodationSearchService {
         return new Query.Builder()
             .bool(b.build())
             .build();
+    }
+
+    private Set<String> eligibleTimeZones(
+            AccommodationSearchRequest.AccommodationSearchRequestDto request
+    ) {
+        if (!hasDateRange(request)) {
+            return Set.of();
+        }
+        return bookingWindowProvider.eligibleTimeZonesForStay(
+            request.getCheckIn(), request.getCheckOut());
+    }
+
+    private boolean hasDateRange(AccommodationSearchRequest.AccommodationSearchRequestDto request) {
+        return request.getCheckIn() != null && request.getCheckOut() != null;
     }
 
     private Viewport determineViewport(AccommodationSearchRequest.MapBoundsDto bounds) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,6 @@ spring:
 
   datasource:
     hikari:
-      connection-init-sql: SET time_zone = '+00:00'
       data-source-properties:
         connectionTimeZone: UTC
         forceConnectionTimeZoneToSession: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,15 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+        jdbc:
+          time_zone: UTC
+
+  datasource:
+    hikari:
+      connection-init-sql: SET time_zone = '+00:00'
+      data-source-properties:
+        connectionTimeZone: UTC
+        forceConnectionTimeZoneToSession: true
 
   servlet:
     multipart:

--- a/src/main/resources/db/migration/V15__add_accommodation_time_zone.sql
+++ b/src/main/resources/db/migration/V15__add_accommodation_time_zone.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accommodation ADD COLUMN time_zone_id VARCHAR(64) NULL;
+UPDATE accommodation SET time_zone_id = 'Asia/Seoul' WHERE time_zone_id IS NULL;
+
+ALTER TABLE accommodation_history ADD COLUMN time_zone_id VARCHAR(64) NULL;
+UPDATE accommodation_history SET time_zone_id = 'Asia/Seoul' WHERE time_zone_id IS NULL;

--- a/src/main/resources/db/migration/V15__add_accommodation_time_zone.sql
+++ b/src/main/resources/db/migration/V15__add_accommodation_time_zone.sql
@@ -1,5 +1,3 @@
 ALTER TABLE accommodation ADD COLUMN time_zone_id VARCHAR(64) NULL;
-UPDATE accommodation SET time_zone_id = 'Asia/Seoul' WHERE time_zone_id IS NULL;
 
 ALTER TABLE accommodation_history ADD COLUMN time_zone_id VARCHAR(64) NULL;
-UPDATE accommodation_history SET time_zone_id = 'Asia/Seoul' WHERE time_zone_id IS NULL;

--- a/src/main/resources/db/migration/V16__migrate_reservation_time_model.sql
+++ b/src/main/resources/db/migration/V16__migrate_reservation_time_model.sql
@@ -1,0 +1,13 @@
+ALTER TABLE reservation
+    CHANGE COLUMN check_in check_in_date DATE NOT NULL,
+    CHANGE COLUMN check_out check_out_date DATE NOT NULL,
+    ADD COLUMN check_in_at DATETIME(6) NOT NULL AFTER check_out_date,
+    ADD COLUMN check_out_at DATETIME(6) NOT NULL AFTER check_in_at,
+    ADD COLUMN time_zone_id VARCHAR(64) NOT NULL AFTER check_out_at;
+
+ALTER TABLE reservation_history
+    CHANGE COLUMN check_in check_in_date DATE NULL,
+    CHANGE COLUMN check_out check_out_date DATE NULL,
+    ADD COLUMN check_in_at DATETIME(6) NULL AFTER check_out_date,
+    ADD COLUMN check_out_at DATETIME(6) NULL AFTER check_in_at,
+    ADD COLUMN time_zone_id VARCHAR(64) NULL AFTER check_out_at;

--- a/src/test/java/kr/kro/airbob/common/api/UtcResponseJsonTest.java
+++ b/src/test/java/kr/kro/airbob/common/api/UtcResponseJsonTest.java
@@ -1,0 +1,55 @@
+package kr.kro.airbob.common.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.kro.airbob.domain.accommodation.dto.AccommodationResponse;
+import kr.kro.airbob.domain.review.dto.ReviewResponse;
+import kr.kro.airbob.domain.wishlist.dto.WishlistAccommodationResponse;
+import kr.kro.airbob.domain.wishlist.dto.WishlistResponse;
+
+@JsonTest
+@DisplayName("절대 시각 API 응답 계약 테스트")
+class UtcResponseJsonTest {
+
+	private static final Instant OCCURRED_AT = Instant.parse("2026-08-12T05:30:00Z");
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("숙소, 리뷰, 위시리스트의 절대 시각은 Z가 붙은 UTC로 반환한다")
+	void serializesAbsoluteTimesWithUtcOffset() {
+		AccommodationResponse.HostAccommodationInfo accommodation =
+			AccommodationResponse.HostAccommodationInfo.builder().createdAt(OCCURRED_AT).build();
+		ReviewResponse.ReviewInfo review = new ReviewResponse.ReviewInfo(
+			1L, 5, "좋아요", OCCURRED_AT, null, List.of());
+		WishlistResponse.WishlistInfo wishlist = WishlistResponse.WishlistInfo.builder()
+			.createdAt(OCCURRED_AT)
+			.build();
+		WishlistAccommodationResponse.WishlistAccommodationInfo wishlistAccommodation =
+			new WishlistAccommodationResponse.WishlistAccommodationInfo(
+				1L, null, OCCURRED_AT, null, null, null, true);
+
+		assertUtc(accommodation, "created_at", "createdAt");
+		assertUtc(review, "reviewed_at", "reviewedAt");
+		assertUtc(wishlist, "created_at", "createdAt");
+		assertUtc(wishlistAccommodation, "created_at", "createdAt");
+	}
+
+	private void assertUtc(Object value, String fieldName, String camelCaseFieldName) {
+		JsonNode json = objectMapper.valueToTree(value);
+		assertThat(json.path(fieldName).asText()).isEqualTo("2026-08-12T05:30:00Z");
+		assertThat(json.has(camelCaseFieldName)).isFalse();
+	}
+}

--- a/src/test/java/kr/kro/airbob/config/JpaAuditingConfigTest.java
+++ b/src/test/java/kr/kro/airbob/config/JpaAuditingConfigTest.java
@@ -1,0 +1,30 @@
+package kr.kro.airbob.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JpaAuditingConfigTest {
+
+	@Test
+	@DisplayName("주입된 Clock의 시간대와 무관하게 감사 시각을 UTC로 생성한다")
+	void createsAuditTimeInUtcRegardlessOfClockZone() {
+		Clock seoulClock = Clock.fixed(
+			Instant.parse("2026-08-13T07:30:00Z"),
+			ZoneId.of("Asia/Seoul")
+		);
+
+		LocalDateTime auditTime = (LocalDateTime) new JpaAuditingConfig()
+			.utcDateTimeProvider(seoulClock)
+			.getNow()
+			.orElseThrow();
+
+		assertThat(auditTime).isEqualTo(LocalDateTime.of(2026, 8, 13, 7, 30));
+	}
+}

--- a/src/test/java/kr/kro/airbob/config/KafkaConfigTest.java
+++ b/src/test/java/kr/kro/airbob/config/KafkaConfigTest.java
@@ -1,0 +1,41 @@
+package kr.kro.airbob.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.retrytopic.RetryTopicSchedulerWrapper;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@DisplayName("Kafka DLQ 설정 테스트")
+class KafkaConfigTest {
+
+	@Test
+	@DisplayName("DLQ 원문 JSON 문자열을 다시 JSON 문자열로 감싸지 않는다")
+	void usesStringSerializerForDlqValues() {
+		KafkaConfig config = new KafkaConfig();
+
+		DefaultKafkaProducerFactory<String, String> producerFactory =
+			(DefaultKafkaProducerFactory<String, String>)config.deadLetterProducerFactory(
+				new KafkaProperties());
+
+		assertThat(producerFactory.getConfigurationProperties()
+			.get(org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG))
+			.isEqualTo(StringSerializer.class);
+	}
+
+	@Test
+	@DisplayName("테스트 프로필에서도 비차단 재시도용 스케줄러를 제공한다")
+	void providesDedicatedRetryTopicScheduler() {
+		KafkaConfig config = new KafkaConfig();
+
+		RetryTopicSchedulerWrapper schedulerWrapper = config.retryTopicScheduler();
+
+		assertThat(schedulerWrapper.getScheduler())
+			.isInstanceOf(ThreadPoolTaskScheduler.class);
+		assertThat(((ThreadPoolTaskScheduler)schedulerWrapper.getScheduler()).getThreadNamePrefix())
+			.isEqualTo("kafka-retry-");
+	}
+}

--- a/src/test/java/kr/kro/airbob/config/SchedulingConfigTest.java
+++ b/src/test/java/kr/kro/airbob/config/SchedulingConfigTest.java
@@ -1,0 +1,21 @@
+package kr.kro.airbob.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+@DisplayName("스케줄러 설정 테스트")
+class SchedulingConfigTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withInitializer(context -> context.getEnvironment().setActiveProfiles("test"))
+		.withUserConfiguration(SchedulingConfig.class);
+
+	@Test
+	@DisplayName("test 프로필에서는 스케줄러를 활성화하지 않는다")
+	void doesNotEnableSchedulingInTestProfile() {
+		contextRunner.run(context -> assertThat(context).doesNotHaveBean(SchedulingConfig.class));
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/accommodation/AccommodationAmenityDeleteBenchmarkIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/AccommodationAmenityDeleteBenchmarkIntegrationTest.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -75,6 +76,7 @@ import kr.kro.airbob.geo.dto.GeocodeResult;
 	"benchmark.bulk-write.allowed-schema=airbob_bulk_write_benchmark"
 })
 @ActiveProfiles({"test", "bulk-write-benchmark"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("AccommodationAmenity 삭제 Before 벤치마크 MySQL 통합 테스트")
 class AccommodationAmenityDeleteBenchmarkIntegrationTest {
 	private static final String INACTIVE_AMENITY_CODE = "INACTIVE_TEST_AMENITY";
@@ -103,8 +105,6 @@ class AccommodationAmenityDeleteBenchmarkIntegrationTest {
 		registry.add("spring.datasource.password", MYSQL::getPassword);
 		registry.add("spring.data.redis.host", REDIS::getHost);
 		registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	@Autowired private AccommodationAmenityDeleteBenchmarkService benchmarkService;
@@ -765,7 +765,7 @@ class AccommodationAmenityDeleteBenchmarkIntegrationTest {
 		return jdbcTemplate.queryForMap("""
 			SELECT id, BIN_TO_UUID(accommodation_uid) AS accommodation_uid, member_id, name,
 			       description, base_price, currency, thumbnail_url, type,
-			       status, check_in_time, check_out_time, address_id, occupancy_policy_id,
+		       status, check_in_time, check_out_time, time_zone_id, address_id, occupancy_policy_id,
 			       created_at, updated_at, created_by, updated_by
 			FROM accommodation
 			WHERE id = ?
@@ -775,7 +775,8 @@ class AccommodationAmenityDeleteBenchmarkIntegrationTest {
 	private List<Map<String, Object>> historySnapshots(long accommodationId) {
 		return new ArrayList<>(jdbcTemplate.queryForList("""
 			SELECT id, accommodation_id, accommodation_uid, name, description, base_price,
-			       currency, thumbnail_url, type, status, check_in_time, check_out_time, member_id,
+		       currency, thumbnail_url, type, status, check_in_time, check_out_time, member_id,
+		       time_zone_id,
 			       address_country, address_state, address_city, address_district, address_street,
 			       address_detail, address_postal_code, address_latitude, address_longitude,
 			       max_occupancy, infant_occupancy, pet_occupancy, created_at, created_by,

--- a/src/test/java/kr/kro/airbob/domain/accommodation/api/AccommodationAvailabilityApiTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/api/AccommodationAvailabilityApiTest.java
@@ -1,0 +1,73 @@
+package kr.kro.airbob.domain.accommodation.api;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+
+import java.time.format.DateTimeFormatter;
+
+import kr.kro.airbob.domain.accommodation.dto.AccommodationResponse;
+import kr.kro.airbob.domain.accommodation.service.AccommodationCommandService;
+import kr.kro.airbob.domain.accommodation.service.AccommodationImageService;
+import kr.kro.airbob.domain.accommodation.service.AccommodationQueryService;
+
+@DisplayName("숙소 예약 가능 정보 API 테스트")
+class AccommodationAvailabilityApiTest {
+
+	private AccommodationQueryService accommodationQueryService;
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		accommodationQueryService = mock(AccommodationQueryService.class);
+		ObjectMapper objectMapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule()
+				.addSerializer(LocalDate.class, new LocalDateSerializer(DateTimeFormatter.ISO_LOCAL_DATE)))
+			.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+		AccommodationController controller = new AccommodationController(
+			mock(AccommodationCommandService.class),
+			mock(AccommodationImageService.class),
+			accommodationQueryService
+		);
+		mockMvc = MockMvcBuilders.standaloneSetup(controller)
+			.setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+			.build();
+	}
+
+	@Test
+	@DisplayName("숙소 ID의 예약 가능 기간과 예약 불가 구간을 반환한다")
+	void returnsAccommodationAvailability() throws Exception {
+		when(accommodationQueryService.findAccommodationAvailability(42L))
+			.thenReturn(new AccommodationResponse.Availability(
+				LocalDate.of(2026, 8, 13),
+				LocalDate.of(2026, 11, 13),
+				List.of(new AccommodationResponse.UnavailableDateRange(
+					LocalDate.of(2026, 8, 20),
+					LocalDate.of(2026, 8, 23)
+				))
+			));
+
+		mockMvc.perform(get("/api/v1/accommodations/42/availability"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.booking_window_start_inclusive").value("2026-08-13"))
+			.andExpect(jsonPath("$.data.booking_window_end_exclusive").value("2026-11-13"))
+			.andExpect(jsonPath("$.data.unavailable_ranges[0].start_date").value("2026-08-20"))
+			.andExpect(jsonPath("$.data.unavailable_ranges[0].end_date_exclusive").value("2026-08-23"));
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponseJsonTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponseJsonTest.java
@@ -3,6 +3,7 @@ package kr.kro.airbob.domain.accommodation.dto;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -68,5 +69,36 @@ class AccommodationResponseJsonTest {
 
 		assertThat(json.path("time_zone_id").asText()).isEqualTo("America/New_York");
 		assertThat(json.has("timeZoneId")).isFalse();
+	}
+
+	@Test
+	@DisplayName("호스트 상세에도 숙소 현지 시간대 식별자를 반환한다")
+	void serializesHostAccommodationTimeZoneId() {
+		Accommodation accommodation = mock(Accommodation.class);
+		when(accommodation.getTimeZoneId()).thenReturn("Europe/Paris");
+		AccommodationResponse.HostDetail response = AccommodationResponse.HostDetail.from(
+			accommodation,
+			List.of(),
+			List.of(),
+			null
+		);
+
+		JsonNode json = objectMapper.valueToTree(response);
+
+		assertThat(json.path("time_zone_id").asText()).isEqualTo("Europe/Paris");
+		assertThat(json.has("timeZoneId")).isFalse();
+	}
+
+	@Test
+	@DisplayName("최근 조회 시각을 UTC Instant 형식으로 반환한다")
+	void serializesRecentlyViewedAtAsUtcInstant() {
+		AccommodationResponse.RecentlyViewedAccommodationInfo response =
+			AccommodationResponse.RecentlyViewedAccommodationInfo.builder()
+				.viewedAt(Instant.parse("2026-08-12T05:30:00Z"))
+				.build();
+
+		JsonNode json = objectMapper.valueToTree(response);
+
+		assertThat(json.path("viewed_at").asText()).isEqualTo("2026-08-12T05:30:00Z");
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponseJsonTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponseJsonTest.java
@@ -27,7 +27,7 @@ class AccommodationResponseJsonTest {
 	@Test
 	@DisplayName("예약 가능 기간과 예약 불가 구간을 snake case로 반환한다")
 	void serializesBookingWindowAndUnavailableRanges() {
-		AccommodationResponse.DetailInfo response = AccommodationResponse.DetailInfo.builder()
+		AccommodationResponse.Availability response = AccommodationResponse.Availability.builder()
 			.bookingWindowStartInclusive(LocalDate.of(2026, 8, 1))
 			.bookingWindowEndExclusive(LocalDate.of(2026, 11, 1))
 			.unavailableRanges(List.of(
@@ -50,15 +50,25 @@ class AccommodationResponseJsonTest {
 	}
 
 	@Test
+	@DisplayName("숙소 상세 응답에는 예약 가능 정보가 포함되지 않는다")
+	void accommodationDetailExcludesAvailability() {
+		AccommodationResponse.DetailInfo response = AccommodationResponse.DetailInfo.builder()
+			.build();
+
+		JsonNode json = objectMapper.valueToTree(response);
+
+		assertThat(json.has("booking_window_start_inclusive")).isFalse();
+		assertThat(json.has("booking_window_end_exclusive")).isFalse();
+		assertThat(json.has("unavailable_ranges")).isFalse();
+	}
+
+	@Test
 	@DisplayName("숙소 현지 시간대 식별자를 snake case로 반환한다")
 	void serializesAccommodationTimeZoneIdInSnakeCase() {
 		Accommodation accommodation = mock(Accommodation.class);
 		when(accommodation.getTimeZoneId()).thenReturn("America/New_York");
 		AccommodationResponse.DetailInfo response = AccommodationResponse.DetailInfo.from(
 			accommodation,
-			LocalDate.of(2026, 8, 11),
-			LocalDate.of(2026, 11, 11),
-			List.of(),
 			false,
 			List.of(),
 			List.of(),

--- a/src/test/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponseJsonTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/dto/AccommodationResponseJsonTest.java
@@ -1,6 +1,7 @@
 package kr.kro.airbob.domain.accommodation.dto;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 
 @JsonTest
 @DisplayName("숙소 상세 응답 JSON 테스트")
@@ -43,5 +46,27 @@ class AccommodationResponseJsonTest {
 		assertThat(json.path("unavailable_ranges").path(0).path("end_date_exclusive").asText())
 			.isEqualTo("2026-08-04");
 		assertThat(json.has("unavailable_dates")).isFalse();
+	}
+
+	@Test
+	@DisplayName("숙소 현지 시간대 식별자를 snake case로 반환한다")
+	void serializesAccommodationTimeZoneIdInSnakeCase() {
+		Accommodation accommodation = mock(Accommodation.class);
+		when(accommodation.getTimeZoneId()).thenReturn("America/New_York");
+		AccommodationResponse.DetailInfo response = AccommodationResponse.DetailInfo.from(
+			accommodation,
+			LocalDate.of(2026, 8, 11),
+			LocalDate.of(2026, 11, 11),
+			List.of(),
+			false,
+			List.of(),
+			List.of(),
+			null
+		);
+
+		JsonNode json = objectMapper.valueToTree(response);
+
+		assertThat(json.path("time_zone_id").asText()).isEqualTo("America/New_York");
+		assertThat(json.has("timeZoneId")).isFalse();
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationBookingProjectionRepositoryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationBookingProjectionRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -29,6 +30,7 @@ import kr.kro.airbob.domain.member.repository.MemberRepository;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({JpaAuditingConfig.class, QueryDslConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("숙소 예약용 경량 조회 테스트")
 class AccommodationBookingProjectionRepositoryTest {
 

--- a/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationBookingProjectionRepositoryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationBookingProjectionRepositoryTest.java
@@ -19,6 +19,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import kr.kro.airbob.config.JpaAuditingConfig;
+import kr.kro.airbob.config.ClockConfig;
 import kr.kro.airbob.config.QueryDslConfig;
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
@@ -29,7 +30,7 @@ import kr.kro.airbob.domain.member.repository.MemberRepository;
 @Testcontainers
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+@Import({ClockConfig.class, JpaAuditingConfig.class, QueryDslConfig.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("숙소 예약용 경량 조회 테스트")
 class AccommodationBookingProjectionRepositoryTest {

--- a/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationBookingProjectionRepositoryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationBookingProjectionRepositoryTest.java
@@ -1,0 +1,88 @@
+package kr.kro.airbob.domain.accommodation.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import kr.kro.airbob.config.JpaAuditingConfig;
+import kr.kro.airbob.config.QueryDslConfig;
+import kr.kro.airbob.domain.accommodation.entity.Accommodation;
+import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
+import kr.kro.airbob.domain.member.entity.Member;
+import kr.kro.airbob.domain.member.repository.MemberRepository;
+
+@DataJpaTest
+@Testcontainers
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+@DisplayName("숙소 예약용 경량 조회 테스트")
+class AccommodationBookingProjectionRepositoryTest {
+
+	@Container
+	private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.33")
+		.withDatabaseName("airbobdb_accommodation_booking_projection");
+
+	@DynamicPropertySource
+	static void setProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+		registry.add("spring.datasource.username", MYSQL::getUsername);
+		registry.add("spring.datasource.password", MYSQL::getPassword);
+		registry.add("spring.flyway.url", MYSQL::getJdbcUrl);
+		registry.add("spring.flyway.user", MYSQL::getUsername);
+		registry.add("spring.flyway.password", MYSQL::getPassword);
+	}
+
+	@Autowired
+	private AccommodationRepository accommodationRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("게시 숙소의 시간대만 예약용 projection으로 조회한다")
+	void findsPublishedAccommodationTimeZoneOnly() {
+		Member host = memberRepository.save(Member.builder()
+			.email("booking-projection@test.com")
+			.nickname("booking-projection")
+			.build());
+		Accommodation published = saveAccommodation(host, AccommodationStatus.PUBLISHED, "America/New_York");
+		Accommodation draft = saveAccommodation(host, AccommodationStatus.DRAFT, "Asia/Seoul");
+
+		assertThat(accommodationRepository.findBookingProjectionByIdAndStatus(
+			published.getId(), AccommodationStatus.PUBLISHED))
+			.hasValueSatisfying(projection ->
+				assertThat(projection.timeZoneId()).isEqualTo("America/New_York"));
+		assertThat(accommodationRepository.findBookingProjectionByIdAndStatus(
+			draft.getId(), AccommodationStatus.PUBLISHED))
+			.isEmpty();
+	}
+
+	private Accommodation saveAccommodation(
+		Member host,
+		AccommodationStatus status,
+		String timeZoneId
+	) {
+		return accommodationRepository.save(Accommodation.builder()
+			.member(host)
+			.name("booking-projection-" + status)
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId(timeZoneId)
+			.status(status)
+			.build());
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationImageRepositoryQueryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationImageRepositoryQueryTest.java
@@ -27,6 +27,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import kr.kro.airbob.config.JpaAuditingConfig;
+import kr.kro.airbob.config.ClockConfig;
 import kr.kro.airbob.config.QueryDslConfig;
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
@@ -39,6 +40,7 @@ import kr.kro.airbob.domain.member.repository.MemberRepository;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
+	ClockConfig.class,
     JpaAuditingConfig.class,
     QueryDslConfig.class,
     AccommodationImageRepositoryQueryTest.SqlCaptureConfig.class

--- a/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationImageRepositoryQueryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/repository/AccommodationImageRepositoryQueryTest.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -42,6 +43,7 @@ import kr.kro.airbob.domain.member.repository.MemberRepository;
     QueryDslConfig.class,
     AccommodationImageRepositoryQueryTest.SqlCaptureConfig.class
 })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("숙소 이미지 저장소 쿼리 테스트")
 class AccommodationImageRepositoryQueryTest {
 

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationAmenityDeleteBeforeBenchmarkServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationAmenityDeleteBeforeBenchmarkServiceTest.java
@@ -5,6 +5,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.verify;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -34,11 +36,13 @@ class AccommodationAmenityDeleteBeforeBenchmarkServiceTest {
 	@Mock private AccommodationRepository accommodationRepository;
 	@Mock private AccommodationHistoryRepository accommodationHistoryRepository;
 	@Mock private CommonCodeService commonCodeService;
+	@Mock private Clock clock;
 	@InjectMocks private AccommodationAmenityDeleteBeforeBenchmarkService service;
 
 	@Test
 	@DisplayName("편의시설 코드는 JVM Locale과 무관하게 ASCII 대문자로 정규화한다")
 	void normalizeAmenityCodeWithRootLocale() {
+		given(clock.instant()).willReturn(Instant.parse("2026-08-12T05:30:00Z"));
 		Locale previousLocale = Locale.getDefault();
 		try {
 			Locale.setDefault(Locale.forLanguageTag("tr-TR"));

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationAmenityDeleteBenchmarkProfileTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationAmenityDeleteBenchmarkProfileTest.java
@@ -3,6 +3,8 @@ package kr.kro.airbob.domain.accommodation.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Clock;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -69,6 +71,7 @@ class AccommodationAmenityDeleteBenchmarkProfileTest {
 		}
 		@Bean JdbcTemplate jdbcTemplate() { return mock(JdbcTemplate.class); }
 		@Bean CommonCodeService commonCodeService() { return mock(CommonCodeService.class); }
+		@Bean Clock clock() { return Clock.systemUTC(); }
 		@Bean BulkOperationMonitor bulkOperationMonitor() { return mock(BulkOperationMonitor.class); }
 		@Bean BulkWriteBenchmarkDatabaseGuard databaseGuard() {
 			return mock(BulkWriteBenchmarkDatabaseGuard.class);

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandServiceTest.java
@@ -9,10 +9,13 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -236,6 +239,42 @@ class AccommodationCommandServiceTest {
 		assertThat(accommodation.getStatus()).isEqualTo(AccommodationStatus.DRAFT);
 	}
 
+	@ParameterizedTest(name = "{0} 고정 offset 식별자는 게시할 수 없다")
+	@ValueSource(strings = {"+09:00", "GMT+09:00"})
+	@DisplayName("IANA region ID가 아닌 고정 offset 시간대면 숙소 게시를 거부한다")
+	void rejectPublishingWithFixedOffsetTimeZoneId(String timeZoneId) {
+		Accommodation accommodation = publishableAccommodation(timeZoneId);
+
+		when(accommodationRepository.findWithDetailsExceptHostAndDeletedById(1L, 2L))
+			.thenReturn(Optional.of(accommodation));
+		lenient().when(accommodationImageRepository.countByAccommodationId(1L)).thenReturn(1L);
+
+		assertThatThrownBy(() -> accommodationCommandService.publishAccommodation(1L, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception -> {
+				assertThat(exception.getErrorCode().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("A003");
+			});
+		assertThat(accommodation.getStatus()).isEqualTo(AccommodationStatus.DRAFT);
+		verifyNoInteractions(outboxEventPublisher);
+	}
+
+	@Test
+	@DisplayName("공백 시간대 식별자면 숙소 게시를 거부한다")
+	void rejectPublishingWithBlankTimeZoneId() {
+		Accommodation accommodation = publishableAccommodation("   ");
+
+		when(accommodationRepository.findWithDetailsExceptHostAndDeletedById(1L, 2L))
+			.thenReturn(Optional.of(accommodation));
+
+		assertThatThrownBy(() -> accommodationCommandService.publishAccommodation(1L, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception -> {
+				assertThat(exception.getErrorCode().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("A003");
+			});
+		assertThat(accommodation.getStatus()).isEqualTo(AccommodationStatus.DRAFT);
+		verifyNoInteractions(outboxEventPublisher);
+	}
+
 	@Test
 	@DisplayName("유효하지 않은 숙소 유형은 A004와 400 응답용 예외로 거부한다")
 	void rejectInvalidAccommodationTypeAsBadRequest() {
@@ -336,6 +375,7 @@ class AccommodationCommandServiceTest {
 	private Accommodation publishableAccommodation(String timeZoneId) {
 		return Accommodation.builder()
 			.id(1L)
+			.accommodationUid(UUID.fromString("11111111-1111-1111-1111-111111111111"))
 			.name("게시 가능한 숙소")
 			.description("설명")
 			.basePrice(100_000L)

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandServiceTest.java
@@ -4,6 +4,8 @@ import static kr.kro.airbob.domain.commoncode.common.CommonCodeGroups.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -11,6 +13,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,6 +27,8 @@ import kr.kro.airbob.domain.accommodation.dto.PolicyRequest;
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationAmenity;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
+import kr.kro.airbob.domain.accommodation.entity.Address;
+import kr.kro.airbob.domain.accommodation.entity.OccupancyPolicy;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationAmenityRepository;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationHistoryRepository;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationImageRepository;
@@ -33,6 +38,8 @@ import kr.kro.airbob.domain.accommodation.repository.OccupancyPolicyRepository;
 import kr.kro.airbob.domain.commoncode.service.CommonCodeService;
 import kr.kro.airbob.domain.member.repository.MemberRepository;
 import kr.kro.airbob.geo.GeocodingService;
+import kr.kro.airbob.geo.TimeZoneResolver;
+import kr.kro.airbob.geo.dto.GeocodeResult;
 import kr.kro.airbob.outbox.OutboxEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,11 +54,187 @@ class AccommodationCommandServiceTest {
 	@Mock private OccupancyPolicyRepository occupancyPolicyRepository;
 	@Mock private CommonCodeService commonCodeService;
 	@Mock private GeocodingService geocodingService;
+	@Mock private TimeZoneResolver timeZoneResolver;
 	@Mock private MemberRepository memberRepository;
 	@Mock private OutboxEventPublisher outboxEventPublisher;
 
 	@InjectMocks
 	private AccommodationCommandService accommodationCommandService;
+
+	@Test
+	@DisplayName("주소가 바뀌면 해석된 좌표와 시간대를 함께 갱신한다")
+	void updateAddressAndTimeZoneTogether() {
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.name("기존 숙소")
+			.status(AccommodationStatus.DRAFT)
+			.build();
+		AddressRequest.AddressInfo addressInfo = seoulAddressInfo();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.addressInfo(addressInfo)
+			.build();
+		GeocodeResult geocodeResult = GeocodeResult.success(37.5665, 126.9780, "서울", null);
+
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(geocodingService.getCoordinates(anyString())).thenReturn(geocodeResult);
+		when(timeZoneResolver.resolve(37.5665, 126.9780)).thenReturn(Optional.of(ZoneId.of("Asia/Seoul")));
+		when(addressRepository.save(any(Address.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		accommodationCommandService.updateAccommodation(1L, request, 2L);
+
+		assertThat(accommodation.getAddress().getLatitude()).isEqualTo(37.5665);
+		assertThat(accommodation.getAddress().getLongitude()).isEqualTo(126.9780);
+		assertThat(accommodation.getTimeZoneId()).isEqualTo("Asia/Seoul");
+		InOrder resolutionOrder = inOrder(geocodingService, timeZoneResolver, addressRepository);
+		resolutionOrder.verify(geocodingService).getCoordinates(anyString());
+		resolutionOrder.verify(timeZoneResolver).resolve(37.5665, 126.9780);
+		resolutionOrder.verify(addressRepository).save(any(Address.class));
+	}
+
+	@Test
+	@DisplayName("지오코딩 실패는 A008로 거부하고 숙소와 주소를 바꾸지 않는다")
+	void rejectGeocodingFailureBeforeAnyMutation() {
+		Address currentAddress = Address.builder()
+			.country("KR")
+			.city("Busan")
+			.street("Old street")
+			.postalCode("48000")
+			.latitude(35.1796)
+			.longitude(129.0756)
+			.build();
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.name("기존 이름")
+			.address(currentAddress)
+			.status(AccommodationStatus.DRAFT)
+			.build();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.name("바뀐 이름")
+			.addressInfo(seoulAddressInfo())
+			.build();
+
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(geocodingService.getCoordinates(anyString())).thenReturn(GeocodeResult.fail());
+
+		assertThatThrownBy(() -> accommodationCommandService.updateAccommodation(1L, request, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception -> {
+				assertThat(exception.getErrorCode().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("A008");
+			});
+		assertThat(accommodation.getName()).isEqualTo("기존 이름");
+		assertThat(accommodation.getAddress()).isSameAs(currentAddress);
+		verifyNoInteractions(timeZoneResolver, addressRepository);
+	}
+
+	@Test
+	@DisplayName("게시 숙소의 시간대 해석 실패는 A008로 거부하고 전체 변경을 중단한다")
+	void rejectTimeZoneResolutionFailureForPublishedAccommodation() {
+		Address currentAddress = Address.builder()
+			.country("KR")
+			.city("Busan")
+			.street("Old street")
+			.postalCode("48000")
+			.latitude(35.1796)
+			.longitude(129.0756)
+			.build();
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.name("공개 중인 숙소")
+			.address(currentAddress)
+			.status(AccommodationStatus.PUBLISHED)
+			.build();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.name("바뀐 이름")
+			.addressInfo(seoulAddressInfo())
+			.build();
+		GeocodeResult geocodeResult = GeocodeResult.success(37.5665, 126.9780, "서울", null);
+
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(geocodingService.getCoordinates(anyString())).thenReturn(geocodeResult);
+		when(timeZoneResolver.resolve(37.5665, 126.9780)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> accommodationCommandService.updateAccommodation(1L, request, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception -> {
+				assertThat(exception.getErrorCode().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("A008");
+			});
+		assertThat(accommodation.getName()).isEqualTo("공개 중인 숙소");
+		assertThat(accommodation.getAddress()).isSameAs(currentAddress);
+		verifyNoInteractions(addressRepository, outboxEventPublisher);
+	}
+
+	@Test
+	@DisplayName("주소가 같아도 시간대가 없으면 위치를 다시 해석해 복구한다")
+	void recoverMissingTimeZoneEvenWhenAddressIsUnchanged() {
+		AddressRequest.AddressInfo addressInfo = seoulAddressInfo();
+		Address currentAddress = Address.builder()
+			.country(addressInfo.country())
+			.state(addressInfo.state())
+			.city(addressInfo.city())
+			.district(addressInfo.district())
+			.street(addressInfo.street())
+			.detail(addressInfo.detail())
+			.postalCode(addressInfo.postalCode())
+			.latitude(1.0)
+			.longitude(2.0)
+			.build();
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.address(currentAddress)
+			.status(AccommodationStatus.DRAFT)
+			.build();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.addressInfo(addressInfo)
+			.build();
+		GeocodeResult geocodeResult = GeocodeResult.success(37.5665, 126.9780, "서울", null);
+
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(geocodingService.getCoordinates(anyString())).thenReturn(geocodeResult);
+		when(timeZoneResolver.resolve(37.5665, 126.9780)).thenReturn(Optional.of(ZoneId.of("Asia/Seoul")));
+		when(addressRepository.save(any(Address.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		accommodationCommandService.updateAccommodation(1L, request, 2L);
+
+		assertThat(accommodation.getTimeZoneId()).isEqualTo("Asia/Seoul");
+		assertThat(accommodation.getAddress().getLatitude()).isEqualTo(37.5665);
+	}
+
+	@Test
+	@DisplayName("시간대가 없으면 숙소 게시를 거부한다")
+	void rejectPublishingWithoutTimeZone() {
+		Accommodation accommodation = publishableAccommodation();
+
+		when(accommodationRepository.findWithDetailsExceptHostAndDeletedById(1L, 2L))
+			.thenReturn(Optional.of(accommodation));
+
+		assertThatThrownBy(() -> accommodationCommandService.publishAccommodation(1L, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception -> {
+				assertThat(exception.getErrorCode().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("A003");
+			});
+		assertThat(accommodation.getStatus()).isEqualTo(AccommodationStatus.DRAFT);
+		verifyNoInteractions(outboxEventPublisher);
+	}
+
+	@Test
+	@DisplayName("IANA 식별자로 해석할 수 없는 시간대면 숙소 게시를 거부한다")
+	void rejectPublishingWithInvalidTimeZoneId() {
+		Accommodation accommodation = publishableAccommodation("Mars/Olympus_Mons");
+
+		when(accommodationRepository.findWithDetailsExceptHostAndDeletedById(1L, 2L))
+			.thenReturn(Optional.of(accommodation));
+
+		assertThatThrownBy(() -> accommodationCommandService.publishAccommodation(1L, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception -> {
+				assertThat(exception.getErrorCode().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("A003");
+			});
+		assertThat(accommodation.getStatus()).isEqualTo(AccommodationStatus.DRAFT);
+	}
 
 	@Test
 	@DisplayName("유효하지 않은 숙소 유형은 A004와 400 응답용 예외로 거부한다")
@@ -138,5 +321,43 @@ class AccommodationCommandServiceTest {
 		} finally {
 			Locale.setDefault(previousLocale);
 		}
+	}
+
+	private AddressRequest.AddressInfo seoulAddressInfo() {
+		return new AddressRequest.AddressInfo(
+			"04524", "KR", "Seoul", "Seoul", "Jung", "Sejong-daero", "110"
+		);
+	}
+
+	private Accommodation publishableAccommodation() {
+		return publishableAccommodation(null);
+	}
+
+	private Accommodation publishableAccommodation(String timeZoneId) {
+		return Accommodation.builder()
+			.id(1L)
+			.name("게시 가능한 숙소")
+			.description("설명")
+			.basePrice(100_000L)
+			.currency("KRW")
+			.type("ENTIRE_HOME")
+			.timeZoneId(timeZoneId)
+			.address(Address.builder()
+				.country("KR")
+				.city("Seoul")
+				.street("Sejong-daero")
+				.postalCode("04524")
+				.latitude(37.5665)
+				.longitude(126.9780)
+				.build())
+			.occupancyPolicy(OccupancyPolicy.builder()
+				.maxOccupancy(4)
+				.infantOccupancy(1)
+				.petOccupancy(0)
+				.build())
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.status(AccommodationStatus.DRAFT)
+			.build();
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationCommandServiceTest.java
@@ -4,6 +4,8 @@ import static kr.kro.airbob.domain.commoncode.common.CommonCodeGroups.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -12,6 +14,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,6 +43,7 @@ import kr.kro.airbob.domain.accommodation.repository.AddressRepository;
 import kr.kro.airbob.domain.accommodation.repository.OccupancyPolicyRepository;
 import kr.kro.airbob.domain.commoncode.service.CommonCodeService;
 import kr.kro.airbob.domain.member.repository.MemberRepository;
+import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.geo.GeocodingService;
 import kr.kro.airbob.geo.TimeZoneResolver;
 import kr.kro.airbob.geo.dto.GeocodeResult;
@@ -48,8 +52,10 @@ import kr.kro.airbob.outbox.OutboxEventPublisher;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("숙소 명령 서비스 단위 테스트")
 class AccommodationCommandServiceTest {
+	private static final Instant NOW = Instant.parse("2030-01-01T00:00:00Z");
 
 	@Mock private AccommodationRepository accommodationRepository;
+	@Mock private ReservationRepository reservationRepository;
 	@Mock private AccommodationAmenityRepository accommodationAmenityRepository;
 	@Mock private AccommodationHistoryRepository accommodationHistoryRepository;
 	@Mock private AccommodationImageRepository accommodationImageRepository;
@@ -60,9 +66,17 @@ class AccommodationCommandServiceTest {
 	@Mock private TimeZoneResolver timeZoneResolver;
 	@Mock private MemberRepository memberRepository;
 	@Mock private OutboxEventPublisher outboxEventPublisher;
+	@Mock private Clock clock;
 
 	@InjectMocks
 	private AccommodationCommandService accommodationCommandService;
+
+	@BeforeEach
+	void setUpClock() {
+		lenient().when(clock.instant()).thenReturn(NOW);
+		lenient().when(reservationRepository.existsFutureInventoryReservation(anyLong(), eq(NOW)))
+			.thenReturn(false);
+	}
 
 	@Test
 	@DisplayName("주소가 바뀌면 해석된 좌표와 시간대를 함께 갱신한다")
@@ -78,7 +92,7 @@ class AccommodationCommandServiceTest {
 			.build();
 		GeocodeResult geocodeResult = GeocodeResult.success(37.5665, 126.9780, "서울", null);
 
-		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(1L, 2L, AccommodationStatus.DELETED))
 			.thenReturn(Optional.of(accommodation));
 		when(geocodingService.getCoordinates(anyString())).thenReturn(geocodeResult);
 		when(timeZoneResolver.resolve(37.5665, 126.9780)).thenReturn(Optional.of(ZoneId.of("Asia/Seoul")));
@@ -117,7 +131,7 @@ class AccommodationCommandServiceTest {
 			.addressInfo(seoulAddressInfo())
 			.build();
 
-		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(1L, 2L, AccommodationStatus.DELETED))
 			.thenReturn(Optional.of(accommodation));
 		when(geocodingService.getCoordinates(anyString())).thenReturn(GeocodeResult.fail());
 
@@ -154,7 +168,7 @@ class AccommodationCommandServiceTest {
 			.build();
 		GeocodeResult geocodeResult = GeocodeResult.success(37.5665, 126.9780, "서울", null);
 
-		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(1L, 2L, AccommodationStatus.DELETED))
 			.thenReturn(Optional.of(accommodation));
 		when(geocodingService.getCoordinates(anyString())).thenReturn(geocodeResult);
 		when(timeZoneResolver.resolve(37.5665, 126.9780)).thenReturn(Optional.empty());
@@ -194,7 +208,7 @@ class AccommodationCommandServiceTest {
 			.build();
 		GeocodeResult geocodeResult = GeocodeResult.success(37.5665, 126.9780, "서울", null);
 
-		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(1L, 2L, AccommodationStatus.DELETED))
 			.thenReturn(Optional.of(accommodation));
 		when(geocodingService.getCoordinates(anyString())).thenReturn(geocodeResult);
 		when(timeZoneResolver.resolve(37.5665, 126.9780)).thenReturn(Optional.of(ZoneId.of("Asia/Seoul")));
@@ -283,7 +297,7 @@ class AccommodationCommandServiceTest {
 			.type("not_a_type")
 			.build();
 
-		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(1L, 2L, AccommodationStatus.DELETED))
 			.thenReturn(Optional.of(accommodation));
 		when(commonCodeService.isValidCode(ACCOMMODATION_TYPE, "NOT_A_TYPE"))
 			.thenReturn(false);
@@ -293,6 +307,73 @@ class AccommodationCommandServiceTest {
 				assertThat(exception.getErrorCode().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
 				assertThat(exception.getErrorCode().getCode()).isEqualTo("A004");
 			});
+	}
+
+	@Test
+	@DisplayName("체크아웃이 체크인보다 늦어 인접 숙박이 겹치는 시간 설정은 거부한다")
+	void rejectOverlappingTurnoverTimesOnUpdate() {
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.status(AccommodationStatus.DRAFT)
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.build();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.checkInTime(LocalTime.of(10, 0))
+			.checkOutTime(LocalTime.of(12, 0))
+			.build();
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
+			1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+
+		assertThatThrownBy(() -> accommodationCommandService.updateAccommodation(1L, request, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception ->
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("C001"));
+
+		assertThat(accommodation.getCheckInTime()).isEqualTo(LocalTime.of(15, 0));
+		assertThat(accommodation.getCheckOutTime()).isEqualTo(LocalTime.of(11, 0));
+		verifyNoInteractions(outboxEventPublisher);
+	}
+
+	@Test
+	@DisplayName("체크인만 수정해도 기존 체크아웃과 비교해 인접 숙박 겹침을 검증한다")
+	void rejectOverlappingTurnoverTimesOnPartialUpdate() {
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.status(AccommodationStatus.DRAFT)
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.build();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.checkInTime(LocalTime.of(10, 0))
+			.build();
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
+			1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+
+		assertThatThrownBy(() -> accommodationCommandService.updateAccommodation(1L, request, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception ->
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("C001"));
+
+		assertThat(accommodation.getCheckInTime()).isEqualTo(LocalTime.of(15, 0));
+		assertThat(accommodation.getCheckOutTime()).isEqualTo(LocalTime.of(11, 0));
+		verifyNoInteractions(outboxEventPublisher);
+	}
+
+	@Test
+	@DisplayName("인접 숙박의 실제 시각이 겹치는 숙소는 게시할 수 없다")
+	void rejectPublishingWithOverlappingTurnoverTimes() {
+		Accommodation accommodation = publishableAccommodation(
+			"Asia/Seoul", LocalTime.of(10, 0), LocalTime.of(12, 0));
+		when(accommodationRepository.findWithDetailsExceptHostAndDeletedById(1L, 2L))
+			.thenReturn(Optional.of(accommodation));
+
+		assertThatThrownBy(() -> accommodationCommandService.publishAccommodation(1L, 2L))
+			.isInstanceOfSatisfying(BaseException.class, exception ->
+				assertThat(exception.getErrorCode().getCode()).isEqualTo("A003"));
+
+		assertThat(accommodation.getStatus()).isEqualTo(AccommodationStatus.DRAFT);
+		verifyNoInteractions(outboxEventPublisher);
 	}
 
 	@Test
@@ -310,7 +391,7 @@ class AccommodationCommandServiceTest {
 			.occupancyPolicyInfo(new PolicyRequest.OccupancyPolicyInfo(4, 1, 0))
 			.build();
 
-		when(accommodationRepository.findByIdAndMemberIdAndStatusNot(1L, 2L, AccommodationStatus.DELETED))
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(1L, 2L, AccommodationStatus.DELETED))
 			.thenReturn(Optional.of(accommodation));
 		when(commonCodeService.isValidCode(eq(AMENITY_TYPE), anyString()))
 			.thenAnswer(invocation -> "WIFI".equals(invocation.getArgument(1)));
@@ -342,7 +423,7 @@ class AccommodationCommandServiceTest {
 				.amenityInfos(List.of(new AmenityRequest.AmenityInfo("wifi", 1)))
 				.build();
 
-			when(accommodationRepository.findByIdAndMemberIdAndStatusNot(
+			when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
 				1L, 2L, AccommodationStatus.DELETED))
 				.thenReturn(Optional.of(accommodation));
 			when(commonCodeService.isValidCode(ACCOMMODATION_TYPE, "PRIVATE_ROOM"))
@@ -362,6 +443,163 @@ class AccommodationCommandServiceTest {
 		}
 	}
 
+	@Test
+	@DisplayName("체크인 시간이 바뀌는 수정은 기존 예약 절대 시각을 보호하기 위해 거부한다")
+	void rejectCheckInTimeChangeThatInvalidatesReservationSnapshot() {
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.status(AccommodationStatus.PUBLISHED)
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId("Asia/Seoul")
+			.build();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.checkInTime(LocalTime.of(16, 0))
+			.build();
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
+			1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(clock.instant()).thenReturn(NOW);
+		when(reservationRepository.existsFutureInventoryReservation(1L, NOW)).thenReturn(true);
+
+		assertThatThrownBy(() -> accommodationCommandService.updateAccommodation(1L, request, 2L))
+			.isInstanceOf(kr.kro.airbob.common.exception.InvalidInputException.class);
+
+		assertThat(accommodation.getCheckInTime()).isEqualTo(LocalTime.of(15, 0));
+	}
+
+	@Test
+	@DisplayName("체크아웃 시간이 바뀌는 수정은 기존 예약 절대 시각을 보호하기 위해 거부한다")
+	void rejectCheckOutTimeChangeThatInvalidatesReservationSnapshot() {
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.accommodationUid(UUID.fromString("33333333-3333-3333-3333-333333333333"))
+			.status(AccommodationStatus.PUBLISHED)
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId("Asia/Seoul")
+			.build();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.checkOutTime(LocalTime.of(10, 0))
+			.build();
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
+			1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(reservationRepository.existsFutureInventoryReservation(1L, NOW)).thenReturn(true);
+
+		assertThatThrownBy(() -> accommodationCommandService.updateAccommodation(1L, request, 2L))
+			.isInstanceOf(kr.kro.airbob.common.exception.InvalidInputException.class);
+
+		assertThat(accommodation.getCheckOutTime()).isEqualTo(LocalTime.of(11, 0));
+	}
+
+	@Test
+	@DisplayName("주소 해석 결과 시간대가 바뀌면 기존 예약 절대 시각을 보호하기 위해 거부한다")
+	void rejectResolvedTimeZoneChangeThatInvalidatesReservationSnapshot() {
+		Address currentAddress = Address.builder()
+			.country("KR")
+			.city("Seoul")
+			.street("Old street")
+			.postalCode("04500")
+			.latitude(37.5)
+			.longitude(127.0)
+			.build();
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.address(currentAddress)
+			.status(AccommodationStatus.DRAFT)
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId("Asia/Seoul")
+			.build();
+		AddressRequest.AddressInfo addressInfo = new AddressRequest.AddressInfo(
+			"10001", "US", "New York", "NY", "Manhattan", "Broadway", "1");
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.addressInfo(addressInfo)
+			.build();
+		GeocodeResult geocodeResult = GeocodeResult.success(40.7128, -74.0060, "New York", null);
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
+			1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(geocodingService.getCoordinates(anyString())).thenReturn(geocodeResult);
+		when(timeZoneResolver.resolve(40.7128, -74.0060))
+			.thenReturn(Optional.of(ZoneId.of("America/New_York")));
+		when(reservationRepository.existsFutureInventoryReservation(1L, NOW)).thenReturn(true);
+
+		assertThatThrownBy(() -> accommodationCommandService.updateAccommodation(1L, request, 2L))
+			.isInstanceOf(kr.kro.airbob.common.exception.InvalidInputException.class);
+
+		assertThat(accommodation.getAddress()).isSameAs(currentAddress);
+		assertThat(accommodation.getTimeZoneId()).isEqualTo("Asia/Seoul");
+		verify(addressRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("주소가 바뀌어도 해석된 시간대가 같으면 미래 예약이 있어도 수정할 수 있다")
+	void allowAddressChangeWhenResolvedTimeZoneStaysTheSame() {
+		Address currentAddress = Address.builder()
+			.country("KR")
+			.city("Seoul")
+			.street("Old street")
+			.postalCode("04500")
+			.latitude(37.5)
+			.longitude(127.0)
+			.build();
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.accommodationUid(UUID.fromString("44444444-4444-4444-4444-444444444444"))
+			.address(currentAddress)
+			.status(AccommodationStatus.PUBLISHED)
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId("Asia/Seoul")
+			.build();
+		AddressRequest.AddressInfo addressInfo = new AddressRequest.AddressInfo(
+			"48000", "KR", "Busan", "Busan", "Haeundae", "Dalmaji-gil", "1");
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.addressInfo(addressInfo)
+			.build();
+		GeocodeResult geocodeResult = GeocodeResult.success(35.1796, 129.0756, "Busan", null);
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
+			1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(geocodingService.getCoordinates(anyString())).thenReturn(geocodeResult);
+		when(timeZoneResolver.resolve(35.1796, 129.0756))
+			.thenReturn(Optional.of(ZoneId.of("Asia/Seoul")));
+		when(addressRepository.save(any(Address.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		accommodationCommandService.updateAccommodation(1L, request, 2L);
+
+		assertThat(accommodation.getAddress().getCity()).isEqualTo("Busan");
+		assertThat(accommodation.getTimeZoneId()).isEqualTo("Asia/Seoul");
+		verify(reservationRepository, never()).existsFutureInventoryReservation(anyLong(), any());
+	}
+
+	@Test
+	@DisplayName("미래 유효 예약이 없으면 체크인 시간을 변경할 수 있다")
+	void allowCheckInTimeChangeWithoutFutureActiveReservation() {
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.accommodationUid(UUID.fromString("22222222-2222-2222-2222-222222222222"))
+			.status(AccommodationStatus.PUBLISHED)
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId("Asia/Seoul")
+			.build();
+		AccommodationRequest.Update request = AccommodationRequest.Update.builder()
+			.checkInTime(LocalTime.of(16, 0))
+			.build();
+		when(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
+			1L, 2L, AccommodationStatus.DELETED))
+			.thenReturn(Optional.of(accommodation));
+		when(clock.instant()).thenReturn(NOW);
+		when(reservationRepository.existsFutureInventoryReservation(1L, NOW)).thenReturn(false);
+
+		accommodationCommandService.updateAccommodation(1L, request, 2L);
+
+		assertThat(accommodation.getCheckInTime()).isEqualTo(LocalTime.of(16, 0));
+	}
+
 	private AddressRequest.AddressInfo seoulAddressInfo() {
 		return new AddressRequest.AddressInfo(
 			"04524", "KR", "Seoul", "Seoul", "Jung", "Sejong-daero", "110"
@@ -373,6 +611,15 @@ class AccommodationCommandServiceTest {
 	}
 
 	private Accommodation publishableAccommodation(String timeZoneId) {
+		return publishableAccommodation(
+			timeZoneId, LocalTime.of(15, 0), LocalTime.of(11, 0));
+	}
+
+	private Accommodation publishableAccommodation(
+		String timeZoneId,
+		LocalTime checkInTime,
+		LocalTime checkOutTime
+	) {
 		return Accommodation.builder()
 			.id(1L)
 			.accommodationUid(UUID.fromString("11111111-1111-1111-1111-111111111111"))
@@ -395,8 +642,8 @@ class AccommodationCommandServiceTest {
 				.infantOccupancy(1)
 				.petOccupancy(0)
 				.build())
-			.checkInTime(LocalTime.of(15, 0))
-			.checkOutTime(LocalTime.of(11, 0))
+			.checkInTime(checkInTime)
+			.checkOutTime(checkOutTime)
 			.status(AccommodationStatus.DRAFT)
 			.build();
 	}

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationDetailQueryCountTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationDetailQueryCountTest.java
@@ -28,6 +28,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import kr.kro.airbob.config.JpaAuditingConfig;
+import kr.kro.airbob.config.ClockConfig;
 import kr.kro.airbob.config.QueryDslConfig;
 import kr.kro.airbob.cursor.util.CursorPageInfoCreator;
 import kr.kro.airbob.domain.accommodation.dto.AccommodationResponse;
@@ -52,6 +53,7 @@ import kr.kro.airbob.outbox.OutboxEventPublisher;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
+	ClockConfig.class,
 	JpaAuditingConfig.class,
 	QueryDslConfig.class,
 	AccommodationQueryService.class

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationDetailQueryCountTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationDetailQueryCountTest.java
@@ -119,8 +119,8 @@ class AccommodationDetailQueryCountTest {
 	}
 
 	@Test
-	@DisplayName("공개 숙소 상세는 리뷰 요약을 포함해 SELECT 네 번으로 조회한다")
-	void findsPublicAccommodationDetailWithReviewSummaryInFourSelects() {
+	@DisplayName("공개 숙소 상세는 리뷰 요약을 포함해 SELECT 세 번으로 조회한다")
+	void findsPublicAccommodationDetailWithReviewSummaryInThreeSelects() {
 		Member host = saveHost("accommodation-detail-query");
 		Accommodation accommodation = savePublishedAccommodation(host, "query-count-accommodation");
 		saveReviewSummary(accommodation, 4, 18L, "4.50");
@@ -132,7 +132,7 @@ class AccommodationDetailQueryCountTest {
 		assertThat(response.reviewSummary().totalCount()).isEqualTo(4);
 		assertThat(response.reviewSummary().averageRating()).isEqualByComparingTo("4.50");
 		assertThat(response.timeZoneId()).isEqualTo("Asia/Seoul");
-		assertThat(statistics.getPrepareStatementCount()).isEqualTo(4);
+		assertThat(statistics.getPrepareStatementCount()).isEqualTo(3);
 	}
 
 	@Test
@@ -149,12 +149,12 @@ class AccommodationDetailQueryCountTest {
 
 		assertThat(response.reviewSummary().totalCount()).isZero();
 		assertThat(response.reviewSummary().averageRating()).isEqualByComparingTo(BigDecimal.ZERO);
-		assertThat(statistics.getPrepareStatementCount()).isEqualTo(4);
+		assertThat(statistics.getPrepareStatementCount()).isEqualTo(3);
 	}
 
 	@Test
-	@DisplayName("로그인한 공개 숙소 상세는 찜 조회를 포함해 SELECT 다섯 번으로 조회한다")
-	void findsAuthenticatedAccommodationDetailInFiveSelects() {
+	@DisplayName("로그인한 공개 숙소 상세는 찜 조회를 포함해 SELECT 네 번으로 조회한다")
+	void findsAuthenticatedAccommodationDetailInFourSelects() {
 		Member host = saveHost("authenticated-accommodation-detail-query");
 		Accommodation accommodation = savePublishedAccommodation(host, "authenticated-query-count-accommodation");
 		saveReviewSummary(accommodation, 2, 9L, "4.50");
@@ -164,7 +164,23 @@ class AccommodationDetailQueryCountTest {
 			accommodationQueryService.findAccommodation(accommodation.getId(), host.getId());
 
 		assertThat(response.isInWishlist()).isFalse();
-		assertThat(statistics.getPrepareStatementCount()).isEqualTo(5);
+		assertThat(statistics.getPrepareStatementCount()).isEqualTo(4);
+	}
+
+	@Test
+	@DisplayName("숙소 예약 가능 정보는 숙소 시간대와 예약 구간을 SELECT 두 번으로 조회한다")
+	void findsAccommodationAvailabilityInTwoSelects() {
+		Member host = saveHost("accommodation-availability-query");
+		Accommodation accommodation = savePublishedAccommodation(host, "availability-query-accommodation");
+		Statistics statistics = prepareQueryMeasurement();
+
+		AccommodationResponse.Availability response =
+			accommodationQueryService.findAccommodationAvailability(accommodation.getId());
+
+		assertThat(response.bookingWindowStartInclusive()).isEqualTo(LocalDate.of(2026, 8, 12));
+		assertThat(response.bookingWindowEndExclusive()).isEqualTo(LocalDate.of(2026, 11, 12));
+		assertThat(response.unavailableRanges()).isEmpty();
+		assertThat(statistics.getPrepareStatementCount()).isEqualTo(2);
 	}
 
 	private Member saveHost(String nickname) {

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationDetailQueryCountTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationDetailQueryCountTest.java
@@ -1,12 +1,15 @@
 package kr.kro.airbob.domain.accommodation.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +39,8 @@ import kr.kro.airbob.domain.commoncode.service.CommonCodeService;
 import kr.kro.airbob.domain.image.service.S3ImageUploader;
 import kr.kro.airbob.domain.member.entity.Member;
 import kr.kro.airbob.domain.member.repository.MemberRepository;
+import kr.kro.airbob.domain.reservation.policy.BookingWindow;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 import kr.kro.airbob.domain.review.entity.AccommodationReviewSummary;
 import kr.kro.airbob.domain.review.repository.AccommodationReviewSummaryRepository;
 import kr.kro.airbob.geo.GeocodingService;
@@ -100,6 +105,15 @@ class AccommodationDetailQueryCountTest {
 	@MockitoBean
 	private S3ImageUploader s3ImageUploader;
 
+	@MockitoBean
+	private BookingWindowProvider bookingWindowProvider;
+
+	@BeforeEach
+	void setUpBookingWindow() {
+		when(bookingWindowProvider.currentFor("Asia/Seoul"))
+			.thenReturn(BookingWindow.startingOn(LocalDate.of(2026, 8, 12)));
+	}
+
 	@Test
 	@DisplayName("공개 숙소 상세는 리뷰 요약을 포함해 SELECT 네 번으로 조회한다")
 	void findsPublicAccommodationDetailWithReviewSummaryInFourSelects() {
@@ -113,6 +127,7 @@ class AccommodationDetailQueryCountTest {
 
 		assertThat(response.reviewSummary().totalCount()).isEqualTo(4);
 		assertThat(response.reviewSummary().averageRating()).isEqualByComparingTo("4.50");
+		assertThat(response.timeZoneId()).isEqualTo("Asia/Seoul");
 		assertThat(statistics.getPrepareStatementCount()).isEqualTo(4);
 	}
 
@@ -170,6 +185,7 @@ class AccommodationDetailQueryCountTest {
 				.build())
 			.checkInTime(LocalTime.of(15, 0))
 			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId("Asia/Seoul")
 			.status(AccommodationStatus.PUBLISHED)
 			.build());
 	}

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationDetailQueryCountTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationDetailQueryCountTest.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -55,6 +56,7 @@ import kr.kro.airbob.outbox.OutboxEventPublisher;
 	QueryDslConfig.class,
 	AccommodationQueryService.class
 })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("숙소 상세 조회 쿼리 테스트")
 class AccommodationDetailQueryCountTest {
 

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryServiceTest.java
@@ -28,6 +28,7 @@ import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
 import kr.kro.airbob.domain.accommodation.repository.projection.AccommodationDetailProjection;
 import kr.kro.airbob.domain.reservation.dto.ReservationDateRange;
 import kr.kro.airbob.domain.reservation.policy.BookingWindow;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.domain.review.repository.AccommodationReviewSummaryRepository;
 import kr.kro.airbob.domain.wishlist.repository.WishlistAccommodationRepository;
@@ -35,6 +36,9 @@ import kr.kro.airbob.domain.wishlist.repository.WishlistAccommodationRepository;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("숙소 조회 서비스 단위 테스트")
 class AccommodationQueryServiceTest {
+	private static final String DEFAULT_TIME_ZONE_ID = "Asia/Seoul";
+	private static final LocalDate BOOKING_WINDOW_START = LocalDate.of(2026, 8, 12);
+	private static final BookingWindow BOOKING_WINDOW = BookingWindow.startingOn(BOOKING_WINDOW_START);
 
 	@Mock private AccommodationRepository accommodationRepository;
 	@Mock private AccommodationAmenityRepository accommodationAmenityRepository;
@@ -43,6 +47,7 @@ class AccommodationQueryServiceTest {
 	@Mock private ReservationRepository reservationRepository;
 	@Mock private WishlistAccommodationRepository wishlistAccommodationRepository;
 	@Mock private CursorPageInfoCreator cursorPageInfoCreator;
+	@Mock private BookingWindowProvider bookingWindowProvider;
 
 	@InjectMocks
 	private AccommodationQueryService accommodationQueryService;
@@ -73,6 +78,19 @@ class AccommodationQueryServiceTest {
 	}
 
 	@Test
+	@DisplayName("숙소 상세 조회는 숙소 현지 시간대의 예약 가능 기간을 반환한다")
+	void accommodationDetailUsesBookingWindowForAccommodationTimeZone() {
+		BookingWindow newYorkWindow = BookingWindow.startingOn(LocalDate.of(2026, 8, 11));
+		givenPublishedAccommodation(1L, "America/New_York", newYorkWindow);
+
+		AccommodationResponse.DetailInfo response = accommodationQueryService.findAccommodation(1L, null);
+
+		assertThat(response.bookingWindowStartInclusive()).isEqualTo(LocalDate.of(2026, 8, 11));
+		assertThat(response.bookingWindowEndExclusive()).isEqualTo(LocalDate.of(2026, 11, 11));
+		verify(bookingWindowProvider).currentFor("America/New_York");
+	}
+
+	@Test
 	@DisplayName("숙소 상세 조회는 이미지와 3개월 예약 구간을 숙소 ID로 조회한다")
 	void accommodationDetailUsesAccommodationIdForImagesAndReservations() {
 		givenPublishedAccommodation(1L);
@@ -97,7 +115,7 @@ class AccommodationQueryServiceTest {
 	@DisplayName("숙소 상세 예약은 숙박일을 펼치지 않고 checkout 제외 구간으로 반환한다")
 	void accommodationDetailReturnsUnavailableRangeWithoutExpandingDates() {
 		Long accommodationId = 1L;
-		LocalDate today = BookingWindow.current().startInclusive();
+		LocalDate today = BOOKING_WINDOW_START;
 		givenPublishedAccommodation(accommodationId);
 		when(reservationRepository.findConfirmedReservationRangesByAccommodationId(
 			eq(accommodationId), any(LocalDateTime.class), any(LocalDateTime.class)))
@@ -119,7 +137,7 @@ class AccommodationQueryServiceTest {
 	@DisplayName("숙소 상세 예약 불가 구간은 3개월 범위로 자르고 정렬해 합친다")
 	void accommodationDetailNormalizesUnavailableRangesWithinBookingWindow() {
 		Long accommodationId = 1L;
-		LocalDate windowStart = BookingWindow.current().startInclusive();
+		LocalDate windowStart = BOOKING_WINDOW_START;
 		LocalDate windowEndExclusive = windowStart.plusMonths(3);
 		givenPublishedAccommodation(accommodationId);
 		when(reservationRepository.findConfirmedReservationRangesByAccommodationId(
@@ -170,7 +188,15 @@ class AccommodationQueryServiceTest {
 		verify(accommodationImageRepository).findByAccommodationIdOrderByIdAsc(1L);
 	}
 
-	private void givenPublishedAccommodation(Long accommodationId) {
+	private Accommodation givenPublishedAccommodation(Long accommodationId) {
+		return givenPublishedAccommodation(accommodationId, DEFAULT_TIME_ZONE_ID, BOOKING_WINDOW);
+	}
+
+	private Accommodation givenPublishedAccommodation(
+		Long accommodationId,
+		String timeZoneId,
+		BookingWindow bookingWindow
+	) {
 		Accommodation accommodation = mock(Accommodation.class);
 
 		when(accommodationRepository.findWithDetailsByAccommodationIdAndStatus(
@@ -183,5 +209,8 @@ class AccommodationQueryServiceTest {
 		when(accommodationAmenityRepository.findAllByAccommodationId(accommodationId)).thenReturn(List.of());
 		when(accommodationImageRepository.findByAccommodationIdOrderByIdAsc(accommodationId))
 			.thenReturn(List.of());
+		when(accommodation.getTimeZoneId()).thenReturn(timeZoneId);
+		when(bookingWindowProvider.currentFor(timeZoneId)).thenReturn(bookingWindow);
+		return accommodation;
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -96,19 +95,20 @@ class AccommodationQueryServiceTest {
 		givenPublishedAccommodation(1L);
 
 		AccommodationResponse.DetailInfo response = accommodationQueryService.findAccommodation(1L, null);
-		ArgumentCaptor<LocalDateTime> windowStartCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
-		ArgumentCaptor<LocalDateTime> windowEndCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+		ArgumentCaptor<LocalDate> windowStartCaptor = ArgumentCaptor.forClass(LocalDate.class);
+		ArgumentCaptor<LocalDate> windowEndCaptor = ArgumentCaptor.forClass(LocalDate.class);
 
 		verify(accommodationImageRepository).findByAccommodationIdOrderByIdAsc(1L);
-		verify(reservationRepository).findConfirmedReservationRangesByAccommodationId(
+		verify(reservationRepository).findActiveReservationRangesByAccommodationId(
 			eq(1L), windowStartCaptor.capture(), windowEndCaptor.capture());
 		assertThat(windowEndCaptor.getValue()).isEqualTo(windowStartCaptor.getValue().plusMonths(3));
 		assertThat(response.bookingWindowStartInclusive())
-			.isEqualTo(windowStartCaptor.getValue().toLocalDate());
+			.isEqualTo(windowStartCaptor.getValue());
 		assertThat(response.bookingWindowEndExclusive())
-			.isEqualTo(windowEndCaptor.getValue().toLocalDate());
+			.isEqualTo(windowEndCaptor.getValue());
 		verify(reservationRepository, never())
-			.findFutureConfirmedReservationRangesByAccommodationUid(any(UUID.class));
+			.findActiveReservationRangesByAccommodationUid(
+				any(UUID.class), any(LocalDate.class), any(LocalDate.class));
 	}
 
 	@Test
@@ -117,11 +117,11 @@ class AccommodationQueryServiceTest {
 		Long accommodationId = 1L;
 		LocalDate today = BOOKING_WINDOW_START;
 		givenPublishedAccommodation(accommodationId);
-		when(reservationRepository.findConfirmedReservationRangesByAccommodationId(
-			eq(accommodationId), any(LocalDateTime.class), any(LocalDateTime.class)))
+		when(reservationRepository.findActiveReservationRangesByAccommodationId(
+			eq(accommodationId), any(LocalDate.class), any(LocalDate.class)))
 			.thenReturn(List.of(new ReservationDateRange(
-				today.plusDays(1).atTime(15, 0),
-				today.plusDays(4).atTime(11, 0)
+				today.plusDays(1),
+				today.plusDays(4)
 			)));
 
 		AccommodationResponse.DetailInfo response =
@@ -140,27 +140,27 @@ class AccommodationQueryServiceTest {
 		LocalDate windowStart = BOOKING_WINDOW_START;
 		LocalDate windowEndExclusive = windowStart.plusMonths(3);
 		givenPublishedAccommodation(accommodationId);
-		when(reservationRepository.findConfirmedReservationRangesByAccommodationId(
-			eq(accommodationId), any(LocalDateTime.class), any(LocalDateTime.class)))
+		when(reservationRepository.findActiveReservationRangesByAccommodationId(
+			eq(accommodationId), any(LocalDate.class), any(LocalDate.class)))
 			.thenReturn(List.of(
 				new ReservationDateRange(
-					windowEndExclusive.minusDays(1).atTime(15, 0),
-					windowEndExclusive.plusDays(5).atTime(11, 0)),
+					windowEndExclusive.minusDays(1),
+					windowEndExclusive.plusDays(5)),
 				new ReservationDateRange(
-					windowStart.plusDays(2).atTime(15, 0),
-					windowStart.plusDays(5).atTime(11, 0)),
+					windowStart.plusDays(2),
+					windowStart.plusDays(5)),
 				new ReservationDateRange(
-					windowStart.minusDays(2).atTime(15, 0),
-					windowStart.plusDays(3).atTime(11, 0)),
+					windowStart.minusDays(2),
+					windowStart.plusDays(3)),
 				new ReservationDateRange(
-					windowStart.plusDays(5).atTime(15, 0),
-					windowStart.plusDays(6).atTime(11, 0)),
+					windowStart.plusDays(5),
+					windowStart.plusDays(6)),
 				new ReservationDateRange(
-					windowStart.minusDays(2).atTime(15, 0),
-					windowStart.atTime(11, 0)),
+					windowStart.minusDays(2),
+					windowStart),
 				new ReservationDateRange(
-					windowEndExclusive.atTime(15, 0),
-					windowEndExclusive.plusDays(2).atTime(11, 0))
+					windowEndExclusive,
+					windowEndExclusive.plusDays(2))
 			));
 
 		AccommodationResponse.DetailInfo response =

--- a/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/accommodation/service/AccommodationQueryServiceTest.java
@@ -21,9 +21,11 @@ import kr.kro.airbob.cursor.util.CursorPageInfoCreator;
 import kr.kro.airbob.domain.accommodation.dto.AccommodationResponse;
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
+import kr.kro.airbob.domain.accommodation.exception.AccommodationNotFoundException;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationAmenityRepository;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationImageRepository;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
+import kr.kro.airbob.domain.accommodation.repository.projection.AccommodationBookingProjection;
 import kr.kro.airbob.domain.accommodation.repository.projection.AccommodationDetailProjection;
 import kr.kro.airbob.domain.reservation.dto.ReservationDateRange;
 import kr.kro.airbob.domain.reservation.policy.BookingWindow;
@@ -77,12 +79,13 @@ class AccommodationQueryServiceTest {
 	}
 
 	@Test
-	@DisplayName("숙소 상세 조회는 숙소 현지 시간대의 예약 가능 기간을 반환한다")
-	void accommodationDetailUsesBookingWindowForAccommodationTimeZone() {
+	@DisplayName("숙소 예약 가능 조회는 숙소 현지 시간대의 예약 가능 기간을 반환한다")
+	void accommodationAvailabilityUsesBookingWindowForAccommodationTimeZone() {
 		BookingWindow newYorkWindow = BookingWindow.startingOn(LocalDate.of(2026, 8, 11));
-		givenPublishedAccommodation(1L, "America/New_York", newYorkWindow);
+		givenPublishedAccommodationAvailability(1L, "America/New_York", newYorkWindow);
 
-		AccommodationResponse.DetailInfo response = accommodationQueryService.findAccommodation(1L, null);
+		AccommodationResponse.Availability response =
+			accommodationQueryService.findAccommodationAvailability(1L);
 
 		assertThat(response.bookingWindowStartInclusive()).isEqualTo(LocalDate.of(2026, 8, 11));
 		assertThat(response.bookingWindowEndExclusive()).isEqualTo(LocalDate.of(2026, 11, 11));
@@ -90,15 +93,26 @@ class AccommodationQueryServiceTest {
 	}
 
 	@Test
-	@DisplayName("숙소 상세 조회는 이미지와 3개월 예약 구간을 숙소 ID로 조회한다")
-	void accommodationDetailUsesAccommodationIdForImagesAndReservations() {
+	@DisplayName("숙소 상세 조회는 예약 정보를 조회하지 않는다")
+	void accommodationDetailSkipsAvailabilityLookup() {
 		givenPublishedAccommodation(1L);
 
-		AccommodationResponse.DetailInfo response = accommodationQueryService.findAccommodation(1L, null);
+		accommodationQueryService.findAccommodation(1L, null);
+
+		verify(accommodationImageRepository).findByAccommodationIdOrderByIdAsc(1L);
+		verifyNoInteractions(bookingWindowProvider, reservationRepository);
+	}
+
+	@Test
+	@DisplayName("숙소 예약 가능 조회는 3개월 예약 구간을 숙소 ID로 조회한다")
+	void accommodationAvailabilityUsesAccommodationIdForReservations() {
+		givenPublishedAccommodationAvailability(1L);
+
+		AccommodationResponse.Availability response =
+			accommodationQueryService.findAccommodationAvailability(1L);
 		ArgumentCaptor<LocalDate> windowStartCaptor = ArgumentCaptor.forClass(LocalDate.class);
 		ArgumentCaptor<LocalDate> windowEndCaptor = ArgumentCaptor.forClass(LocalDate.class);
 
-		verify(accommodationImageRepository).findByAccommodationIdOrderByIdAsc(1L);
 		verify(reservationRepository).findActiveReservationRangesByAccommodationId(
 			eq(1L), windowStartCaptor.capture(), windowEndCaptor.capture());
 		assertThat(windowEndCaptor.getValue()).isEqualTo(windowStartCaptor.getValue().plusMonths(3));
@@ -112,11 +126,11 @@ class AccommodationQueryServiceTest {
 	}
 
 	@Test
-	@DisplayName("숙소 상세 예약은 숙박일을 펼치지 않고 checkout 제외 구간으로 반환한다")
-	void accommodationDetailReturnsUnavailableRangeWithoutExpandingDates() {
+	@DisplayName("숙소 예약 가능 조회는 숙박일을 펼치지 않고 checkout 제외 구간으로 반환한다")
+	void accommodationAvailabilityReturnsRangeWithoutExpandingDates() {
 		Long accommodationId = 1L;
 		LocalDate today = BOOKING_WINDOW_START;
-		givenPublishedAccommodation(accommodationId);
+		givenPublishedAccommodationAvailability(accommodationId);
 		when(reservationRepository.findActiveReservationRangesByAccommodationId(
 			eq(accommodationId), any(LocalDate.class), any(LocalDate.class)))
 			.thenReturn(List.of(new ReservationDateRange(
@@ -124,8 +138,8 @@ class AccommodationQueryServiceTest {
 				today.plusDays(4)
 			)));
 
-		AccommodationResponse.DetailInfo response =
-			accommodationQueryService.findAccommodation(accommodationId, null);
+		AccommodationResponse.Availability response =
+			accommodationQueryService.findAccommodationAvailability(accommodationId);
 
 		assertThat(response.bookingWindowEndExclusive()).isEqualTo(today.plusMonths(3));
 		assertThat(response.unavailableRanges()).containsExactly(
@@ -134,12 +148,12 @@ class AccommodationQueryServiceTest {
 	}
 
 	@Test
-	@DisplayName("숙소 상세 예약 불가 구간은 3개월 범위로 자르고 정렬해 합친다")
-	void accommodationDetailNormalizesUnavailableRangesWithinBookingWindow() {
+	@DisplayName("숙소 예약 불가 구간은 3개월 범위로 자르고 정렬해 합친다")
+	void accommodationAvailabilityNormalizesRangesWithinBookingWindow() {
 		Long accommodationId = 1L;
 		LocalDate windowStart = BOOKING_WINDOW_START;
 		LocalDate windowEndExclusive = windowStart.plusMonths(3);
-		givenPublishedAccommodation(accommodationId);
+		givenPublishedAccommodationAvailability(accommodationId);
 		when(reservationRepository.findActiveReservationRangesByAccommodationId(
 			eq(accommodationId), any(LocalDate.class), any(LocalDate.class)))
 			.thenReturn(List.of(
@@ -163,14 +177,25 @@ class AccommodationQueryServiceTest {
 					windowEndExclusive.plusDays(2))
 			));
 
-		AccommodationResponse.DetailInfo response =
-			accommodationQueryService.findAccommodation(accommodationId, null);
+		AccommodationResponse.Availability response =
+			accommodationQueryService.findAccommodationAvailability(accommodationId);
 
 		assertThat(response.unavailableRanges()).containsExactly(
 			new AccommodationResponse.UnavailableDateRange(windowStart, windowStart.plusDays(6)),
 			new AccommodationResponse.UnavailableDateRange(
 				windowEndExclusive.minusDays(1), windowEndExclusive)
 		);
+	}
+
+	@Test
+	@DisplayName("게시되지 않은 숙소의 예약 가능 정보는 조회할 수 없다")
+	void accommodationAvailabilityRequiresPublishedAccommodation() {
+		when(accommodationRepository.findBookingProjectionByIdAndStatus(
+			1L, AccommodationStatus.PUBLISHED)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> accommodationQueryService.findAccommodationAvailability(1L))
+			.isInstanceOf(AccommodationNotFoundException.class);
+		verifyNoInteractions(bookingWindowProvider, reservationRepository);
 	}
 
 	@Test
@@ -189,14 +214,6 @@ class AccommodationQueryServiceTest {
 	}
 
 	private Accommodation givenPublishedAccommodation(Long accommodationId) {
-		return givenPublishedAccommodation(accommodationId, DEFAULT_TIME_ZONE_ID, BOOKING_WINDOW);
-	}
-
-	private Accommodation givenPublishedAccommodation(
-		Long accommodationId,
-		String timeZoneId,
-		BookingWindow bookingWindow
-	) {
 		Accommodation accommodation = mock(Accommodation.class);
 
 		when(accommodationRepository.findWithDetailsByAccommodationIdAndStatus(
@@ -209,8 +226,21 @@ class AccommodationQueryServiceTest {
 		when(accommodationAmenityRepository.findAllByAccommodationId(accommodationId)).thenReturn(List.of());
 		when(accommodationImageRepository.findByAccommodationIdOrderByIdAsc(accommodationId))
 			.thenReturn(List.of());
-		when(accommodation.getTimeZoneId()).thenReturn(timeZoneId);
-		when(bookingWindowProvider.currentFor(timeZoneId)).thenReturn(bookingWindow);
 		return accommodation;
+	}
+
+	private void givenPublishedAccommodationAvailability(Long accommodationId) {
+		givenPublishedAccommodationAvailability(accommodationId, DEFAULT_TIME_ZONE_ID, BOOKING_WINDOW);
+	}
+
+	private void givenPublishedAccommodationAvailability(
+		Long accommodationId,
+		String timeZoneId,
+		BookingWindow bookingWindow
+	) {
+		when(accommodationRepository.findBookingProjectionByIdAndStatus(
+			accommodationId, AccommodationStatus.PUBLISHED))
+			.thenReturn(Optional.of(new AccommodationBookingProjection(timeZoneId)));
+		when(bookingWindowProvider.currentFor(timeZoneId)).thenReturn(bookingWindow);
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/auth/filter/SessionAuthFilterPublicPathTest.java
+++ b/src/test/java/kr/kro/airbob/domain/auth/filter/SessionAuthFilterPublicPathTest.java
@@ -18,6 +18,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 class SessionAuthFilterPublicPathTest {
 
 	@Test
+	@DisplayName("숙소 예약 가능 정보 GET은 익명 요청을 필터 체인에 전달한다")
+	void anonymousAccommodationAvailabilityGetPassesFilterChain() throws Exception {
+		SessionAuthFilter filter = createFilter();
+		MockHttpServletRequest request = new MockHttpServletRequest(
+			"GET",
+			"/api/v1/accommodations/42/availability"
+		);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+
+		filter.doFilter(request, response, chain);
+
+		assertThat(chain.getRequest()).isSameAs(request);
+		assertThat(response.getStatus()).isEqualTo(200);
+	}
+
+	@Test
 	@DisplayName("v2 리뷰 요약 GET은 익명 요청을 필터 체인에 전달한다")
 	void anonymousV2ReviewSummaryGetPassesFilterChain() throws Exception {
 		SessionAuthFilter filter = createFilter();

--- a/src/test/java/kr/kro/airbob/domain/commoncode/service/CommonCodeAdminServiceIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/commoncode/service/CommonCodeAdminServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.test.context.ActiveProfiles;
@@ -45,6 +46,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("공통 코드 관리 서비스 통합 테스트")
 class CommonCodeAdminServiceIntegrationTest {
 
@@ -76,8 +78,6 @@ class CommonCodeAdminServiceIntegrationTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	@Test

--- a/src/test/java/kr/kro/airbob/domain/commoncode/service/CommonCodeServiceIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/commoncode/service/CommonCodeServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -33,6 +34,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("공통 코드 서비스 통합 테스트")
 class CommonCodeServiceIntegrationTest {
 
@@ -62,8 +64,6 @@ class CommonCodeServiceIntegrationTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	@Test

--- a/src/test/java/kr/kro/airbob/domain/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/CouponConcurrencyTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -63,6 +64,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 	"benchmark.read-model.token=test-token"
 })
 @ActiveProfiles({"test", "coupon-benchmark"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CouponConcurrencyTest {
 
 	private static final int THREAD_COUNT = 100;
@@ -117,8 +119,6 @@ class CouponConcurrencyTest {
 		registry.add("spring.flyway.password", MYSQL::getPassword);
 		registry.add("spring.data.redis.host", REDIS::getHost);
 		registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private Coupon lockCoupon;

--- a/src/test/java/kr/kro/airbob/domain/coupon/CouponRestoreTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/CouponRestoreTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -37,6 +38,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CouponRestoreTest {
 
 	private static final long RESERVATION_ID = 100L;
@@ -78,9 +80,6 @@ class CouponRestoreTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private Member member;

--- a/src/test/java/kr/kro/airbob/domain/coupon/CouponUsageConcurrencyTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/CouponUsageConcurrencyTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -44,6 +45,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CouponUsageConcurrencyTest {
 
 	private static final int THREAD_COUNT = 20;
@@ -85,9 +87,6 @@ class CouponUsageConcurrencyTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private Member member;

--- a/src/test/java/kr/kro/airbob/domain/coupon/repository/CouponLegacyIssuanceQueryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/repository/CouponLegacyIssuanceQueryTest.java
@@ -12,6 +12,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -24,6 +25,7 @@ import kr.kro.airbob.config.QueryDslConfig;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({JpaAuditingConfig.class, QueryDslConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("기존 쿠폰 발급 배포 차단 쿼리 테스트")
 class CouponLegacyIssuanceQueryTest {
 

--- a/src/test/java/kr/kro/airbob/domain/coupon/repository/CouponLegacyIssuanceQueryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/repository/CouponLegacyIssuanceQueryTest.java
@@ -18,13 +18,14 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import kr.kro.airbob.config.JpaAuditingConfig;
+import kr.kro.airbob.config.ClockConfig;
 import kr.kro.airbob.config.QueryDslConfig;
 
 @DataJpaTest
 @Testcontainers
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+@Import({ClockConfig.class, JpaAuditingConfig.class, QueryDslConfig.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("기존 쿠폰 발급 배포 차단 쿼리 테스트")
 class CouponLegacyIssuanceQueryTest {

--- a/src/test/java/kr/kro/airbob/domain/history/HistorySnapshotIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/history/HistorySnapshotIntegrationTest.java
@@ -2,6 +2,7 @@ package kr.kro.airbob.domain.history;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -54,6 +56,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("이력 테이블 SCD2 동작 통합 테스트")
 class HistorySnapshotIntegrationTest {
 
@@ -90,8 +93,6 @@ class HistorySnapshotIntegrationTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	@BeforeEach
@@ -113,7 +114,7 @@ class HistorySnapshotIntegrationTest {
 			.build();
 
 		AccommodationHistory history = AccommodationHistory.of(
-			accommodation, ChangeType.UPDATE, "시간대 변경"
+			accommodation, ChangeType.UPDATE, "시간대 변경", LocalDateTime.of(2026, 8, 12, 0, 0)
 		);
 
 		assertThat(history.getTimeZoneId()).isEqualTo("America/New_York");

--- a/src/test/java/kr/kro/airbob/domain/history/HistorySnapshotIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/history/HistorySnapshotIntegrationTest.java
@@ -36,6 +36,7 @@ import kr.kro.airbob.common.history.ChangeType;
 import kr.kro.airbob.common.history.HistoryConstants;
 import kr.kro.airbob.domain.accommodation.dto.AccommodationResponse;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationHistory;
+import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationHistoryRepository;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
@@ -100,6 +101,22 @@ class HistorySnapshotIntegrationTest {
 		memberHistoryRepository.deleteAllInBatch();
 		accommodationRepository.deleteAllInBatch();
 		memberRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("숙소 이력 스냅샷은 원본 숙소의 시간대 식별자를 복사한다")
+	void accommodationHistoryCopiesTimeZoneId() {
+		Accommodation accommodation = Accommodation.builder()
+			.id(1L)
+			.timeZoneId("America/New_York")
+			.status(AccommodationStatus.DRAFT)
+			.build();
+
+		AccommodationHistory history = AccommodationHistory.of(
+			accommodation, ChangeType.UPDATE, "시간대 변경"
+		);
+
+		assertThat(history.getTimeZoneId()).isEqualTo("America/New_York");
 	}
 
 	@Test

--- a/src/test/java/kr/kro/airbob/domain/member/MemberRoleManagementIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/member/MemberRoleManagementIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.orm.jpa.EntityManagerHolder;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -56,6 +58,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("회원 역할 관리 통합 테스트")
 class MemberRoleManagementIntegrationTest {
 
@@ -93,8 +96,6 @@ class MemberRoleManagementIntegrationTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	@BeforeEach
@@ -318,7 +319,7 @@ class MemberRoleManagementIntegrationTest {
 
 	private void createCurrentHistory(Member member, String reason) {
 		memberHistoryRepository.saveAndFlush(MemberHistory.openSystem(
-			member, ChangeType.CREATE, reason, "TEST"));
+			member, ChangeType.CREATE, reason, "TEST", LocalDateTime.now()));
 	}
 
 	private void changeRoleAs(Long actorId, Long targetId, MemberRole role, String reason) {

--- a/src/test/java/kr/kro/airbob/domain/member/service/MemberAdminServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/member/service/MemberAdminServiceTest.java
@@ -9,7 +9,10 @@ import static org.mockito.Mockito.mock;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import kr.kro.airbob.common.history.ChangeType;
@@ -36,6 +39,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MemberAdminServiceTest {
 
+	private static final Instant NOW = Instant.parse("2026-08-12T05:30:00Z");
+	private static final Clock FIXED_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
 	@Mock
 	private MemberRepository memberRepository;
 	@Mock
@@ -46,7 +52,7 @@ class MemberAdminServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		service = new MemberAdminService(memberRepository, memberHistoryRepository, entityManager);
+		service = new MemberAdminService(memberRepository, memberHistoryRepository, entityManager, FIXED_CLOCK);
 	}
 
 	@Test
@@ -245,6 +251,9 @@ class MemberAdminServiceTest {
 		assertThat(savedHistory.getRole()).isEqualTo(MemberRole.ADMIN);
 		assertThat(savedHistory.getChangeType()).isEqualTo(ChangeType.ROLE_CHANGE);
 		assertThat(savedHistory.getChangeReason()).isEqualTo("운영 관리자 지정");
+		LocalDateTime expected = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC);
+		assertThat(currentHistory.getValidTo()).isEqualTo(expected);
+		assertThat(savedHistory.getValidFrom()).isEqualTo(expected);
 		assertThat(savedHistory.getValidTo()).isEqualTo(HistoryConstants.FOREVER);
 	}
 

--- a/src/test/java/kr/kro/airbob/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/member/service/MemberServiceTest.java
@@ -8,6 +8,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import kr.kro.airbob.common.history.HistoryConstants;
@@ -31,6 +35,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
+    private static final Instant NOW = Instant.parse("2026-08-12T05:30:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
     @Mock
     private MemberRepository memberRepository;
     @Mock
@@ -42,7 +49,8 @@ class MemberServiceTest {
 
     @Test
     void createMemberStoresBCryptPasswordHash() {
-        MemberService memberService = new MemberService(memberRepository, historyRepository, sessionInvalidator);
+        MemberService memberService = new MemberService(
+            memberRepository, historyRepository, sessionInvalidator, FIXED_CLOCK);
         MemberRequest.Signup request = MemberRequest.Signup.builder()
             .email("guest@airbob.test")
             .nickname("guest")
@@ -62,7 +70,8 @@ class MemberServiceTest {
 
     @Test
     void deleteMemberRevokesAllSessions() {
-        MemberService memberService = new MemberService(memberRepository, historyRepository, sessionInvalidator);
+        MemberService memberService = new MemberService(
+            memberRepository, historyRepository, sessionInvalidator, FIXED_CLOCK);
         Member member = Member.builder()
             .id(10L)
             .email("guest@airbob.test")
@@ -81,8 +90,37 @@ class MemberServiceTest {
     }
 
     @Test
+    void deleteMemberClosesAndOpensHistoryAtSameUtcTime() {
+        MemberService memberService = new MemberService(
+            memberRepository, historyRepository, sessionInvalidator, FIXED_CLOCK);
+        Member member = Member.builder()
+            .id(10L)
+            .status(MemberStatus.ACTIVE)
+            .build();
+        MemberHistory currentHistory = MemberHistory.builder()
+            .memberId(10L)
+            .status(MemberStatus.ACTIVE)
+            .changeType(kr.kro.airbob.common.history.ChangeType.CREATE)
+            .validFrom(LocalDateTime.of(2026, 8, 1, 0, 0))
+            .validTo(HistoryConstants.FOREVER)
+            .build();
+        given(memberRepository.findByIdForUpdate(10L)).willReturn(Optional.of(member));
+        given(historyRepository.findByMemberIdAndValidTo(10L, HistoryConstants.FOREVER))
+            .willReturn(Optional.of(currentHistory));
+        ArgumentCaptor<MemberHistory> historyCaptor = ArgumentCaptor.forClass(MemberHistory.class);
+
+        memberService.deleteMember(10L, "사용자 탈퇴");
+
+        LocalDateTime expected = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC);
+        assertThat(currentHistory.getValidTo()).isEqualTo(expected);
+        then(historyRepository).should().save(historyCaptor.capture());
+        assertThat(historyCaptor.getValue().getValidFrom()).isEqualTo(expected);
+    }
+
+    @Test
     void getMemberInfoReturnsActiveMemberProfile() {
-        MemberService service = new MemberService(memberRepository, historyRepository, sessionInvalidator);
+        MemberService service = new MemberService(
+            memberRepository, historyRepository, sessionInvalidator, FIXED_CLOCK);
         Member member = Member.builder()
             .id(10L)
             .email("guest@airbob.test")
@@ -103,7 +141,8 @@ class MemberServiceTest {
 
     @Test
     void getMemberInfoRejectsMissingOrInactiveMember() {
-        MemberService service = new MemberService(memberRepository, historyRepository, sessionInvalidator);
+        MemberService service = new MemberService(
+            memberRepository, historyRepository, sessionInvalidator, FIXED_CLOCK);
         given(memberRepository.findByIdAndStatus(10L, MemberStatus.ACTIVE))
             .willReturn(Optional.empty());
 

--- a/src/test/java/kr/kro/airbob/domain/payment/dto/PaymentRequestValidationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/dto/PaymentRequestValidationTest.java
@@ -1,0 +1,24 @@
+package kr.kro.airbob.domain.payment.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+class PaymentRequestValidationTest {
+
+	private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+	@Test
+	void 결제키가_200자를_초과하면_거부한다() {
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"p".repeat(201), UUID.randomUUID().toString(), 10_000);
+
+		assertThat(validator.validate(request))
+			.anyMatch(violation -> violation.getPropertyPath().toString().equals("paymentKey"));
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/payment/dto/PaymentResponseTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/dto/PaymentResponseTest.java
@@ -1,0 +1,88 @@
+package kr.kro.airbob.domain.payment.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.kro.airbob.domain.payment.entity.Payment;
+import kr.kro.airbob.domain.payment.entity.PaymentMethod;
+import kr.kro.airbob.domain.payment.entity.PaymentStatus;
+import kr.kro.airbob.domain.payment.entity.PaymentTransaction;
+import kr.kro.airbob.domain.payment.entity.PaymentTransactionType;
+
+@JsonTest
+@DisplayName("결제 응답 시간 테스트")
+class PaymentResponseTest {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("승인 시각과 UTC 감사 시각을 offset이 있는 절대 시각으로 응답한다")
+	void paymentInfoUsesInstants() {
+		Payment payment = Payment.builder()
+			.paymentKey("payment-key")
+			.orderId("order-id")
+			.amount(100_000L)
+			.balanceAmount(100_000L)
+			.method(PaymentMethod.CARD)
+			.status(PaymentStatus.DONE)
+			.approvedAt(Instant.parse("2026-08-12T05:30:00.123456Z"))
+			.createdAt(LocalDateTime.of(2026, 8, 12, 5, 29))
+			.build();
+
+		PaymentResponse.PaymentInfo response = PaymentResponse.PaymentInfo.from(payment, List.of());
+
+		assertThat(response.requestedAt()).isEqualTo(Instant.parse("2026-08-12T05:29:00Z"));
+		assertThat(response.approvedAt()).isEqualTo(Instant.parse("2026-08-12T05:30:00.123456Z"));
+	}
+
+	@Test
+	@DisplayName("취소 시각과 가상계좌 만료 시각을 절대 시각으로 응답한다")
+	void transactionTimesUseInstants() {
+		Instant canceledAt = Instant.parse("2026-08-12T06:00:00.123456Z");
+		Instant dueDate = Instant.parse("2026-08-13T14:30:00.654321Z");
+		PaymentTransaction transaction = PaymentTransaction.builder()
+			.transactionType(PaymentTransactionType.CANCEL)
+			.cancelAmount(100_000L)
+			.cancelReason("사용자 요청")
+			.canceledAt(canceledAt)
+			.virtualDueDate(dueDate)
+			.createdAt(LocalDateTime.of(2026, 8, 12, 5, 59))
+			.build();
+
+		PaymentResponse.CancelInfo cancelInfo = PaymentResponse.CancelInfo.from(transaction);
+		PaymentResponse.VirtualAccountInfo virtualAccountInfo =
+			PaymentResponse.VirtualAccountInfo.from(transaction);
+
+		assertThat(cancelInfo.canceledAt()).isEqualTo(canceledAt);
+		assertThat(virtualAccountInfo.dueDate()).isEqualTo(dueDate);
+	}
+
+	@Test
+	@DisplayName("결제 API의 모든 절대 시각은 ISO-8601 UTC Z 문자열로 직렬화한다")
+	void serializesAbsoluteTimesWithUtcOffset() throws Exception {
+		PaymentResponse.PaymentInfo response = PaymentResponse.PaymentInfo.builder()
+			.orderId("order-id")
+			.status(PaymentStatus.DONE)
+			.requestedAt(Instant.parse("2026-08-12T05:29:00.123456Z"))
+			.approvedAt(Instant.parse("2026-08-12T05:30:00.654321Z"))
+			.build();
+		JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+		assertThat(json.path("requested_at").asText())
+			.isEqualTo("2026-08-12T05:29:00.123456Z");
+		assertThat(json.path("approved_at").asText())
+			.isEqualTo("2026-08-12T05:30:00.654321Z");
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/payment/entity/PaymentTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/entity/PaymentTest.java
@@ -2,6 +2,8 @@ package kr.kro.airbob.domain.payment.entity;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -69,6 +71,21 @@ class PaymentTest {
 			// then
 			assertThat(payment.getBalanceAmount()).isEqualTo(100_000L);
 			assertThat(payment.getBalanceAmount()).isEqualTo(payment.getAmount());
+		}
+
+		@Test
+		@DisplayName("Toss 승인 시각은 offset을 보존한 절대 시각으로 변환된다")
+		void 승인_시각_offset_보존() {
+			ZonedDateTime approvedAt = ZonedDateTime.of(
+				2026, 8, 12, 14, 30, 0, 123_456_000,
+				ZoneId.of("Asia/Seoul")
+			);
+			tossResponse.setApprovedAt(approvedAt);
+
+			Payment payment = Payment.create(tossResponse, reservation);
+
+			assertThat(payment.getApprovedAt())
+				.isEqualTo(Instant.parse("2026-08-12T05:30:00.123456Z"));
 		}
 
 		@Test

--- a/src/test/java/kr/kro/airbob/domain/payment/entity/PaymentTransactionTimeTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/entity/PaymentTransactionTimeTest.java
@@ -1,0 +1,77 @@
+package kr.kro.airbob.domain.payment.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kr.kro.airbob.domain.payment.dto.TossPaymentResponse;
+import kr.kro.airbob.domain.reservation.entity.Reservation;
+
+@DisplayName("결제 거래 시각 테스트")
+class PaymentTransactionTimeTest {
+
+	@Test
+	@DisplayName("가상계좌 만료 시각은 offset을 보존한 절대 시각으로 저장한다")
+	void virtualAccountDueDatePreservesOffset() {
+		Reservation reservation = reservation();
+		ZonedDateTime dueDate = ZonedDateTime.of(
+			2026, 8, 13, 23, 30, 0, 123_456_000,
+			ZoneId.of("Asia/Seoul")
+		);
+		TossPaymentResponse response = TossPaymentResponse.builder()
+			.paymentKey("payment-key")
+			.orderId(reservation.getReservationUid().toString())
+			.totalAmount(100_000L)
+			.method("가상계좌")
+			.status("WAITING_FOR_DEPOSIT")
+			.virtualAccount(TossPaymentResponse.VirtualAccount.builder()
+				.dueDate(dueDate)
+				.build())
+			.build();
+
+		PaymentTransaction transaction = PaymentTransaction.virtualIssued(response, reservation);
+
+		assertThat(transaction.getVirtualDueDate())
+			.isEqualTo(Instant.parse("2026-08-13T14:30:00.123456Z"));
+	}
+
+	@Test
+	@DisplayName("PG 취소 시각은 offset을 보존한 절대 시각으로 저장한다")
+	void cancellationTimePreservesOffset() {
+		Reservation reservation = reservation();
+		Payment payment = Payment.builder()
+			.id(2L)
+			.paymentKey("payment-key")
+			.orderId(reservation.getReservationUid().toString())
+			.method(PaymentMethod.CARD)
+			.status(PaymentStatus.CANCELED)
+			.reservation(reservation)
+			.build();
+		ZonedDateTime canceledAt = ZonedDateTime.of(
+			2026, 11, 1, 1, 30, 0, 654_321_000,
+			ZoneId.of("America/New_York")
+		);
+		TossPaymentResponse.Cancel cancel = TossPaymentResponse.Cancel.builder()
+			.cancelAmount(100_000L)
+			.cancelReason("사용자 요청")
+			.canceledAt(canceledAt)
+			.build();
+
+		PaymentTransaction transaction = PaymentTransaction.cancel(cancel, payment);
+
+		assertThat(transaction.getCanceledAt()).isEqualTo(canceledAt.toInstant());
+	}
+
+	private Reservation reservation() {
+		return Reservation.builder()
+			.id(1L)
+			.reservationUid(UUID.randomUUID())
+			.build();
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/payment/service/PaymentApprovalServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/service/PaymentApprovalServiceTest.java
@@ -1,0 +1,171 @@
+package kr.kro.airbob.domain.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kr.kro.airbob.common.exception.InvalidInputException;
+import kr.kro.airbob.common.history.ChangeType;
+import kr.kro.airbob.domain.payment.dto.PaymentRequest;
+import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.entity.ReservationHistory;
+import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
+import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
+import kr.kro.airbob.domain.reservation.repository.ReservationHistoryRepository;
+import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
+import kr.kro.airbob.outbox.EventType;
+import kr.kro.airbob.outbox.OutboxEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("결제 승인 선점 서비스 테스트")
+class PaymentApprovalServiceTest {
+
+	private static final Instant NOW = Instant.parse("2026-08-12T12:00:00Z");
+
+	@Mock private ReservationRepository reservationRepository;
+	@Mock private ReservationHistoryRepository historyRepository;
+	@Mock private OutboxEventPublisher outboxEventPublisher;
+
+	private PaymentApprovalService paymentApprovalService;
+
+	@BeforeEach
+	void setUp() {
+		paymentApprovalService = new PaymentApprovalService(
+			reservationRepository,
+			historyRepository,
+			outboxEventPublisher,
+			Clock.fixed(NOW, ZoneOffset.UTC)
+		);
+	}
+
+	@Test
+	@DisplayName("미만료 예약을 잠근 뒤 결제 처리 상태와 PG 호출 이벤트를 원자적으로 만든다")
+	void claimsPendingReservationAndPublishesPgCall() {
+		UUID reservationUid = UUID.randomUUID();
+		Reservation reservation = reservation(reservationUid, ReservationStatus.PAYMENT_PENDING, NOW.plusSeconds(1));
+		PaymentRequest.Confirm request = request(reservationUid, 100_000);
+		given(reservationRepository.findByReservationUidWithLock(reservationUid))
+			.willReturn(Optional.of(reservation));
+		ArgumentCaptor<ReservationHistory> historyCaptor = ArgumentCaptor.forClass(ReservationHistory.class);
+
+		boolean claimed = paymentApprovalService.preparePgCall(request);
+
+		assertThat(claimed).isTrue();
+		assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PROCESSING);
+		then(historyRepository).should().save(historyCaptor.capture());
+		assertThat(historyCaptor.getValue().getStatus()).isEqualTo(ReservationStatus.PAYMENT_PROCESSING);
+		assertThat(historyCaptor.getValue().getChangeType()).isEqualTo(ChangeType.STATUS_CHANGE);
+		then(outboxEventPublisher).should().save(EventType.PG_CALL_REQUESTED, request);
+	}
+
+	@Test
+	@DisplayName("만료 시각과 정확히 같으면 PG 호출 이벤트를 만들지 않는다")
+	void rejectsAtExactExpiry() {
+		UUID reservationUid = UUID.randomUUID();
+		Reservation reservation = reservation(reservationUid, ReservationStatus.PAYMENT_PENDING, NOW);
+		PaymentRequest.Confirm request = request(reservationUid, 100_000);
+		given(reservationRepository.findByReservationUidWithLock(reservationUid))
+			.willReturn(Optional.of(reservation));
+
+		boolean claimed = paymentApprovalService.preparePgCall(request);
+
+		assertThat(claimed).isFalse();
+		assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
+		then(historyRepository).shouldHaveNoInteractions();
+		then(outboxEventPublisher).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("이미 결제 처리 중이면 중복 PG 호출 이벤트를 만들지 않는다")
+	void skipsDuplicateClaim() {
+		UUID reservationUid = UUID.randomUUID();
+		Reservation reservation = reservation(
+			reservationUid, ReservationStatus.PAYMENT_PROCESSING, NOW.plusSeconds(1));
+		PaymentRequest.Confirm request = request(reservationUid, 100_000);
+		given(reservationRepository.findByReservationUidWithLock(reservationUid))
+			.willReturn(Optional.of(reservation));
+
+		boolean claimed = paymentApprovalService.preparePgCall(request);
+
+		assertThat(claimed).isFalse();
+		then(historyRepository).shouldHaveNoInteractions();
+		then(outboxEventPublisher).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("예약 금액과 다른 요청은 상태를 바꾸거나 PG 호출 이벤트를 만들지 않는다")
+	void rejectsMismatchedAmount() {
+		UUID reservationUid = UUID.randomUUID();
+		Reservation reservation = reservation(reservationUid, ReservationStatus.PAYMENT_PENDING, NOW.plusSeconds(1));
+		PaymentRequest.Confirm request = request(reservationUid, 90_000);
+		given(reservationRepository.findByReservationUidWithLock(reservationUid))
+			.willReturn(Optional.of(reservation));
+
+		assertThatThrownBy(() -> paymentApprovalService.preparePgCall(request))
+			.isInstanceOf(InvalidInputException.class)
+			.hasMessageContaining("결제 승인 요청");
+
+		assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
+		then(historyRepository).shouldHaveNoInteractions();
+		then(outboxEventPublisher).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("주문 번호가 UUID 형식이 아니면 저장소를 조회하지 않는다")
+	void rejectsMalformedOrderId() {
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", "not-a-uuid", 100_000);
+
+		assertThatThrownBy(() -> paymentApprovalService.preparePgCall(request))
+			.isInstanceOf(InvalidInputException.class)
+			.hasMessageContaining("주문 번호");
+
+		then(reservationRepository).shouldHaveNoInteractions();
+		then(historyRepository).shouldHaveNoInteractions();
+		then(outboxEventPublisher).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("주문 번호에 해당하는 예약이 없으면 영구 오류로 종료한다")
+	void rejectsMissingReservation() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = request(reservationUid, 100_000);
+		given(reservationRepository.findByReservationUidWithLock(reservationUid))
+			.willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> paymentApprovalService.preparePgCall(request))
+			.isInstanceOf(ReservationNotFoundException.class);
+
+		then(historyRepository).shouldHaveNoInteractions();
+		then(outboxEventPublisher).shouldHaveNoInteractions();
+	}
+
+	private PaymentRequest.Confirm request(UUID reservationUid, int amount) {
+		return new PaymentRequest.Confirm("payment-key", reservationUid.toString(), amount);
+	}
+
+	private Reservation reservation(UUID reservationUid, ReservationStatus status, Instant expiresAt) {
+		return Reservation.builder()
+			.id(1L)
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(status)
+			.expiresAt(expiresAt)
+			.build();
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/payment/service/PaymentCancellationProcessorTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/service/PaymentCancellationProcessorTest.java
@@ -86,38 +86,42 @@ class PaymentCancellationProcessorTest {
 	class ProcessSuccessTest {
 
 		@Test
-		@DisplayName("취소 성공 시 processSuccessfulCancellation이 호출된다")
+		@DisplayName("취소 성공 시 reservationUid와 응답으로 트랜잭션 처리를 위임한다")
 		void 취소_성공_처리() {
 			// given
 			PaymentEvent.PgCancelCallSucceededEvent event = new PaymentEvent.PgCancelCallSucceededEvent(
 				cancelResponse, reservationUid.toString()
 			);
 
-			given(paymentRepository.findByReservationReservationUid(reservationUid))
-				.willReturn(Optional.of(payment));
-
 			// when
 			cancellationProcessor.processSuccess(event);
 
 			// then
-			then(paymentTransactionService).should().processSuccessfulCancellation(payment, cancelResponse);
+			then(paymentTransactionService).should().processSuccessfulCancellation(
+				reservationUid.toString(), cancelResponse);
+			then(paymentRepository).shouldHaveNoInteractions();
 		}
 
 		@Test
-		@DisplayName("Payment 조회 실패 시 PaymentNotFoundException이 발생한다")
-		void Payment_조회_실패_예외() {
-			// given
-			PaymentEvent.PgCancelCallSucceededEvent event = new PaymentEvent.PgCancelCallSucceededEvent(
-				cancelResponse, reservationUid.toString()
-			);
+		@DisplayName("PG가 부분 환불 응답을 반환하면 수동 조정 알림을 보낸다")
+		void alertsOnPartialCancellationResponse() {
+			TossPaymentResponse partialResponse = TossPaymentResponse.builder()
+				.status("PARTIAL_CANCELED")
+				.balanceAmount(50_000L)
+				.build();
+			PaymentEvent.PgCancelCallSucceededEvent event =
+				new PaymentEvent.PgCancelCallSucceededEvent(
+					partialResponse, reservationUid.toString());
 
-			given(paymentRepository.findByReservationReservationUid(reservationUid))
-				.willReturn(Optional.empty());
+			cancellationProcessor.processSuccess(event);
 
-			// when & then
-			assertThatThrownBy(() -> cancellationProcessor.processSuccess(event))
-				.isInstanceOf(PaymentNotFoundException.class);
+			then(slackNotificationService).should().sendAlert(slackMessageCaptor.capture());
+			assertThat(slackMessageCaptor.getValue())
+				.contains("[FATAL]")
+				.contains("PARTIAL_CANCELED")
+				.contains("50000");
 		}
+
 	}
 
 	@Nested

--- a/src/test/java/kr/kro/airbob/domain/payment/service/PaymentCompensationServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/service/PaymentCompensationServiceTest.java
@@ -28,6 +28,8 @@ import kr.kro.airbob.domain.payment.exception.TossPaymentException;
 import kr.kro.airbob.domain.payment.exception.code.PaymentCancelErrorCode;
 import kr.kro.airbob.domain.payment.repository.PaymentRepository;
 import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
+import kr.kro.airbob.domain.reservation.service.ReservationTransactionService;
 import kr.kro.airbob.outbox.SlackNotificationService;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,6 +47,9 @@ class PaymentCompensationServiceTest {
 
 	@Mock
 	private PaymentTransactionService paymentTransactionService;
+
+	@Mock
+	private ReservationTransactionService reservationTransactionService;
 
 	@Mock
 	private SlackNotificationService slackNotificationService;
@@ -88,6 +93,9 @@ class PaymentCompensationServiceTest {
 		@DisplayName("정상 보상 처리 시 cancelPayment가 호출된다")
 		void 정상_보상_처리() {
 			// given
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
 			given(paymentRepository.findByReservationReservationUid(reservationUid))
 				.willReturn(Optional.of(payment));
 
@@ -114,6 +122,9 @@ class PaymentCompensationServiceTest {
 		@DisplayName("보상 처리 시 processCompensationInTx가 호출된다")
 		void processCompensationInTx_호출() {
 			// given
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
 			given(paymentRepository.findByReservationReservationUid(reservationUid))
 				.willReturn(Optional.of(payment));
 
@@ -129,13 +140,17 @@ class PaymentCompensationServiceTest {
 			compensationService.compensate(reservationUid.toString());
 
 			// then
-			then(paymentTransactionService).should().processCompensationInTx(payment, cancelResponse);
+			then(paymentTransactionService).should()
+				.processCompensationInTx(reservationUid.toString(), cancelResponse);
 		}
 
 		@Test
 		@DisplayName("이미 CANCELED 상태면 보상을 스킵한다")
 		void 이미_CANCELED_스킵() {
 			// given
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
 			TossPaymentResponse canceledResponse = TossPaymentResponse.builder()
 				.paymentKey("pk_test_123")
 				.orderId(reservationUid.toString())
@@ -147,6 +162,7 @@ class PaymentCompensationServiceTest {
 				.build();
 
 			Payment canceledPayment = Payment.create(canceledResponse, reservation);
+			canceledPayment.updateOnCancel(canceledResponse);
 
 			given(paymentRepository.findByReservationReservationUid(reservationUid))
 				.willReturn(Optional.of(canceledPayment));
@@ -159,9 +175,12 @@ class PaymentCompensationServiceTest {
 		}
 
 		@Test
-		@DisplayName("이미 PARTIAL_CANCELED 상태면 보상을 스킵한다")
-		void 이미_PARTIAL_CANCELED_스킵() {
+		@DisplayName("PARTIAL_CANCELED 상태면 남은 금액의 보상을 다시 시도한다")
+		void PARTIAL_CANCELED_남은금액_보상재시도() {
 			// given
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
 			TossPaymentResponse partialCanceledResponse = TossPaymentResponse.builder()
 				.paymentKey("pk_test_123")
 				.orderId(reservationUid.toString())
@@ -176,18 +195,58 @@ class PaymentCompensationServiceTest {
 
 			given(paymentRepository.findByReservationReservationUid(reservationUid))
 				.willReturn(Optional.of(partialCanceledPayment));
+			TossPaymentResponse completedResponse = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
+				.status("CANCELED")
+				.balanceAmount(0L)
+				.build();
+			given(tossPaymentsAdapter.cancelPayment(anyString(), anyString(), isNull()))
+				.willReturn(completedResponse);
 
 			// when
 			compensationService.compensate(reservationUid.toString());
 
 			// then
-			then(tossPaymentsAdapter).should(never()).cancelPayment(anyString(), anyString(), any());
+			then(tossPaymentsAdapter).should().cancelPayment(
+				eq("pk_test_123"), contains("Saga 보상"), isNull());
+			then(paymentTransactionService).should()
+				.processCompensationInTx(reservationUid.toString(), completedResponse);
+		}
+
+		@Test
+		@DisplayName("보상 응답이 전액 취소가 아니면 성공으로 간주하지 않는다")
+		void partialCompensationResponseFails() {
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
+			given(paymentRepository.findByReservationReservationUid(reservationUid))
+				.willReturn(Optional.of(payment));
+			TossPaymentResponse partialResponse = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
+				.status("PARTIAL_CANCELED")
+				.balanceAmount(50_000L)
+				.build();
+			given(tossPaymentsAdapter.cancelPayment(anyString(), anyString(), isNull()))
+				.willReturn(partialResponse);
+
+			assertThatThrownBy(() -> compensationService.compensate(reservationUid.toString()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("전액 취소");
+
+			then(paymentTransactionService).shouldHaveNoInteractions();
 		}
 
 		@Test
 		@DisplayName("결제 정보를 찾을 수 없으면 PaymentNotFoundException이 발생한다")
 		void 결제정보_없음_예외() {
 			// given
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
 			given(paymentRepository.findByReservationReservationUid(reservationUid))
 				.willReturn(Optional.empty());
 
@@ -200,6 +259,9 @@ class PaymentCompensationServiceTest {
 		@DisplayName("TossPaymentException 발생 시 예외가 재throw된다")
 		void TossPaymentException_재throw() {
 			// given
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
 			given(paymentRepository.findByReservationReservationUid(reservationUid))
 				.willReturn(Optional.of(payment));
 
@@ -218,6 +280,9 @@ class PaymentCompensationServiceTest {
 		@DisplayName("일반 Exception 발생 시 예외가 재throw된다")
 		void 일반_Exception_재throw() {
 			// given
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
 			given(paymentRepository.findByReservationReservationUid(reservationUid))
 				.willReturn(Optional.of(payment));
 
@@ -234,6 +299,9 @@ class PaymentCompensationServiceTest {
 		@DisplayName("cancelReason에 'Saga 보상' 문구가 포함된다")
 		void cancelReason_Saga_보상_포함() {
 			// given
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(true);
 			given(paymentRepository.findByReservationReservationUid(reservationUid))
 				.willReturn(Optional.of(payment));
 
@@ -254,6 +322,20 @@ class PaymentCompensationServiceTest {
 				argThat(reason -> reason.contains("Saga 보상")),
 				isNull()
 			);
+		}
+
+		@Test
+		@DisplayName("이미 확정된 예약이면 정상 결제를 보상 취소하지 않는다")
+		void confirmedReservationSkipsCompensation() {
+			given(reservationTransactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패"))
+				.willReturn(false);
+
+			compensationService.compensate(reservationUid.toString());
+
+			then(paymentRepository).shouldHaveNoInteractions();
+			then(tossPaymentsAdapter).shouldHaveNoInteractions();
+			then(paymentTransactionService).shouldHaveNoInteractions();
 		}
 	}
 
@@ -336,6 +418,25 @@ class PaymentCompensationServiceTest {
 			boolean hasSuccessMessage = alerts.stream()
 				.anyMatch(msg -> msg.contains("[COMPENSATION]") && msg.contains("성공"));
 			assertThat(hasSuccessMessage).isTrue();
+		}
+
+		@Test
+		@DisplayName("유령 결제 환불이 부분 취소에 그치면 성공 알림을 보내지 않는다")
+		void ghostPartialRefundDoesNotReportSuccess() {
+			String paymentKey = "pk_ghost_123";
+			TossPaymentResponse partialResponse = TossPaymentResponse.builder()
+				.status("PARTIAL_CANCELED")
+				.balanceAmount(50_000L)
+				.build();
+			given(tossPaymentsAdapter.cancelPayment(anyString(), anyString(), isNull()))
+				.willReturn(partialResponse);
+
+			compensationService.compensateGhostPayment(paymentKey);
+
+			then(slackNotificationService).should(atLeastOnce()).sendAlert(slackMessageCaptor.capture());
+			assertThat(slackMessageCaptor.getAllValues())
+				.noneMatch(message -> message.contains("[COMPENSATION]") && message.contains("성공"))
+				.anyMatch(message -> message.contains("[FATAL]") && message.contains("전액 취소"));
 		}
 
 		@Test

--- a/src/test/java/kr/kro/airbob/domain/payment/service/PaymentTransactionServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/service/PaymentTransactionServiceTest.java
@@ -27,9 +27,11 @@ import kr.kro.airbob.domain.payment.entity.PaymentStatus;
 import kr.kro.airbob.domain.payment.entity.PaymentTransaction;
 import kr.kro.airbob.domain.payment.entity.PaymentTransactionType;
 import kr.kro.airbob.domain.payment.event.PaymentEvent;
+import kr.kro.airbob.domain.payment.exception.PaymentNotFoundException;
 import kr.kro.airbob.domain.payment.repository.PaymentRepository;
 import kr.kro.airbob.domain.payment.repository.PaymentTransactionRepository;
 import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.outbox.EventType;
 import kr.kro.airbob.outbox.OutboxEventPublisher;
 
@@ -45,6 +47,9 @@ class PaymentTransactionServiceTest {
 
 	@Mock
 	private PaymentTransactionRepository paymentTransactionRepository;
+
+	@Mock
+	private ReservationRepository reservationRepository;
 
 	@Mock
 	private OutboxEventPublisher outboxEventPublisher;
@@ -88,6 +93,10 @@ class PaymentTransactionServiceTest {
 		@Test
 		@DisplayName("결제 성공 시 거래 원장에 CONFIRM이 기록된다")
 		void 거래원장_CONFIRM_기록() {
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.empty());
 			// when
 			paymentTransactionService.processSuccessfulPayment(tossResponse, reservation);
 
@@ -104,6 +113,10 @@ class PaymentTransactionServiceTest {
 		@Test
 		@DisplayName("결제 성공 시 Payment가 저장된다")
 		void Payment_저장() {
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.empty());
 			// when
 			paymentTransactionService.processSuccessfulPayment(tossResponse, reservation);
 
@@ -119,6 +132,10 @@ class PaymentTransactionServiceTest {
 		@Test
 		@DisplayName("결제 성공 시 PAYMENT_COMPLETED 이벤트가 발행된다")
 		void PAYMENT_COMPLETED_이벤트_발행() {
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.empty());
 			// when
 			paymentTransactionService.processSuccessfulPayment(tossResponse, reservation);
 
@@ -130,6 +147,47 @@ class PaymentTransactionServiceTest {
 					return completedEvent.reservationUid().equals(reservationUid.toString());
 				})
 			);
+		}
+
+		@Test
+		@DisplayName("예약과 금액이 다른 승인 응답은 어떤 결제 데이터도 저장하지 않는다")
+		void rejectsMismatchedSuccessfulPaymentResponse() {
+			TossPaymentResponse mismatched = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(90_000L)
+				.balanceAmount(90_000L)
+				.method("카드")
+				.status("DONE")
+				.approvedAt(ZonedDateTime.now())
+				.build();
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(reservation));
+
+			assertThatThrownBy(() -> paymentTransactionService.processSuccessfulPayment(
+				mismatched, reservation))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("PG 승인 응답");
+
+			then(paymentRepository).shouldHaveNoInteractions();
+			then(paymentTransactionRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("같은 승인 성공 이벤트를 다시 받으면 결제와 완료 이벤트를 중복 생성하지 않는다")
+		void duplicateSuccessfulPaymentIsIdempotent() {
+			Payment existing = Payment.create(tossResponse, reservation);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(existing));
+
+			paymentTransactionService.processSuccessfulPayment(tossResponse, reservation);
+
+			then(paymentRepository).should(never()).save(any());
+			then(paymentTransactionRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
 		}
 	}
 
@@ -184,11 +242,50 @@ class PaymentTransactionServiceTest {
 				})
 			);
 		}
+
+		@Test
+		@DisplayName("결제 실패 이력은 DB 컬럼 길이에 맞게 외부 문자열을 제한한다")
+		void 실패_이력_외부문자열_길이제한() {
+			PaymentRequest.Confirm confirmRequest = new PaymentRequest.Confirm(
+				"p".repeat(201), reservationUid.toString(), 100_000
+			);
+
+			paymentTransactionService.processFailedPayment(
+				confirmRequest, reservation, "C".repeat(101), "M".repeat(513)
+			);
+
+			then(paymentTransactionRepository).should().save(transactionCaptor.capture());
+			PaymentTransaction savedTransaction = transactionCaptor.getValue();
+			assertThat(savedTransaction.getPaymentKey()).hasSize(200);
+			assertThat(savedTransaction.getFailureCode()).hasSize(100);
+			assertThat(savedTransaction.getFailureMessage()).hasSize(512);
+		}
 	}
 
 	@Nested
 	@DisplayName("processSuccessfulCancellation 테스트")
 	class ProcessSuccessfulCancellationTest {
+
+		@Test
+		@DisplayName("결제 취소 성공 반영 시 결제를 잠금 조회할 수 없으면 실패한다")
+		void 결제_잠금조회_실패() {
+			TossPaymentResponse cancelResponse = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
+				.status("CANCELED")
+				.balanceAmount(0L)
+				.build();
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.empty());
+
+			assertThatThrownBy(() -> paymentTransactionService.processSuccessfulCancellation(
+				reservationUid.toString(), cancelResponse))
+				.isInstanceOf(PaymentNotFoundException.class);
+
+			then(paymentTransactionRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
 
 		@Test
 		@DisplayName("취소 성공 시 Payment 상태가 업데이트된다")
@@ -204,13 +301,19 @@ class PaymentTransactionServiceTest {
 				.build();
 
 			TossPaymentResponse cancelResponse = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
 				.status("CANCELED")
 				.balanceAmount(0L)
 				.cancels(List.of(cancelData))
 				.build();
 
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(payment));
+
 			// when
-			paymentTransactionService.processSuccessfulCancellation(payment, cancelResponse);
+			paymentTransactionService.processSuccessfulCancellation(reservationUid.toString(), cancelResponse);
 
 			// then
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
@@ -231,17 +334,111 @@ class PaymentTransactionServiceTest {
 				.build();
 
 			TossPaymentResponse cancelResponse = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
 				.status("PARTIAL_CANCELED")
 				.balanceAmount(50_000L)
 				.cancels(List.of(cancelData))
 				.build();
 
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(payment));
+
 			// when
-			paymentTransactionService.processSuccessfulCancellation(payment, cancelResponse);
+			paymentTransactionService.processSuccessfulCancellation(reservationUid.toString(), cancelResponse);
 
 			// then
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
 			assertThat(payment.getBalanceAmount()).isEqualTo(50_000L);
+			then(outboxEventPublisher).should().save(
+				eq(PAYMENT_CANCELLATION_FAILED),
+				isA(PaymentEvent.PaymentCancellationFailedEvent.class)
+			);
+			then(outboxEventPublisher).should(never()).save(
+				eq(PAYMENT_CANCELLATION_COMPLETED), any());
+		}
+
+		@Test
+		@DisplayName("전액 취소 성공 시 예약 취소 완료 전달 이벤트가 발행된다")
+		void 전액취소_완료이벤트_발행() {
+			Payment payment = Payment.create(tossResponse, reservation);
+			TossPaymentResponse.Cancel cancelData = TossPaymentResponse.Cancel.builder()
+				.cancelAmount(100_000L)
+				.cancelReason("고객 요청")
+				.transactionKey("tx_cancel")
+				.canceledAt(ZonedDateTime.now())
+				.build();
+			TossPaymentResponse cancelResponse = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
+				.status("CANCELED")
+				.balanceAmount(0L)
+				.cancels(List.of(cancelData))
+				.build();
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(payment));
+
+			paymentTransactionService.processSuccessfulCancellation(reservationUid.toString(), cancelResponse);
+
+			then(outboxEventPublisher).should().save(
+				eq(PAYMENT_CANCELLATION_COMPLETED),
+				argThat(event -> event instanceof PaymentEvent.PaymentCancellationCompletedEvent completed
+					&& completed.reservationUid().equals(reservationUid.toString()))
+			);
+		}
+
+		@Test
+		@DisplayName("같은 전액 취소 성공 결과를 다시 받으면 원장과 완료 이벤트를 중복 생성하지 않는다")
+		void 중복_전액취소_멱등() {
+			Payment payment = Payment.create(tossResponse, reservation);
+			TossPaymentResponse.Cancel cancelData = TossPaymentResponse.Cancel.builder()
+				.cancelAmount(100_000L)
+				.cancelReason("고객 요청")
+				.transactionKey("tx_cancel")
+				.canceledAt(ZonedDateTime.now())
+				.build();
+			TossPaymentResponse cancelResponse = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
+				.status("CANCELED")
+				.balanceAmount(0L)
+				.cancels(List.of(cancelData))
+				.build();
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(payment));
+
+			paymentTransactionService.processSuccessfulCancellation(reservationUid.toString(), cancelResponse);
+			paymentTransactionService.processSuccessfulCancellation(reservationUid.toString(), cancelResponse);
+
+			then(paymentTransactionRepository).should(times(1)).save(any(PaymentTransaction.class));
+			then(outboxEventPublisher).should(times(1)).save(
+				eq(PAYMENT_CANCELLATION_COMPLETED), any());
+		}
+
+		@Test
+		@DisplayName("다른 결제의 PG 취소 응답은 Payment와 예약에 반영하지 않는다")
+		void rejectsMismatchedCancellationResponse() {
+			Payment payment = Payment.create(tossResponse, reservation);
+			TossPaymentResponse cancelResponse = TossPaymentResponse.builder()
+				.paymentKey("another-payment-key")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
+				.status("CANCELED")
+				.balanceAmount(0L)
+				.build();
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(payment));
+
+			assertThatThrownBy(() -> paymentTransactionService.processSuccessfulCancellation(
+				reservationUid.toString(), cancelResponse))
+				.isInstanceOf(IllegalStateException.class);
+
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.DONE);
+			then(paymentTransactionRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
 		}
 	}
 
@@ -263,13 +460,19 @@ class PaymentTransactionServiceTest {
 				.build();
 
 			TossPaymentResponse cancelResponse = TossPaymentResponse.builder()
+				.paymentKey("pk_test_123")
+				.orderId(reservationUid.toString())
+				.totalAmount(100_000L)
 				.status("CANCELED")
 				.balanceAmount(0L)
 				.cancels(List.of(cancelData))
 				.build();
 
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(java.util.Optional.of(payment));
+
 			// when
-			paymentTransactionService.processCompensationInTx(payment, cancelResponse);
+			paymentTransactionService.processCompensationInTx(reservationUid.toString(), cancelResponse);
 
 			// then
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);

--- a/src/test/java/kr/kro/airbob/domain/payment/service/TossPaymentsAdapterTest.java
+++ b/src/test/java/kr/kro/airbob/domain/payment/service/TossPaymentsAdapterTest.java
@@ -1,13 +1,167 @@
 package kr.kro.airbob.domain.payment.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.backoff.Sleeper;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.kro.airbob.domain.payment.exception.TossPaymentException;
+import kr.kro.airbob.domain.payment.exception.code.PaymentConfirmErrorCode;
 
 @DisplayName("TossPaymentsAdapter 테스트")
 class TossPaymentsAdapterTest {
+	private MockRestServiceServer server;
+	private TossPaymentsAdapter adapter;
+
+	@BeforeEach
+	void setUp() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://api.example.com");
+		server = MockRestServiceServer.bindTo(builder).build();
+		adapter = new TossPaymentsAdapter(builder.build(), new ObjectMapper());
+	}
+
+	@Test
+	@DisplayName("같은 결제 승인 재시도는 동일한 멱등키를 사용한다")
+	void confirmationUsesStableIdempotencyKey() {
+		String orderId = "reservation-order-123";
+
+		server.expect(requestTo("https://api.example.com/v1/payments/confirm"))
+			.andExpect(header(
+				TossPaymentsAdapter.IDEMPOTENCY_KEY_HEADER,
+				TossPaymentsAdapter.CONFIRMATION_IDEMPOTENCY_KEY_PREFIX + orderId
+			))
+			.andRespond(withSuccess(
+				"{\"paymentKey\":\"payment-key-123\",\"orderId\":\"reservation-order-123\",\"status\":\"DONE\"}",
+				MediaType.APPLICATION_JSON
+			));
+
+		adapter.confirmPayment("payment-key-123", orderId, 100_000);
+
+		server.verify();
+	}
+
+	@Test
+	@DisplayName("같은 결제 취소 재시도는 동일한 멱등키를 사용한다")
+	void cancellationUsesStableIdempotencyKey() {
+		String paymentKey = "payment-key-123";
+
+		server.expect(requestTo("https://api.example.com/v1/payments/payment-key-123/cancel"))
+			.andExpect(header(
+				TossPaymentsAdapter.IDEMPOTENCY_KEY_HEADER,
+				TossPaymentsAdapter.CANCELLATION_IDEMPOTENCY_KEY_PREFIX + paymentKey
+			))
+			.andRespond(withSuccess(
+				"{\"status\":\"CANCELED\",\"balanceAmount\":0}",
+				MediaType.APPLICATION_JSON
+			));
+
+		adapter.cancelPayment(paymentKey, "사용자 요청", null);
+
+		server.verify();
+	}
+
+	@Test
+	@DisplayName("처리 중인 결제 승인 멱등 요청은 최종 실패로 확정하지 않는다")
+	void confirmationInProgressIsRetryable() {
+		server.expect(requestTo("https://api.example.com/v1/payments/confirm"))
+			.andRespond(withStatus(HttpStatus.CONFLICT)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body("""
+					{"code":"IDEMPOTENT_REQUEST_PROCESSING","message":"이전 요청을 처리하고 있어요."}
+					"""));
+
+		assertThatThrownBy(() -> adapter.confirmPayment("payment-key-123", "reservation-order-123", 100_000))
+			.isInstanceOf(ResourceAccessException.class)
+			.hasMessageContaining("IDEMPOTENT_REQUEST_PROCESSING");
+
+		server.verify();
+	}
+
+	@Test
+	@DisplayName("처리 중인 결제 승인은 같은 멱등키로 재시도한 뒤 성공한다")
+	void retriesConfirmationInProgressWithStableIdempotencyKey() {
+		String orderId = "reservation-order-123";
+		for (int attempt = 0; attempt < 2; attempt++) {
+			server.expect(requestTo("https://api.example.com/v1/payments/confirm"))
+				.andExpect(header("Idempotency-Key", "airbob-confirm-" + orderId))
+				.andRespond(withStatus(HttpStatus.CONFLICT)
+					.contentType(MediaType.APPLICATION_JSON)
+					.body("""
+						{"code":"IDEMPOTENT_REQUEST_PROCESSING","message":"이전 요청을 처리하고 있어요."}
+						"""));
+		}
+		server.expect(requestTo("https://api.example.com/v1/payments/confirm"))
+			.andExpect(header("Idempotency-Key", "airbob-confirm-" + orderId))
+			.andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(RetryProxyConfig.class);
+			context.registerBean(TossPaymentsAdapter.class, () -> adapter);
+			context.registerBean(Sleeper.class, () -> backOffPeriod -> { });
+			context.refresh();
+
+			TossPaymentsAdapter retryingAdapter = context.getBean(TossPaymentsAdapter.class);
+			assertThat(retryingAdapter.confirmPayment("payment-key-123", orderId, 100_000))
+				.isNotNull();
+		}
+		server.verify();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableRetry
+	static class RetryProxyConfig {
+	}
+
+	@Test
+	@DisplayName("처리 중인 결제 취소 멱등 요청은 최종 실패로 확정하지 않는다")
+	void cancellationInProgressIsRetryable() {
+		server.expect(requestTo("https://api.example.com/v1/payments/payment-key-123/cancel"))
+			.andRespond(withStatus(HttpStatus.CONFLICT)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body("""
+					{"code":"IDEMPOTENT_REQUEST_PROCESSING","message":"이전 요청을 처리하고 있어요."}
+					"""));
+
+		assertThatThrownBy(() -> adapter.cancelPayment("payment-key-123", "사용자 요청", null))
+			.isInstanceOf(ResourceAccessException.class)
+			.hasMessageContaining("IDEMPOTENT_REQUEST_PROCESSING");
+
+		server.verify();
+	}
+
+	@Test
+	@DisplayName("토스의 최상위 오류 코드를 결제 승인 오류로 매핑한다")
+	void mapsTopLevelConfirmationErrorCode() {
+		server.expect(requestTo("https://api.example.com/v1/payments/confirm"))
+			.andRespond(withStatus(HttpStatus.BAD_REQUEST)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body("""
+					{"code":"INVALID_REQUEST","message":"잘못된 요청입니다."}
+					"""));
+
+		assertThatThrownBy(() -> adapter.confirmPayment("payment-key-123", "reservation-order-123", 100_000))
+			.isInstanceOfSatisfying(TossPaymentException.class, exception ->
+				assertThat(exception.getErrorCode()).isEqualTo(PaymentConfirmErrorCode.INVALID_REQUEST));
+
+		server.verify();
+	}
 
 	@Nested
 	@DisplayName("상수 값 검증 테스트")

--- a/src/test/java/kr/kro/airbob/domain/recentlyViewed/service/RecentlyViewedServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/recentlyViewed/service/RecentlyViewedServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -90,6 +91,9 @@ class RecentlyViewedServiceTest {
 		assertThat(result.accommodations())
 			.extracting(AccommodationResponse.RecentlyViewedAccommodationInfo::isInWishlist)
 			.containsExactly(true, false);
+		assertThat(result.accommodations())
+			.extracting(AccommodationResponse.RecentlyViewedAccommodationInfo::viewedAt)
+			.containsExactly(Instant.ofEpochMilli(2_000L), Instant.ofEpochMilli(1_000L));
 		verify(accommodationRepository).findByIdInAndStatus(anyList(), eq(AccommodationStatus.PUBLISHED));
 		verify(summaryRepository).findByAccommodationIdIn(anyList());
 		verify(wishlistAccommodationRepository)

--- a/src/test/java/kr/kro/airbob/domain/reservation/ReservationConcurrencyTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/ReservationConcurrencyTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -38,7 +39,11 @@ import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
 import kr.kro.airbob.domain.accommodation.repository.AddressRepository;
 import kr.kro.airbob.domain.member.entity.Member;
 import kr.kro.airbob.domain.member.repository.MemberRepository;
+import kr.kro.airbob.domain.payment.dto.PaymentRequest;
+import kr.kro.airbob.domain.payment.service.PaymentApprovalService;
 import kr.kro.airbob.domain.reservation.dto.ReservationRequest;
+import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
 import kr.kro.airbob.domain.reservation.exception.ReservationConflictException;
 import kr.kro.airbob.domain.reservation.exception.ReservationLockException;
 import kr.kro.airbob.domain.reservation.policy.BookingWindow;
@@ -47,11 +52,14 @@ import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.domain.reservation.repository.ReservationHistoryRepository;
 import kr.kro.airbob.domain.reservation.service.ReservationService;
 import kr.kro.airbob.domain.reservation.service.ReservationTransactionService;
+import kr.kro.airbob.outbox.EventType;
+import kr.kro.airbob.outbox.repository.OutboxRepository;
 import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ReservationConcurrencyTest {
 
 	private static final int THREAD_COUNT = 50;
@@ -73,6 +81,10 @@ class ReservationConcurrencyTest {
 	private AddressRepository addressRepository;
 	@Autowired
 	private ReservationHistoryRepository historyRepository;
+	@Autowired
+	private PaymentApprovalService paymentApprovalService;
+	@Autowired
+	private OutboxRepository outboxRepository;
 
 	@MockitoBean
 	private ElasticsearchClient elasticsearchClient;
@@ -103,9 +115,6 @@ class ReservationConcurrencyTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private Accommodation accommodation;
@@ -114,6 +123,7 @@ class ReservationConcurrencyTest {
 	@BeforeEach
 	void setUp() {
 		given(bookingWindowProvider.currentFor(TIME_ZONE_ID)).willReturn(BOOKING_WINDOW);
+		outboxRepository.deleteAllInBatch();
 		historyRepository.deleteAllInBatch();
 		reservationRepository.deleteAllInBatch();
 		accommodationRepository.deleteAllInBatch();
@@ -144,11 +154,70 @@ class ReservationConcurrencyTest {
 
 	@AfterEach
 	void tearDown() {
+		outboxRepository.deleteAllInBatch();
 		historyRepository.deleteAllInBatch();
 		reservationRepository.deleteAllInBatch();
 		accommodationRepository.deleteAllInBatch();
 		memberRepository.deleteAllInBatch();
 		addressRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("같은 결제 승인 요청이 동시에 도착해도 PG 호출 이벤트는 한 건만 만든다")
+	void concurrentPaymentApprovalClaimsOnce() throws InterruptedException {
+		LocalDate checkInDate = WINDOW_START.plusDays(30);
+		Reservation pendingReservation = transactionService.createPendingReservationInTx(
+			new ReservationRequest.Create(
+				accommodation.getId(), checkInDate, checkInDate.plusDays(2), 2),
+			guests.getFirst().getId(),
+			"결제 승인 선점 동시성 테스트"
+		);
+		outboxRepository.deleteAllInBatch();
+
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key",
+			pendingReservation.getReservationUid().toString(),
+			pendingReservation.getTotalPrice().intValue()
+		);
+		ExecutorService executorService = Executors.newFixedThreadPool(2);
+		CountDownLatch readyLatch = new CountDownLatch(2);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(2);
+		AtomicInteger claimedCount = new AtomicInteger();
+		AtomicInteger unexpectedFailCount = new AtomicInteger();
+
+		for (int i = 0; i < 2; i++) {
+			executorService.submit(() -> {
+				try {
+					readyLatch.countDown();
+					startLatch.await();
+					if (paymentApprovalService.preparePgCall(request)) {
+						claimedCount.incrementAndGet();
+					}
+				} catch (Exception e) {
+					unexpectedFailCount.incrementAndGet();
+				} finally {
+					doneLatch.countDown();
+				}
+			});
+		}
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await();
+		executorService.shutdown();
+
+		Reservation claimedReservation = reservationRepository
+			.findByReservationUid(pendingReservation.getReservationUid())
+			.orElseThrow();
+		long pgCallEventCount = outboxRepository.findAll().stream()
+			.filter(outbox -> EventType.PG_CALL_REQUESTED.name().equals(outbox.getEventType()))
+			.count();
+
+		assertThat(unexpectedFailCount.get()).isZero();
+		assertThat(claimedCount.get()).isEqualTo(1);
+		assertThat(claimedReservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PROCESSING);
+		assertThat(pgCallEventCount).isEqualTo(1);
 	}
 
 	@Test

--- a/src/test/java/kr/kro/airbob/domain/reservation/ReservationConcurrencyTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/ReservationConcurrencyTest.java
@@ -1,6 +1,7 @@
 package kr.kro.airbob.domain.reservation;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -41,6 +42,7 @@ import kr.kro.airbob.domain.reservation.dto.ReservationRequest;
 import kr.kro.airbob.domain.reservation.exception.ReservationConflictException;
 import kr.kro.airbob.domain.reservation.exception.ReservationLockException;
 import kr.kro.airbob.domain.reservation.policy.BookingWindow;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.domain.reservation.repository.ReservationHistoryRepository;
 import kr.kro.airbob.domain.reservation.service.ReservationService;
@@ -53,6 +55,9 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 class ReservationConcurrencyTest {
 
 	private static final int THREAD_COUNT = 50;
+	private static final String TIME_ZONE_ID = "Asia/Seoul";
+	private static final LocalDate WINDOW_START = LocalDate.of(2026, 8, 12);
+	private static final BookingWindow BOOKING_WINDOW = BookingWindow.startingOn(WINDOW_START);
 
 	@Autowired
 	private ReservationService reservationService;
@@ -77,6 +82,8 @@ class ReservationConcurrencyTest {
 	private AccommodationSearchRepository accommodationSearchRepository;
 	@MockitoBean
 	private io.awspring.cloud.s3.S3Template s3Template;
+	@MockitoBean
+	private BookingWindowProvider bookingWindowProvider;
 
 	@Container
 	private static final MySQLContainer<?> mySQLContainer = new MySQLContainer<>("mysql:8.0.33")
@@ -106,6 +113,7 @@ class ReservationConcurrencyTest {
 
 	@BeforeEach
 	void setUp() {
+		given(bookingWindowProvider.currentFor(TIME_ZONE_ID)).willReturn(BOOKING_WINDOW);
 		historyRepository.deleteAllInBatch();
 		reservationRepository.deleteAllInBatch();
 		accommodationRepository.deleteAllInBatch();
@@ -122,6 +130,7 @@ class ReservationConcurrencyTest {
 			.member(host)
 			.checkInTime(LocalTime.of(15, 0))
 			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId(TIME_ZONE_ID)
 			.status(AccommodationStatus.PUBLISHED)
 			.build());
 
@@ -155,7 +164,7 @@ class ReservationConcurrencyTest {
 		AtomicInteger expectedFailCount = new AtomicInteger(0);
 		AtomicInteger unexpectedFailCount = new AtomicInteger(0);
 
-		LocalDate checkInDate = BookingWindow.current().startInclusive().plusDays(30);
+		LocalDate checkInDate = WINDOW_START.plusDays(30);
 		LocalDate checkOutDate = checkInDate.plusDays(2);
 
 		// when
@@ -223,7 +232,7 @@ class ReservationConcurrencyTest {
 		AtomicInteger successCount = new AtomicInteger(0);
 		AtomicInteger failCount = new AtomicInteger(0);
 
-		LocalDate checkInDate = BookingWindow.current().startInclusive().plusDays(30);
+		LocalDate checkInDate = WINDOW_START.plusDays(30);
 		LocalDate checkOutDate = checkInDate.plusDays(2);
 
 		ReservationRequest.Create request = new ReservationRequest.Create(
@@ -286,6 +295,7 @@ class ReservationConcurrencyTest {
 			.member(host2)
 			.checkInTime(LocalTime.of(15, 0))
 			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId(TIME_ZONE_ID)
 			.status(AccommodationStatus.PUBLISHED)
 			.build());
 
@@ -297,7 +307,7 @@ class ReservationConcurrencyTest {
 		AtomicInteger successCount = new AtomicInteger(0);
 		AtomicInteger unexpectedFailCount = new AtomicInteger(0);
 
-		LocalDate checkInDate = BookingWindow.current().startInclusive().plusDays(30);
+		LocalDate checkInDate = WINDOW_START.plusDays(30);
 		LocalDate checkOutDate = checkInDate.plusDays(2);
 
 		Member guestA = guests.get(0);
@@ -371,7 +381,7 @@ class ReservationConcurrencyTest {
 		AtomicInteger failCount = new AtomicInteger(0);
 		AtomicInteger unexpectedFailCount = new AtomicInteger(0);
 
-		LocalDate baseDate = BookingWindow.current().startInclusive().plusDays(30);
+		LocalDate baseDate = WINDOW_START.plusDays(30);
 		ReservationRequest.Create requestA = new ReservationRequest.Create(
 			accommodation.getId(),
 			baseDate.plusDays(1),

--- a/src/test/java/kr/kro/airbob/domain/reservation/ReservationHistoryInsertBenchmarkIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/ReservationHistoryInsertBenchmarkIntegrationTest.java
@@ -17,6 +17,7 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -61,6 +62,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 	"reservation.expiration.history-batch-size=2"
 })
 @ActiveProfiles({"test", "bulk-write-benchmark"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("ReservationHistory IDENTITY INSERT Before 벌크 쓰기 통합 테스트")
 class ReservationHistoryInsertBenchmarkIntegrationTest {
 
@@ -87,8 +89,6 @@ class ReservationHistoryInsertBenchmarkIntegrationTest {
 		registry.add("spring.datasource.password", MYSQL::getPassword);
 		registry.add("spring.data.redis.host", REDIS::getHost);
 		registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	@Autowired private ReservationHistoryInsertBenchmarkService benchmarkService;

--- a/src/test/java/kr/kro/airbob/domain/reservation/dto/ReservationRequestValidationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/dto/ReservationRequestValidationTest.java
@@ -1,0 +1,50 @@
+package kr.kro.airbob.domain.reservation.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+@DisplayName("예약 생성 요청 검증 테스트")
+class ReservationRequestValidationTest {
+
+	private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+	@Test
+	@DisplayName("날짜의 과거 여부는 DTO 검증 대상이 아니다")
+	void allowsPastDatesForAccommodationLocalDateValidation() {
+		ReservationRequest.Create request = new ReservationRequest.Create(
+			1L,
+			LocalDate.of(2000, 1, 1),
+			LocalDate.of(2000, 1, 2),
+			2
+		);
+
+		assertThat(validator.validate(request)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("필수 날짜와 양수 숙소 ID 및 인원수 제약은 유지한다")
+	void keepsRequiredAndPositiveConstraints() {
+		ReservationRequest.Create request = new ReservationRequest.Create(
+			0L,
+			null,
+			null,
+			0
+		);
+
+		assertThat(validator.validate(request))
+			.extracting(violation -> violation.getPropertyPath().toString())
+			.containsExactlyInAnyOrder(
+				"accommodationId",
+				"checkInDate",
+				"checkOutDate",
+				"guestCount"
+			);
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/reservation/dto/ReservationResponseTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/dto/ReservationResponseTest.java
@@ -1,0 +1,114 @@
+package kr.kro.airbob.domain.reservation.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.kro.airbob.domain.accommodation.entity.Accommodation;
+import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
+import kr.kro.airbob.domain.member.entity.Member;
+import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
+
+@JsonTest
+@DisplayName("예약 응답 시간대 테스트")
+class ReservationResponseTest {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("숙소 시간대가 바뀌어도 예약 당시 시간대 스냅샷으로 현지 시각을 복원한다")
+	void detailsUseReservationTimeZoneSnapshot() {
+		ZoneId reservationZone = ZoneId.of("America/New_York");
+		LocalDateTime createdAt = LocalDateTime.of(2026, 3, 1, 9, 30);
+		LocalDateTime localCheckIn = LocalDateTime.of(2026, 3, 8, 15, 0);
+		LocalDateTime localCheckOut = LocalDateTime.of(2026, 3, 10, 11, 0);
+		Member host = Member.builder().id(1L).nickname("host").build();
+		Member guest = Member.builder().id(2L).nickname("guest").build();
+		Accommodation accommodation = Accommodation.builder()
+			.id(10L)
+			.member(host)
+			.name("time-zone-snapshot")
+			.checkInTime(LocalTime.of(15, 0))
+			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId("America/Los_Angeles")
+			.status(AccommodationStatus.PUBLISHED)
+			.build();
+		Reservation reservation = Reservation.builder()
+			.id(20L)
+			.reservationUid(UUID.randomUUID())
+			.reservationCode("ABC1234567")
+			.accommodation(accommodation)
+			.guest(guest)
+			.checkInDate(LocalDate.of(2026, 3, 8))
+			.checkOutDate(LocalDate.of(2026, 3, 10))
+			.checkInAt(localCheckIn.atZone(reservationZone).toInstant())
+			.checkOutAt(localCheckOut.atZone(reservationZone).toInstant())
+			.timeZoneId(reservationZone.getId())
+			.guestCount(2)
+			.totalPrice(200_000L)
+			.currency("KRW")
+			.status(ReservationStatus.CONFIRMED)
+			.expiresAt(Instant.parse("2026-03-01T00:00:00Z"))
+			.createdAt(createdAt)
+			.build();
+
+		ReservationResponse.GuestDetail guestDetail = ReservationResponse.GuestDetail.from(
+			reservation, null, true);
+		ReservationResponse.HostDetail hostDetail = ReservationResponse.HostDetail.from(
+			reservation, null);
+		ReservationResponse.GuestReservationInfo guestInfo =
+			ReservationResponse.GuestReservationInfo.from(reservation);
+		ReservationResponse.HostReservationInfo hostInfo =
+			ReservationResponse.HostReservationInfo.from(reservation);
+
+		assertThat(guestDetail.createdAt()).isEqualTo(Instant.parse("2026-03-01T09:30:00Z"));
+		assertThat(guestDetail.timeZoneId()).isEqualTo("America/New_York");
+		assertThat(guestDetail.checkInDateTime()).isEqualTo(localCheckIn);
+		assertThat(guestDetail.checkOutDateTime()).isEqualTo(localCheckOut);
+		assertThat(guestDetail.checkInTime()).isEqualTo(LocalTime.of(15, 0));
+		assertThat(guestDetail.checkOutTime()).isEqualTo(LocalTime.of(11, 0));
+		assertThat(hostDetail.timeZoneId()).isEqualTo("America/New_York");
+		assertThat(hostDetail.checkInDateTime()).isEqualTo(localCheckIn);
+		assertThat(hostDetail.checkOutDateTime()).isEqualTo(localCheckOut);
+		assertThat(hostDetail.createdAt()).isEqualTo(Instant.parse("2026-03-01T09:30:00Z"));
+		assertThat(guestInfo.createdAt()).isEqualTo(Instant.parse("2026-03-01T09:30:00Z"));
+		assertThat(guestInfo.status()).isEqualTo(ReservationStatus.CONFIRMED);
+		assertThat(hostInfo.createdAt()).isEqualTo(Instant.parse("2026-03-01T09:30:00Z"));
+	}
+
+	@Test
+	@DisplayName("예약 API의 절대 시각은 Z를 포함하고 숙박 현지 시각은 time_zone_id와 함께 응답한다")
+	void serializesUtcAndLocalStayContract() throws Exception {
+		ReservationResponse.GuestDetail response = ReservationResponse.GuestDetail.builder()
+			.reservationUid("reservation-uid")
+			.status(ReservationStatus.CANCELLATION_PENDING)
+			.createdAt(Instant.parse("2026-08-12T05:30:00.123456Z"))
+			.checkInDateTime(LocalDateTime.of(2026, 8, 20, 15, 0))
+			.checkOutDateTime(LocalDateTime.of(2026, 8, 22, 11, 0))
+			.timeZoneId("America/New_York")
+			.build();
+		JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+		assertThat(json.path("created_at").asText())
+			.isEqualTo("2026-08-12T05:30:00.123456Z");
+		assertThat(json.path("check_in_date_time").asText())
+			.isEqualTo("2026-08-20T15:00:00");
+		assertThat(json.path("time_zone_id").asText()).isEqualTo("America/New_York");
+		assertThat(json.path("status").asText()).isEqualTo("CANCELLATION_PENDING");
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/reservation/entity/ReservationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/entity/ReservationTest.java
@@ -3,8 +3,8 @@ package kr.kro.airbob.domain.reservation.entity;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Instant;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,13 +16,38 @@ import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.member.entity.Member;
 import kr.kro.airbob.domain.reservation.dto.ReservationRequest;
 import kr.kro.airbob.domain.reservation.exception.InvalidReservationDateException;
+import kr.kro.airbob.domain.reservation.exception.InvalidReservationLocalTimeException;
 import kr.kro.airbob.domain.reservation.exception.InvalidReservationStatusException;
 
 @DisplayName("Reservation 엔티티 테스트")
 class ReservationTest {
+	private static final String TIME_ZONE_ID = "Asia/Seoul";
+	private static final Instant NOW = Instant.parse("2026-01-01T00:00:00Z");
 
 	private Accommodation accommodation;
 	private Member guest;
+
+	@Test
+	@DisplayName("리뷰 가능 상태는 CONFIRMED와 CANCELLATION_FAILED뿐이다")
+	void reviewableReservationStatuses() {
+		assertThat(ReservationStatus.CONFIRMED.isReviewableReservation()).isTrue();
+		assertThat(ReservationStatus.CANCELLATION_FAILED.isReviewableReservation()).isTrue();
+		assertThat(ReservationStatus.CANCELLATION_PENDING.isReviewableReservation()).isFalse();
+		assertThat(ReservationStatus.CANCELLED.isReviewableReservation()).isFalse();
+		assertThat(ReservationStatus.PAYMENT_PENDING.isReviewableReservation()).isFalse();
+		assertThat(ReservationStatus.EXPIRED.isReviewableReservation()).isFalse();
+	}
+
+	@Test
+	@DisplayName("확정 이후 파생된 취소 상태는 중복 결제 완료 이벤트에서 이미 확정된 예약으로 본다")
+	void confirmedPaymentStatuses() {
+		assertThat(ReservationStatus.CONFIRMED.hasConfirmedPayment()).isTrue();
+		assertThat(ReservationStatus.CANCELLATION_PENDING.hasConfirmedPayment()).isTrue();
+		assertThat(ReservationStatus.CANCELLATION_FAILED.hasConfirmedPayment()).isTrue();
+		assertThat(ReservationStatus.CANCELLED.hasConfirmedPayment()).isTrue();
+		assertThat(ReservationStatus.PAYMENT_PENDING.hasConfirmedPayment()).isFalse();
+		assertThat(ReservationStatus.EXPIRED.hasConfirmedPayment()).isFalse();
+	}
 
 	@BeforeEach
 	void setUp() {
@@ -31,6 +56,7 @@ class ReservationTest {
 			.basePrice(100_000L)
 			.checkInTime(LocalTime.of(15, 0))
 			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId(TIME_ZONE_ID)
 			.build();
 
 		guest = Member.builder()
@@ -53,7 +79,7 @@ class ReservationTest {
 			ReservationRequest.Create request = new ReservationRequest.Create(1L, checkInDate, checkOutDate, 2);
 
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 
 			// then
 			assertThat(reservation.getTotalPrice()).isEqualTo(300_000L);
@@ -68,7 +94,7 @@ class ReservationTest {
 			ReservationRequest.Create request = new ReservationRequest.Create(1L, checkInDate, checkOutDate, 2);
 
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 
 			// then
 			assertThat(reservation.getTotalPrice()).isEqualTo(100_000L);
@@ -83,7 +109,7 @@ class ReservationTest {
 			ReservationRequest.Create request = new ReservationRequest.Create(1L, checkInDate, checkOutDate, 2);
 
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 
 			// then
 			assertThat(reservation.getTotalPrice()).isEqualTo(3_000_000L);
@@ -97,7 +123,7 @@ class ReservationTest {
 			ReservationRequest.Create request = new ReservationRequest.Create(1L, sameDate, sameDate, 2);
 
 			// when & then
-			assertThatThrownBy(() -> Reservation.createPendingReservation(accommodation, guest, request, "ABC123"))
+			assertThatThrownBy(() -> Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW))
 				.isInstanceOf(InvalidReservationDateException.class)
 				.extracting(e -> ((InvalidReservationDateException)e).getErrorCode())
 				.isEqualTo(ErrorCode.INVALID_RESERVATION_DATE);
@@ -112,7 +138,7 @@ class ReservationTest {
 			ReservationRequest.Create request = new ReservationRequest.Create(1L, checkInDate, checkOutDate, 2);
 
 			// when & then
-			assertThatThrownBy(() -> Reservation.createPendingReservation(accommodation, guest, request, "ABC123"))
+			assertThatThrownBy(() -> Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW))
 				.isInstanceOf(InvalidReservationDateException.class);
 		}
 	}
@@ -122,11 +148,46 @@ class ReservationTest {
 	class StatusTransitionTest {
 
 		@Test
-		@DisplayName("PAYMENT_PENDING 상태에서 confirm() 호출 시 CONFIRMED로 변경된다")
-		void 정상_결제대기에서_확정() {
+		@DisplayName("미만료 PAYMENT_PENDING 예약은 결제 처리를 선점한다")
+		void startsPaymentBeforeExpiry() {
+			Reservation reservation = createPendingReservation();
+
+			boolean started = reservation.startPayment(NOW);
+
+			assertThat(started).isTrue();
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PROCESSING);
+		}
+
+		@Test
+		@DisplayName("만료 시각과 같거나 지난 예약은 결제 처리를 선점하지 않는다")
+		void doesNotStartPaymentAtOrAfterExpiry() {
+			Reservation reservation = createPendingReservation();
+
+			boolean started = reservation.startPayment(reservation.getExpiresAt());
+
+			assertThat(started).isFalse();
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
+		}
+
+		@Test
+		@DisplayName("이미 결제 처리 중이면 중복 요청을 선점하지 않는다")
+		void doesNotStartPaymentTwice() {
+			Reservation reservation = createPendingReservation();
+			assertThat(reservation.startPayment(NOW)).isTrue();
+
+			boolean startedAgain = reservation.startPayment(NOW.plusSeconds(1));
+
+			assertThat(startedAgain).isFalse();
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PROCESSING);
+		}
+
+		@Test
+		@DisplayName("PAYMENT_PROCESSING 상태에서 confirm() 호출 시 CONFIRMED로 변경된다")
+		void 정상_결제처리중에서_확정() {
 			// given
 			Reservation reservation = createPendingReservation();
-			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
+			reservation.startPayment(NOW);
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PROCESSING);
 
 			// when
 			reservation.confirm();
@@ -149,28 +210,41 @@ class ReservationTest {
 		}
 
 		@Test
-		@DisplayName("CONFIRMED 상태에서 cancel() 호출 시 CANCELLED로 변경된다")
-		void 정상_확정에서_취소() {
+		@DisplayName("PAYMENT_PROCESSING 상태도 PG 실패나 보상 시 EXPIRED로 변경된다")
+		void expiresPaymentProcessingReservation() {
+			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
+
+			reservation.expire();
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.EXPIRED);
+		}
+
+		@Test
+		@DisplayName("CONFIRMED 상태에서 취소 요청 시 CANCELLATION_PENDING으로 변경된다")
+		void 정상_확정에서_취소요청() {
 			// given
 			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
 			reservation.confirm();
 			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 
 			// when
-			reservation.cancel();
+			reservation.requestCancellation();
 
 			// then
-			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			assertThat(reservation.getStatus().name()).isEqualTo("CANCELLATION_PENDING");
 		}
 
 		@Test
-		@DisplayName("CANCELLED 상태에서 failCancellation() 호출 시 CANCELLATION_FAILED로 변경된다")
-		void 정상_취소에서_취소실패() {
+		@DisplayName("CANCELLATION_PENDING 상태에서 failCancellation() 호출 시 CANCELLATION_FAILED로 변경된다")
+		void 정상_취소대기에서_취소실패() {
 			// given
 			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
 			reservation.confirm();
-			reservation.cancel();
-			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			reservation.requestCancellation();
+			assertThat(reservation.getStatus().name()).isEqualTo("CANCELLATION_PENDING");
 
 			// when
 			reservation.failCancellation();
@@ -180,10 +254,51 @@ class ReservationTest {
 		}
 
 		@Test
+		@DisplayName("CANCELLATION_PENDING 상태에서 completeCancellation() 호출 시 CANCELLED로 변경된다")
+		void 정상_취소대기에서_취소완료() {
+			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
+			reservation.confirm();
+			reservation.requestCancellation();
+
+			reservation.completeCancellation();
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+		}
+
+		@Test
+		@DisplayName("CANCELLATION_FAILED 예약은 새 attempt 식별자 없이 재요청할 수 없다")
+		void 취소실패에서_재요청_거부() {
+			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
+			reservation.confirm();
+			reservation.requestCancellation();
+			reservation.failCancellation();
+
+			assertThatThrownBy(reservation::requestCancellation)
+				.isInstanceOf(InvalidReservationStatusException.class);
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_FAILED);
+		}
+
+		@Test
+		@DisplayName("CANCELLATION_FAILED 예약에 늦은 성공 이벤트가 오면 CANCELLED로 수렴한다")
+		void 취소실패에서_늦은성공_수렴() {
+			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
+			reservation.confirm();
+			reservation.requestCancellation();
+			reservation.failCancellation();
+
+			assertThat(reservation.completeCancellation()).isTrue();
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+		}
+
+		@Test
 		@DisplayName("CONFIRMED 상태에서 expire() 호출 시 InvalidReservationStatusException이 발생한다")
 		void 예외_확정상태에서_만료시도() {
 			// given
 			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
 			reservation.confirm();
 
 			// when & then
@@ -214,7 +329,7 @@ class ReservationTest {
 			Reservation reservation = createPendingReservation();
 
 			// when & then
-			assertThatThrownBy(reservation::cancel)
+			assertThatThrownBy(reservation::requestCancellation)
 				.isInstanceOf(InvalidReservationStatusException.class)
 				.extracting(e -> ((InvalidReservationStatusException)e).getErrorCode())
 				.isEqualTo(ErrorCode.CANNOT_CANCEL_RESERVATION);
@@ -225,8 +340,9 @@ class ReservationTest {
 		void 예외_취소상태에서_확정시도() {
 			// given
 			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
 			reservation.confirm();
-			reservation.cancel();
+			reservation.requestCancellation();
 
 			// when & then
 			assertThatThrownBy(reservation::confirm)
@@ -240,8 +356,9 @@ class ReservationTest {
 		void 멱등성_이미_취소실패_상태() {
 			// given
 			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
 			reservation.confirm();
-			reservation.cancel();
+			reservation.requestCancellation();
 			reservation.failCancellation();
 			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_FAILED);
 
@@ -253,16 +370,28 @@ class ReservationTest {
 		}
 
 		@Test
-		@DisplayName("CONFIRMED가 아닌 상태에서 failCancellation() 호출 시 상태가 유지된다")
-		void 멱등성_PAYMENT_PENDING에서_failCancellation_호출시_상태유지() {
+		@DisplayName("레거시 CANCELLED 예약은 PG 취소 실패 복구 시 CANCELLATION_FAILED로 되돌린다")
+		void 레거시_취소실패_복구() {
+			Reservation reservation = createPendingReservation();
+			reservation.startPayment(NOW);
+			reservation.confirm();
+			reservation.requestCancellation();
+			reservation.completeCancellation();
+
+			reservation.recoverLegacyCancellationFailure();
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_FAILED);
+		}
+
+		@Test
+		@DisplayName("PAYMENT_PENDING 상태에서 failCancellation() 호출 시 상태 오류가 발생한다")
+		void PAYMENT_PENDING에서_failCancellation_호출시_오류() {
 			// given
 			Reservation reservation = createPendingReservation();
 			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
 
-			// when - CANCELLED가 아닌 상태에서 호출
-			reservation.failCancellation();
-
-			// then - 상태 유지 (예외 없음)
+			assertThatThrownBy(reservation::failCancellation)
+				.isInstanceOf(InvalidReservationStatusException.class);
 			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
 		}
 	}
@@ -272,13 +401,89 @@ class ReservationTest {
 	class FactoryMethodTest {
 
 		@Test
+		@DisplayName("DST 전환으로 존재하지 않는 숙소 현지 체크인 시각은 예약을 거절한다")
+		void DST_gap_현지시각은_예약_거절() {
+			Accommodation newYorkAccommodation = Accommodation.builder()
+				.id(1L)
+				.basePrice(100_000L)
+				.checkInTime(LocalTime.of(2, 30))
+				.checkOutTime(LocalTime.of(1, 30))
+				.timeZoneId("America/New_York")
+				.build();
+			ReservationRequest.Create request = new ReservationRequest.Create(
+				1L,
+				LocalDate.of(2026, 3, 8),
+				LocalDate.of(2026, 3, 9),
+				2
+			);
+
+			assertThatThrownBy(() -> Reservation.createPendingReservation(
+				newYorkAccommodation, guest, request, "ABC123", NOW))
+				.isInstanceOf(InvalidReservationLocalTimeException.class)
+				.extracting(e -> ((InvalidReservationLocalTimeException)e).getErrorCode())
+				.isEqualTo(ErrorCode.RESERVATION_LOCAL_TIME_INVALID);
+		}
+
+		@Test
+		@DisplayName("DST 종료로 두 번 존재하는 숙소 현지 시각은 첫 번째 시점으로 고정한다")
+		void DST_overlap_현지시각은_첫번째_시점_사용() {
+			Accommodation newYorkAccommodation = Accommodation.builder()
+				.id(1L)
+				.basePrice(100_000L)
+				.checkInTime(LocalTime.of(1, 30))
+				.checkOutTime(LocalTime.of(0, 30))
+				.timeZoneId("America/New_York")
+				.build();
+			ReservationRequest.Create request = new ReservationRequest.Create(
+				1L,
+				LocalDate.of(2026, 11, 1),
+				LocalDate.of(2026, 11, 2),
+				2
+			);
+
+			Reservation reservation = Reservation.createPendingReservation(
+				newYorkAccommodation, guest, request, "ABC123", NOW);
+
+			assertThat(reservation.getCheckInAt()).isEqualTo(Instant.parse("2026-11-01T05:30:00Z"));
+		}
+
+		@Test
+		@DisplayName("뉴욕 DST 경계를 지나도 숙소 현지 시각을 정확한 UTC 시점으로 저장한다")
+		void 뉴욕_DST_시간대_스냅샷과_UTC_시점_계산() {
+			Accommodation newYorkAccommodation = Accommodation.builder()
+				.id(1L)
+				.basePrice(100_000L)
+				.checkInTime(LocalTime.of(15, 0))
+				.checkOutTime(LocalTime.of(11, 0))
+				.timeZoneId("America/New_York")
+				.build();
+			ReservationRequest.Create request = new ReservationRequest.Create(
+				1L,
+				LocalDate.of(2026, 3, 7),
+				LocalDate.of(2026, 3, 9),
+				2
+			);
+			Instant now = Instant.parse("2026-01-01T00:00:00Z");
+
+			Reservation reservation = Reservation.createPendingReservation(
+				newYorkAccommodation, guest, request, "ABC123", now);
+
+			assertThat(reservation.getCheckInDate()).isEqualTo(LocalDate.of(2026, 3, 7));
+			assertThat(reservation.getCheckOutDate()).isEqualTo(LocalDate.of(2026, 3, 9));
+			assertThat(reservation.getCheckInAt()).isEqualTo(Instant.parse("2026-03-07T20:00:00Z"));
+			assertThat(reservation.getCheckOutAt()).isEqualTo(Instant.parse("2026-03-09T15:00:00Z"));
+			assertThat(reservation.getTimeZoneId()).isEqualTo("America/New_York");
+			assertThat(reservation.getExpiresAt()).isEqualTo(Instant.parse("2026-01-01T00:15:00Z"));
+		}
+
+		@Test
 		@DisplayName("createPendingReservation 호출 시 PAYMENT_PENDING 상태로 생성된다")
 		void 정상_예약_생성_상태확인() {
 			// given
 			ReservationRequest.Create request = createValidRequest();
 
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 
 			// then
 			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
@@ -293,14 +498,14 @@ class ReservationTest {
 			ReservationRequest.Create request = new ReservationRequest.Create(1L, checkInDate, checkOutDate, 2);
 
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 
 			// then
-			LocalDateTime expectedCheckIn = LocalDateTime.of(2025, 1, 26, 15, 0);
-			LocalDateTime expectedCheckOut = LocalDateTime.of(2025, 1, 28, 11, 0);
+			Instant expectedCheckIn = Instant.parse("2025-01-26T06:00:00Z");
+			Instant expectedCheckOut = Instant.parse("2025-01-28T02:00:00Z");
 
-			assertThat(reservation.getCheckIn()).isEqualTo(expectedCheckIn);
-			assertThat(reservation.getCheckOut()).isEqualTo(expectedCheckOut);
+			assertThat(reservation.getCheckInAt()).isEqualTo(expectedCheckIn);
+			assertThat(reservation.getCheckOutAt()).isEqualTo(expectedCheckOut);
 		}
 
 		@Test
@@ -308,16 +513,11 @@ class ReservationTest {
 		void 만료시간_설정() {
 			// given
 			ReservationRequest.Create request = createValidRequest();
-			LocalDateTime beforeCreation = LocalDateTime.now();
-
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 
 			// then
-			LocalDateTime afterCreation = LocalDateTime.now();
-			assertThat(reservation.getExpiresAt())
-				.isAfterOrEqualTo(beforeCreation.plusMinutes(15))
-				.isBeforeOrEqualTo(afterCreation.plusMinutes(15).plusSeconds(1));
+			assertThat(reservation.getExpiresAt()).isEqualTo(NOW.plusSeconds(15 * 60));
 		}
 
 		@Test
@@ -328,7 +528,7 @@ class ReservationTest {
 			String reservationCode = "XYZ789";
 
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, reservationCode);
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, reservationCode, NOW);
 
 			// then
 			assertThat(reservation.getReservationCode()).isEqualTo(reservationCode);
@@ -341,7 +541,7 @@ class ReservationTest {
 			ReservationRequest.Create request = createValidRequest();
 
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 
 			// then
 			assertThat(reservation.getCurrency()).isEqualTo("KRW");
@@ -356,7 +556,7 @@ class ReservationTest {
 				1L, LocalDate.of(2025, 1, 26), LocalDate.of(2025, 1, 28), guestCount);
 
 			// when
-			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+			Reservation reservation = Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 
 			// then
 			assertThat(reservation.getGuestCount()).isEqualTo(guestCount);
@@ -365,7 +565,7 @@ class ReservationTest {
 
 	private Reservation createPendingReservation() {
 		ReservationRequest.Create request = createValidRequest();
-		return Reservation.createPendingReservation(accommodation, guest, request, "ABC123");
+		return Reservation.createPendingReservation(accommodation, guest, request, "ABC123", NOW);
 	}
 
 	private ReservationRequest.Create createValidRequest() {

--- a/src/test/java/kr/kro/airbob/domain/reservation/policy/BookingWindowProviderTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/policy/BookingWindowProviderTest.java
@@ -1,0 +1,27 @@
+package kr.kro.airbob.domain.reservation.policy;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("숙소 현지 날짜 기준 예약 가능 기간 테스트")
+class BookingWindowProviderTest {
+
+	@Test
+	@DisplayName("같은 UTC 시각도 숙소 시간대에 따라 서로 다른 시작일의 예약 가능 기간을 계산한다")
+	void calculatesBookingWindowFromAccommodationLocalDate() {
+		Clock clock = Clock.fixed(Instant.parse("2026-08-12T01:00:00Z"), ZoneOffset.UTC);
+		BookingWindowProvider provider = new BookingWindowProvider(clock);
+
+		assertThat(provider.currentFor("Asia/Seoul"))
+			.isEqualTo(new BookingWindow(LocalDate.of(2026, 8, 12), LocalDate.of(2026, 11, 12)));
+		assertThat(provider.currentFor("America/New_York"))
+			.isEqualTo(new BookingWindow(LocalDate.of(2026, 8, 11), LocalDate.of(2026, 11, 11)));
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/reservation/policy/BookingWindowProviderTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/policy/BookingWindowProviderTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,5 +25,65 @@ class BookingWindowProviderTest {
 			.isEqualTo(new BookingWindow(LocalDate.of(2026, 8, 12), LocalDate.of(2026, 11, 12)));
 		assertThat(provider.currentFor("America/New_York"))
 			.isEqualTo(new BookingWindow(LocalDate.of(2026, 8, 11), LocalDate.of(2026, 11, 11)));
+	}
+
+	@Test
+	@DisplayName("같은 숙박일도 현지 3개월 예약 창 안에 있는 시간대만 반환한다")
+	void findsEligibleTimeZonesForStay() {
+		Clock clock = Clock.fixed(Instant.parse("2026-08-12T00:30:00Z"), ZoneOffset.UTC);
+		BookingWindowProvider provider = new BookingWindowProvider(clock);
+
+		var eligibleTimeZones = provider.eligibleTimeZonesForStay(
+			LocalDate.of(2026, 11, 11),
+			LocalDate.of(2026, 11, 12)
+		);
+
+		assertThat(eligibleTimeZones)
+			.contains("Asia/Seoul")
+			.doesNotContain("America/New_York");
+	}
+
+	@Test
+	@DisplayName("전체 시간대의 예약 가능 여부는 동일한 기준 시각으로 계산한다")
+	void usesSingleInstantForAllTimeZones() {
+		AtomicInteger instantCalls = new AtomicInteger();
+		Instant now = Instant.parse("2026-08-12T00:30:00Z");
+		Clock clock = new Clock() {
+			@Override
+			public ZoneId getZone() {
+				return ZoneOffset.UTC;
+			}
+
+			@Override
+			public Clock withZone(ZoneId zone) {
+				return this;
+			}
+
+			@Override
+			public Instant instant() {
+				instantCalls.incrementAndGet();
+				return now;
+			}
+		};
+		BookingWindowProvider provider = new BookingWindowProvider(clock);
+
+		provider.eligibleTimeZonesForStay(
+			LocalDate.of(2026, 8, 20), LocalDate.of(2026, 8, 21));
+
+		assertThat(instantCalls).hasValue(1);
+	}
+
+	@Test
+	@DisplayName("색인 범위는 전 세계 현지 날짜의 3개월 예약 창을 포함하도록 UTC 날짜 양쪽에 하루를 둔다")
+	void calculatesGlobalSafeIndexingWindow() {
+		Clock clock = Clock.fixed(Instant.parse("2026-08-31T23:30:00Z"), ZoneOffset.UTC);
+		BookingWindowProvider provider = new BookingWindowProvider(clock);
+
+		ReservationIndexingWindow window = provider.currentIndexingWindow();
+
+		assertThat(window).isEqualTo(new ReservationIndexingWindow(
+			LocalDate.of(2026, 8, 30),
+			LocalDate.of(2026, 12, 1)
+		));
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriterIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriterIntegrationTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -70,7 +73,7 @@ class ReservationHistoryBatchWriterIntegrationTest {
 	@ValueSource(ints = {0, 1, 2, 3, 5})
 	@DisplayName("제출한 모든 history를 정확히 저장한다")
 	void persistsEverySubmittedHistory(int size) {
-		LocalDateTime historyCreatedAt = LocalDateTime.of(2026, 7, 21, 12, 30);
+		Instant historyCreatedAt = Instant.parse("2026-07-21T12:30:00Z");
 
 		writer.writeAll(histories(size), historyCreatedAt);
 
@@ -81,9 +84,9 @@ class ReservationHistoryBatchWriterIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("21개 non-ID snapshot column을 정확히 저장한다")
+	@DisplayName("24개 non-ID snapshot column을 정확히 저장한다")
 	void persistsAllSnapshotColumns() {
-		LocalDateTime historyCreatedAt = LocalDateTime.of(2026, 7, 21, 12, 30);
+		Instant historyCreatedAt = Instant.parse("2026-07-21T12:30:00Z");
 		ReservationHistory history = history(1);
 
 		writer.writeAll(List.of(history), historyCreatedAt);
@@ -98,6 +101,7 @@ class ReservationHistoryBatchWriterIntegrationTest {
 			.containsEntry("reservation_code", history.getReservationCode())
 			.containsEntry("accommodation_id", history.getAccommodationId())
 			.containsEntry("guest_id", history.getGuestId())
+			.containsEntry("time_zone_id", history.getTimeZoneId())
 			.containsEntry("guest_count", history.getGuestCount())
 			.containsEntry("total_price", history.getTotalPrice())
 			.containsEntry("currency", history.getCurrency())
@@ -109,11 +113,14 @@ class ReservationHistoryBatchWriterIntegrationTest {
 			.containsEntry("change_reason", history.getChangeReason())
 			.containsEntry("source_system", history.getSourceSystem())
 			.containsEntry("client_ip", null);
-		assertThat(asLocalDateTime(row.get("check_in"))).isEqualTo(history.getCheckIn());
-		assertThat(asLocalDateTime(row.get("check_out"))).isEqualTo(history.getCheckOut());
-		assertThat(asLocalDateTime(row.get("expires_at"))).isEqualTo(history.getExpiresAt());
-		assertThat(asLocalDateTime(row.get("created_at"))).isEqualTo(history.getCreatedAt());
-		assertThat(asLocalDateTime(row.get("history_created_at"))).isEqualTo(historyCreatedAt);
+		assertThat(asLocalDate(row.get("check_in_date"))).isEqualTo(history.getCheckInDate());
+		assertThat(asLocalDate(row.get("check_out_date"))).isEqualTo(history.getCheckOutDate());
+		assertThat(asInstant(row.get("check_in_at"))).isEqualTo(history.getCheckInAt());
+		assertThat(asInstant(row.get("check_out_at"))).isEqualTo(history.getCheckOutAt());
+		assertThat(asInstant(row.get("expires_at"))).isEqualTo(history.getExpiresAt());
+		assertThat(asInstant(row.get("created_at")))
+			.isEqualTo(Timestamp.valueOf(history.getCreatedAt()).toInstant());
+		assertThat(asInstant(row.get("history_created_at"))).isEqualTo(historyCreatedAt);
 	}
 
 	@Test
@@ -121,7 +128,7 @@ class ReservationHistoryBatchWriterIntegrationTest {
 	@DisplayName("outer transaction에 참여하고 rollback한다")
 	void joinsAndRollsBackTheOuterTransaction() {
 		assertThatThrownBy(() -> transactionTemplate.executeWithoutResult(status -> {
-			writer.writeAll(histories(5), LocalDateTime.of(2026, 7, 21, 12, 30));
+			writer.writeAll(histories(5), Instant.parse("2026-07-21T12:30:00Z"));
 			throw new IntentionalRollback();
 		})).isInstanceOf(IntentionalRollback.class);
 
@@ -146,14 +153,17 @@ class ReservationHistoryBatchWriterIntegrationTest {
 			.reservationCode("R" + index)
 			.accommodationId(100L + index)
 			.guestId(200L + index)
-			.checkIn(LocalDateTime.of(2026, 8, 1, 15, 0).plusDays(index))
-			.checkOut(LocalDateTime.of(2026, 8, 2, 11, 0).plusDays(index))
+			.checkInDate(LocalDate.of(2026, 8, 1).plusDays(index))
+			.checkOutDate(LocalDate.of(2026, 8, 2).plusDays(index))
+			.checkInAt(LocalDateTime.of(2026, 8, 1, 15, 0).plusDays(index).toInstant(ZoneOffset.UTC))
+			.checkOutAt(LocalDateTime.of(2026, 8, 2, 11, 0).plusDays(index).toInstant(ZoneOffset.UTC))
+			.timeZoneId("UTC")
 			.guestCount(2)
 			.totalPrice(100_000L + index)
 			.currency("KRW")
 			.status(ReservationStatus.EXPIRED)
 			.message("snapshot-" + index)
-			.expiresAt(LocalDateTime.of(2026, 7, 21, 11, 0))
+			.expiresAt(Instant.parse("2026-07-21T11:00:00Z"))
 			.createdAt(LocalDateTime.of(2026, 7, 1, 9, 0))
 			.createdBy(200L + index)
 			.changeType(ChangeType.STATUS_CHANGE)
@@ -168,6 +178,23 @@ class ReservationHistoryBatchWriterIntegrationTest {
 			return timestamp.toLocalDateTime();
 		}
 		return (LocalDateTime) value;
+	}
+
+	private LocalDate asLocalDate(Object value) {
+		if (value instanceof java.sql.Date date) {
+			return date.toLocalDate();
+		}
+		return (LocalDate) value;
+	}
+
+	private Instant asInstant(Object value) {
+		if (value instanceof Timestamp timestamp) {
+			return timestamp.toInstant();
+		}
+		if (value instanceof LocalDateTime localDateTime) {
+			return localDateTime.toInstant(ZoneOffset.UTC);
+		}
+		return (Instant) value;
 	}
 
 	private static class IntentionalRollback extends RuntimeException {

--- a/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriterIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriterIntegrationTest.java
@@ -10,12 +10,14 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +45,7 @@ import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(ReservationHistoryBatchWriter.class)
 @Testcontainers
+@ResourceLock("jvm-default-time-zone")
 @DisplayName("ReservationHistory JDBC batch writer MySQL integration test")
 class ReservationHistoryBatchWriterIntegrationTest {
 
@@ -84,12 +87,18 @@ class ReservationHistoryBatchWriterIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("24개 non-ID snapshot column을 정확히 저장한다")
+	@DisplayName("JVM 기본 시간대와 무관하게 24개 non-ID snapshot column을 UTC 기준으로 저장한다")
 	void persistsAllSnapshotColumns() {
 		Instant historyCreatedAt = Instant.parse("2026-07-21T12:30:00Z");
 		ReservationHistory history = history(1);
+		TimeZone originalTimeZone = TimeZone.getDefault();
 
-		writer.writeAll(List.of(history), historyCreatedAt);
+		try {
+			TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+			writer.writeAll(List.of(history), historyCreatedAt);
+		} finally {
+			TimeZone.setDefault(originalTimeZone);
+		}
 
 		Map<String, Object> row = jdbcTemplate.queryForMap(
 			"SELECT * FROM reservation_history WHERE reservation_id = ?",
@@ -115,12 +124,16 @@ class ReservationHistoryBatchWriterIntegrationTest {
 			.containsEntry("client_ip", null);
 		assertThat(asLocalDate(row.get("check_in_date"))).isEqualTo(history.getCheckInDate());
 		assertThat(asLocalDate(row.get("check_out_date"))).isEqualTo(history.getCheckOutDate());
-		assertThat(asInstant(row.get("check_in_at"))).isEqualTo(history.getCheckInAt());
-		assertThat(asInstant(row.get("check_out_at"))).isEqualTo(history.getCheckOutAt());
-		assertThat(asInstant(row.get("expires_at"))).isEqualTo(history.getExpiresAt());
-		assertThat(asInstant(row.get("created_at")))
-			.isEqualTo(Timestamp.valueOf(history.getCreatedAt()).toInstant());
-		assertThat(asInstant(row.get("history_created_at"))).isEqualTo(historyCreatedAt);
+		assertThat(readDateTime(history.getReservationId(), "check_in_at"))
+			.isEqualTo(LocalDateTime.ofInstant(history.getCheckInAt(), ZoneOffset.UTC));
+		assertThat(readDateTime(history.getReservationId(), "check_out_at"))
+			.isEqualTo(LocalDateTime.ofInstant(history.getCheckOutAt(), ZoneOffset.UTC));
+		assertThat(readDateTime(history.getReservationId(), "expires_at"))
+			.isEqualTo(LocalDateTime.ofInstant(history.getExpiresAt(), ZoneOffset.UTC));
+		assertThat(readDateTime(history.getReservationId(), "created_at"))
+			.isEqualTo(history.getCreatedAt());
+		assertThat(readDateTime(history.getReservationId(), "history_created_at"))
+			.isEqualTo(LocalDateTime.ofInstant(historyCreatedAt, ZoneOffset.UTC));
 	}
 
 	@Test
@@ -173,13 +186,6 @@ class ReservationHistoryBatchWriterIntegrationTest {
 			.build();
 	}
 
-	private LocalDateTime asLocalDateTime(Object value) {
-		if (value instanceof Timestamp timestamp) {
-			return timestamp.toLocalDateTime();
-		}
-		return (LocalDateTime) value;
-	}
-
 	private LocalDate asLocalDate(Object value) {
 		if (value instanceof java.sql.Date date) {
 			return date.toLocalDate();
@@ -187,14 +193,12 @@ class ReservationHistoryBatchWriterIntegrationTest {
 		return (LocalDate) value;
 	}
 
-	private Instant asInstant(Object value) {
-		if (value instanceof Timestamp timestamp) {
-			return timestamp.toInstant();
-		}
-		if (value instanceof LocalDateTime localDateTime) {
-			return localDateTime.toInstant(ZoneOffset.UTC);
-		}
-		return (Instant) value;
+	private LocalDateTime readDateTime(long reservationId, String column) {
+		return jdbcTemplate.queryForObject(
+			"SELECT " + column + " FROM reservation_history WHERE reservation_id = ?",
+			(resultSet, rowNumber) -> resultSet.getObject(column, LocalDateTime.class),
+			reservationId
+		);
 	}
 
 	private static class IntentionalRollback extends RuntimeException {

--- a/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriterTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriterTest.java
@@ -9,7 +9,10 @@ import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
@@ -36,6 +39,7 @@ import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReservationHistory JDBC batch writer unit test")
 class ReservationHistoryBatchWriterTest {
+	private static final Instant HISTORY_CREATED_AT = Instant.parse("2026-07-21T12:00:00Z");
 
 	@Mock private JdbcTemplate jdbcTemplate;
 	@Mock private PreparedStatement statement;
@@ -62,7 +66,7 @@ class ReservationHistoryBatchWriterTest {
 		BulkOperationContext context = new BulkOperationContext("expired-reservation-cleanup-after");
 		BulkOperationContextHolder.initContext(context);
 
-		writer.writeAll(histories(5), LocalDateTime.of(2026, 7, 21, 12, 0));
+		writer.writeAll(histories(5), HISTORY_CREATED_AT);
 		BulkOperationSnapshot snapshot = context.snapshot(BulkOperationSnapshot.Outcome.SUCCESS, 1L);
 
 		assertThat(snapshot.jdbcBatchCalls()).isEqualTo(3);
@@ -80,7 +84,7 @@ class ReservationHistoryBatchWriterTest {
 		BulkOperationContext context = new BulkOperationContext("expired-reservation-cleanup-after");
 		BulkOperationContextHolder.initContext(context);
 
-		writer.writeAll(histories(1), LocalDateTime.of(2026, 7, 21, 12, 0));
+		writer.writeAll(histories(1), HISTORY_CREATED_AT);
 
 		assertThat(context.snapshot(BulkOperationSnapshot.Outcome.SUCCESS, 1L).jdbcAffectedRows())
 			.isNull();
@@ -95,7 +99,7 @@ class ReservationHistoryBatchWriterTest {
 		BulkOperationContext context = new BulkOperationContext("expired-reservation-cleanup-after");
 		BulkOperationContextHolder.initContext(context);
 
-		assertThatThrownBy(() -> writer.writeAll(histories(1), LocalDateTime.of(2026, 7, 21, 12, 0)))
+		assertThatThrownBy(() -> writer.writeAll(histories(1), HISTORY_CREATED_AT))
 			.isInstanceOf(DataIntegrityViolationException.class);
 		assertThat(context.snapshot(BulkOperationSnapshot.Outcome.FAILURE, 1L).jdbcBatchCalls()).isZero();
 	}
@@ -109,7 +113,7 @@ class ReservationHistoryBatchWriterTest {
 		BulkOperationContext context = new BulkOperationContext("expired-reservation-cleanup-after");
 		BulkOperationContextHolder.initContext(context);
 
-		assertThatThrownBy(() -> writer.writeAll(histories(2), LocalDateTime.of(2026, 7, 21, 12, 0)))
+		assertThatThrownBy(() -> writer.writeAll(histories(2), HISTORY_CREATED_AT))
 			.isInstanceOf(DataIntegrityViolationException.class);
 		assertThat(context.snapshot(BulkOperationSnapshot.Outcome.FAILURE, 1L).jdbcBatchCalls()).isZero();
 	}
@@ -119,7 +123,7 @@ class ReservationHistoryBatchWriterTest {
 	void skipsEmptyInput() {
 		ReservationHistoryBatchWriter writer = new ReservationHistoryBatchWriter(jdbcTemplate, 2);
 
-		writer.writeAll(List.of(), LocalDateTime.of(2026, 7, 21, 12, 0));
+		writer.writeAll(List.of(), HISTORY_CREATED_AT);
 
 		then(jdbcTemplate).shouldHaveNoInteractions();
 	}
@@ -134,20 +138,22 @@ class ReservationHistoryBatchWriterTest {
 			.changeType(ChangeType.STATUS_CHANGE)
 			.build();
 
-		writer.writeAll(List.of(history), LocalDateTime.of(2026, 7, 21, 12, 0));
+		writer.writeAll(List.of(history), HISTORY_CREATED_AT);
 		batchSetterCaptor.getValue().setValues(statement, 0);
 
 		then(statement).should().setNull(4, Types.BIGINT);
 		then(statement).should().setNull(5, Types.BIGINT);
-		then(statement).should().setNull(6, Types.TIMESTAMP);
-		then(statement).should().setNull(7, Types.TIMESTAMP);
-		then(statement).should().setNull(8, Types.INTEGER);
-		then(statement).should().setNull(9, Types.BIGINT);
-		then(statement).should().setNull(13, Types.TIMESTAMP);
-		then(statement).should().setNull(14, Types.TIMESTAMP);
-		then(statement).should().setNull(15, Types.BIGINT);
-		then(statement).should().setNull(17, Types.BIGINT);
-		then(statement).should().setTimestamp(16, Timestamp.valueOf(LocalDateTime.of(2026, 7, 21, 12, 0)));
+		then(statement).should().setNull(6, Types.DATE);
+		then(statement).should().setNull(7, Types.DATE);
+		then(statement).should().setNull(8, Types.TIMESTAMP);
+		then(statement).should().setNull(9, Types.TIMESTAMP);
+		then(statement).should().setNull(11, Types.INTEGER);
+		then(statement).should().setNull(12, Types.BIGINT);
+		then(statement).should().setNull(16, Types.TIMESTAMP);
+		then(statement).should().setNull(17, Types.TIMESTAMP);
+		then(statement).should().setNull(18, Types.BIGINT);
+		then(statement).should().setNull(20, Types.BIGINT);
+		then(statement).should().setTimestamp(19, Timestamp.from(HISTORY_CREATED_AT));
 	}
 
 	private List<ReservationHistory> histories(int size) {
@@ -165,14 +171,17 @@ class ReservationHistoryBatchWriterTest {
 			.reservationCode("R" + index)
 			.accommodationId(100L + index)
 			.guestId(200L + index)
-			.checkIn(LocalDateTime.of(2026, 8, 1, 15, 0).plusDays(index))
-			.checkOut(LocalDateTime.of(2026, 8, 2, 11, 0).plusDays(index))
+			.checkInDate(LocalDate.of(2026, 8, 1).plusDays(index))
+			.checkOutDate(LocalDate.of(2026, 8, 2).plusDays(index))
+			.checkInAt(LocalDateTime.of(2026, 8, 1, 15, 0).plusDays(index).toInstant(ZoneOffset.UTC))
+			.checkOutAt(LocalDateTime.of(2026, 8, 2, 11, 0).plusDays(index).toInstant(ZoneOffset.UTC))
+			.timeZoneId("UTC")
 			.guestCount(2)
 			.totalPrice(100_000L + index)
 			.currency("KRW")
 			.status(ReservationStatus.EXPIRED)
 			.message("snapshot-" + index)
-			.expiresAt(LocalDateTime.of(2026, 7, 21, 11, 0))
+			.expiresAt(Instant.parse("2026-07-21T11:00:00Z"))
 			.createdAt(LocalDateTime.of(2026, 7, 1, 9, 0))
 			.createdBy(200L + index)
 			.changeType(ChangeType.STATUS_CHANGE)

--- a/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriterTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationHistoryBatchWriterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.*;
 import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
-import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -153,7 +152,11 @@ class ReservationHistoryBatchWriterTest {
 		then(statement).should().setNull(17, Types.TIMESTAMP);
 		then(statement).should().setNull(18, Types.BIGINT);
 		then(statement).should().setNull(20, Types.BIGINT);
-		then(statement).should().setTimestamp(19, Timestamp.from(HISTORY_CREATED_AT));
+		then(statement).should().setObject(
+			19,
+			LocalDateTime.ofInstant(HISTORY_CREATED_AT, ZoneOffset.UTC),
+			Types.TIMESTAMP
+		);
 	}
 
 	private List<ReservationHistory> histories(int size) {

--- a/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationRepositoryQueryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationRepositoryQueryTest.java
@@ -33,6 +33,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import kr.kro.airbob.config.JpaAuditingConfig;
+import kr.kro.airbob.config.ClockConfig;
 import kr.kro.airbob.config.QueryDslConfig;
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
@@ -54,6 +55,7 @@ import jakarta.persistence.EntityManager;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
+	ClockConfig.class,
     JpaAuditingConfig.class,
     QueryDslConfig.class,
     ReservationRepositoryQueryTest.SqlCaptureConfig.class

--- a/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationRepositoryQueryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/repository/ReservationRepositoryQueryTest.java
@@ -2,8 +2,12 @@ package kr.kro.airbob.domain.reservation.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -19,9 +23,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -33,9 +39,15 @@ import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
 import kr.kro.airbob.domain.member.entity.Member;
 import kr.kro.airbob.domain.member.repository.MemberRepository;
+import kr.kro.airbob.domain.payment.entity.Payment;
+import kr.kro.airbob.domain.payment.entity.PaymentMethod;
+import kr.kro.airbob.domain.payment.entity.PaymentStatus;
+import kr.kro.airbob.domain.payment.repository.PaymentRepository;
 import kr.kro.airbob.domain.reservation.dto.ReservationDateRange;
 import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.entity.ReservationFilterType;
 import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
+import jakarta.persistence.EntityManager;
 
 @DataJpaTest
 @Testcontainers
@@ -46,6 +58,7 @@ import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
     QueryDslConfig.class,
     ReservationRepositoryQueryTest.SqlCaptureConfig.class
 })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("예약 QueryDSL 저장소 테스트")
 class ReservationRepositoryQueryTest {
 
@@ -72,8 +85,471 @@ class ReservationRepositoryQueryTest {
     @Autowired
     private MemberRepository memberRepository;
 
+	@Autowired
+	private PaymentRepository paymentRepository;
+
     @Autowired
     private CapturingStatementInspector sqlInspector;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("만료 시각이 지난 결제 대기 예약은 충돌로 판단하지 않는다")
+	void expiredPendingReservationDoesNotConflict() {
+		Member member = memberRepository.save(Member.builder()
+			.email("reservation-conflict@test.com")
+			.nickname("reservation-conflict")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "conflict-target");
+		Instant now = Instant.parse("2030-01-01T00:00:00Z");
+		Instant requestedCheckInAt = Instant.parse("2030-02-01T06:00:00Z");
+		Instant requestedCheckOutAt = Instant.parse("2030-02-03T02:00:00Z");
+
+		Reservation expired = saveReservation(accommodation, member, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3),
+			requestedCheckInAt, requestedCheckOutAt, now);
+		reservationRepository.flush();
+
+		assertThat(reservationRepository.existsConflictingReservation(
+			accommodation.getId(), LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3), now
+		)).isFalse();
+
+		Reservation active = saveReservation(accommodation, member, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3),
+			requestedCheckInAt, requestedCheckOutAt, now.plus(1, ChronoUnit.MICROS));
+		reservationRepository.flush();
+
+		assertThat(reservationRepository.existsConflictingReservation(
+			accommodation.getId(), LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3), now
+		)).isTrue();
+		assertThat(reservationRepository.findMyReservationsByGuestIdWithCursor(
+			member.getId(), null, null, ReservationFilterType.UPCOMING, now, PageRequest.of(0, 10)
+		).getContent())
+			.contains(active)
+			.doesNotContain(expired);
+
+		Accommodation processingAccommodation = saveAccommodation(member, "processing-conflict-target");
+		Reservation processing = saveReservation(
+			processingAccommodation, member, ReservationStatus.PAYMENT_PROCESSING,
+			LocalDate.of(2030, 3, 1), LocalDate.of(2030, 3, 3),
+			Instant.parse("2030-03-01T06:00:00Z"), Instant.parse("2030-03-03T02:00:00Z"),
+			now.minusSeconds(1));
+		reservationRepository.flush();
+
+		assertThat(reservationRepository.existsConflictingReservation(
+			processingAccommodation.getId(), LocalDate.of(2030, 3, 1), LocalDate.of(2030, 3, 3), now
+		)).isTrue();
+		assertThat(reservationRepository.findMyReservationsByGuestIdWithCursor(
+			member.getId(), null, null, ReservationFilterType.UPCOMING, now, PageRequest.of(0, 10)
+		).getContent()).contains(processing);
+	}
+
+	@Test
+	@DisplayName("체크인 시각이나 시간대가 바뀌어도 같은 숙박 날짜는 충돌한다")
+	void sameStayDatesConflictEvenWhenInstantsDoNotOverlap() {
+		Member member = memberRepository.save(Member.builder()
+			.email("reservation-date-inventory@test.com")
+			.nickname("reservation-date-inventory")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "date-inventory-target");
+		LocalDate checkIn = LocalDate.of(2030, 2, 1);
+		LocalDate checkOut = LocalDate.of(2030, 2, 3);
+		Instant now = Instant.parse("2030-01-01T00:00:00Z");
+		saveReservation(
+			accommodation,
+			member,
+			ReservationStatus.CONFIRMED,
+			checkIn,
+			checkOut,
+			Instant.parse("2030-02-01T20:00:00Z"),
+			Instant.parse("2030-02-02T02:00:00Z"),
+			now.minusSeconds(1)
+		);
+		reservationRepository.flush();
+
+		assertThat(reservationRepository.existsConflictingReservation(
+			accommodation.getId(), checkIn, checkOut, now
+		)).isTrue();
+	}
+
+	@Test
+	@DisplayName("확정·취소 처리 중·취소 실패 예약은 모두 재고 충돌로 판단한다")
+	void everyActiveReservationStatusConflicts() {
+		Member member = memberRepository.save(Member.builder()
+			.email("active-reservation-status@test.com")
+			.nickname("active-reservation-status")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "active-status-target");
+		LocalDate checkIn = LocalDate.of(2030, 2, 1);
+		LocalDate checkOut = LocalDate.of(2030, 2, 3);
+		Instant now = Instant.parse("2030-01-01T00:00:00Z");
+
+		for (ReservationStatus status : List.of(
+			ReservationStatus.CONFIRMED,
+			ReservationStatus.CANCELLATION_PENDING,
+			ReservationStatus.CANCELLATION_FAILED
+		)) {
+			Reservation reservation = saveReservation(
+				accommodation, member, status, checkIn, checkOut);
+			reservationRepository.flush();
+
+			assertThat(reservationRepository.existsConflictingReservation(
+				accommodation.getId(), checkIn, checkOut, now))
+				.as("status=%s", status)
+				.isTrue();
+
+			reservationRepository.delete(reservation);
+			reservationRepository.flush();
+		}
+	}
+
+	@Test
+	@DisplayName("체크아웃 시각과 현재 시각이 같으면 과거 예약이고 예정 예약이 아니다")
+	void exactCheckoutIsPastAndNotUpcoming() {
+		Member host = memberRepository.save(Member.builder()
+			.email("reservation-boundary-host@test.com")
+			.nickname("reservation-boundary-host")
+			.build());
+		Member guest = memberRepository.save(Member.builder()
+			.email("reservation-boundary-guest@test.com")
+			.nickname("reservation-boundary-guest")
+			.build());
+		Accommodation accommodation = saveAccommodation(host, "boundary-target");
+		Instant now = Instant.parse("2030-02-03T02:00:00Z");
+		Reservation reservation = saveReservation(
+			accommodation, guest, ReservationStatus.CONFIRMED,
+			LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3),
+			Instant.parse("2030-02-01T06:00:00Z"), now, now.minusSeconds(1)
+		);
+		reservationRepository.flush();
+
+		assertThat(reservationRepository.findMyReservationsByGuestIdWithCursor(
+			guest.getId(), null, null, ReservationFilterType.PAST, now, PageRequest.of(0, 10)
+		).getContent()).containsExactly(reservation);
+		assertThat(reservationRepository.findMyReservationsByGuestIdWithCursor(
+			guest.getId(), null, null, ReservationFilterType.UPCOMING, now, PageRequest.of(0, 10)
+		).getContent()).isEmpty();
+		assertThat(reservationRepository.findHostReservationsByHostIdWithCursor(
+			host.getId(), null, null, ReservationFilterType.PAST, now, PageRequest.of(0, 10)
+		).getContent()).containsExactly(reservation);
+		assertThat(reservationRepository.findHostReservationsByHostIdWithCursor(
+			host.getId(), null, null, ReservationFilterType.UPCOMING, now, PageRequest.of(0, 10)
+		).getContent()).isEmpty();
+		assertThat(reservationRepository.existsPastCompletedReservationByGuest(
+			accommodation.getId(), guest.getId(), now
+		)).isTrue();
+	}
+
+	@Test
+	@DisplayName("리뷰 자격은 체크아웃한 확정·취소 실패 예약에만 부여한다")
+	void reviewEligibilityExcludesCancellationPending() {
+		Member host = memberRepository.save(Member.builder()
+			.email("review-status-host@test.com")
+			.nickname("review-status-host")
+			.build());
+		Member guest = memberRepository.save(Member.builder()
+			.email("review-status-guest@test.com")
+			.nickname("review-status-guest")
+			.build());
+		Instant now = Instant.parse("2030-02-03T02:00:00Z");
+
+		for (ReservationStatus status : ReservationStatus.values()) {
+			Accommodation accommodation = saveAccommodation(host, "review-status-" + status.name());
+			saveReservation(
+				accommodation, guest, status,
+				LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3),
+				Instant.parse("2030-02-01T06:00:00Z"), now, now.minusSeconds(1));
+			reservationRepository.flush();
+
+			assertThat(reservationRepository.existsPastCompletedReservationByGuest(
+				accommodation.getId(), guest.getId(), now))
+				.as("status=%s", status)
+				.isEqualTo(status == ReservationStatus.CONFIRMED
+					|| status == ReservationStatus.CANCELLATION_FAILED);
+		}
+	}
+
+	@Test
+	@DisplayName("과거·예정 목록은 활성 상태를 포함하고 게스트 취소 목록은 배치 전 만료 예약도 포함한다")
+	void reservationFiltersUseActiveAndTerminalStatusSets() {
+		Member host = memberRepository.save(Member.builder()
+			.email("filter-status-host@test.com")
+			.nickname("filter-status-host")
+			.build());
+		Member guest = memberRepository.save(Member.builder()
+			.email("filter-status-guest@test.com")
+			.nickname("filter-status-guest")
+			.build());
+		Accommodation accommodation = saveAccommodation(host, "filter-status-target");
+		Instant now = Instant.parse("2030-02-03T02:00:00Z");
+		List<Reservation> pastActive = new ArrayList<>();
+		List<Reservation> upcomingActive = new ArrayList<>();
+
+		for (ReservationStatus status : List.of(
+			ReservationStatus.CONFIRMED,
+			ReservationStatus.CANCELLATION_PENDING,
+			ReservationStatus.CANCELLATION_FAILED
+		)) {
+			pastActive.add(saveReservation(
+				accommodation, guest, status,
+				LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3),
+				Instant.parse("2030-02-01T06:00:00Z"), now, now.minusSeconds(1)));
+			upcomingActive.add(saveReservation(
+				accommodation, guest, status,
+				LocalDate.of(2030, 2, 4), LocalDate.of(2030, 2, 5),
+				Instant.parse("2030-02-04T06:00:00Z"),
+				Instant.parse("2030-02-05T02:00:00Z"), now.minusSeconds(1)));
+		}
+		Reservation cancelled = saveReservation(
+			accommodation, guest, ReservationStatus.CANCELLED,
+			LocalDate.of(2030, 2, 4), LocalDate.of(2030, 2, 5));
+		Reservation expired = saveReservation(
+			accommodation, guest, ReservationStatus.EXPIRED,
+			LocalDate.of(2030, 2, 5), LocalDate.of(2030, 2, 6));
+		Reservation expiredPending = saveReservation(
+			accommodation, guest, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 6), LocalDate.of(2030, 2, 7),
+			Instant.parse("2030-02-06T06:00:00Z"),
+			Instant.parse("2030-02-07T02:00:00Z"), now);
+		Reservation processing = saveReservation(
+			accommodation, guest, ReservationStatus.PAYMENT_PROCESSING,
+			LocalDate.of(2030, 2, 7), LocalDate.of(2030, 2, 8),
+			Instant.parse("2030-02-07T06:00:00Z"),
+			Instant.parse("2030-02-08T02:00:00Z"), now.minusSeconds(1));
+		reservationRepository.flush();
+		List<Reservation> guestUpcoming = new ArrayList<>(upcomingActive);
+		guestUpcoming.add(processing);
+
+		assertThat(reservationRepository.findMyReservationsByGuestIdWithCursor(
+			guest.getId(), null, null, ReservationFilterType.PAST, now, PageRequest.of(0, 20)
+		).getContent()).containsExactlyInAnyOrderElementsOf(pastActive);
+		assertThat(reservationRepository.findMyReservationsByGuestIdWithCursor(
+			guest.getId(), null, null, ReservationFilterType.UPCOMING, now, PageRequest.of(0, 20)
+		).getContent()).containsExactlyInAnyOrderElementsOf(guestUpcoming);
+		assertThat(reservationRepository.findMyReservationsByGuestIdWithCursor(
+			guest.getId(), null, null, ReservationFilterType.CANCELLED, now, PageRequest.of(0, 20)
+		).getContent()).containsExactlyInAnyOrder(cancelled, expired, expiredPending);
+
+		assertThat(reservationRepository.findHostReservationsByHostIdWithCursor(
+			host.getId(), null, null, ReservationFilterType.PAST, now, PageRequest.of(0, 20)
+		).getContent()).containsExactlyInAnyOrderElementsOf(pastActive);
+		assertThat(reservationRepository.findHostReservationsByHostIdWithCursor(
+			host.getId(), null, null, ReservationFilterType.UPCOMING, now, PageRequest.of(0, 20)
+		).getContent()).containsExactlyInAnyOrderElementsOf(upcomingActive);
+		assertThat(reservationRepository.findHostReservationsByHostIdWithCursor(
+			host.getId(), null, null, ReservationFilterType.CANCELLED, now, PageRequest.of(0, 20)
+		).getContent()).containsExactlyInAnyOrder(cancelled, expired);
+	}
+
+	@Test
+	@DisplayName("만료 경계 이전과 정확한 경계의 결제 대기 예약만 조회한다")
+	void findsExpiredPendingReservationsAtOrBeforeCutoff() {
+		Member member = memberRepository.save(Member.builder()
+			.email("reservation-expiry-query@test.com")
+			.nickname("reservation-expiry-query")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "expiry-target");
+		Instant cutoff = Instant.parse("2030-01-01T00:00:00.123456Z");
+		Reservation before = saveReservation(accommodation, member, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 2),
+			Instant.parse("2030-02-01T06:00:00Z"), Instant.parse("2030-02-02T02:00:00Z"),
+			cutoff.minus(1, ChronoUnit.MICROS));
+		Reservation exact = saveReservation(accommodation, member, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 2), LocalDate.of(2030, 2, 3),
+			Instant.parse("2030-02-02T06:00:00Z"), Instant.parse("2030-02-03T02:00:00Z"), cutoff);
+		saveReservation(accommodation, member, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 3), LocalDate.of(2030, 2, 4),
+			Instant.parse("2030-02-03T06:00:00Z"), Instant.parse("2030-02-04T02:00:00Z"),
+			cutoff.plus(1, ChronoUnit.MICROS));
+		reservationRepository.flush();
+
+		assertThat(reservationRepository.findAllByStatusAndExpiresAtLessThanEqual(
+			ReservationStatus.PAYMENT_PENDING, cutoff
+		)).containsExactlyInAnyOrder(before, exact);
+	}
+
+	@Test
+	@DisplayName("예약의 절대 시각은 MySQL 왕복 후에도 마이크로초 정밀도로 유지된다")
+	void instantColumnsRoundTripWithMicrosecondPrecision() {
+		Member member = memberRepository.save(Member.builder()
+			.email("reservation-instant-roundtrip@test.com")
+			.nickname("reservation-instant-roundtrip")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "instant-roundtrip-target");
+		Instant checkInAt = Instant.parse("2030-02-01T06:00:00.123456Z");
+		Instant checkOutAt = Instant.parse("2030-02-03T02:00:00.234567Z");
+		Instant expiresAt = Instant.parse("2030-01-01T00:15:00.345678Z");
+		Reservation saved = saveReservation(accommodation, member, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3), checkInAt, checkOutAt, expiresAt);
+		reservationRepository.flush();
+		entityManager.clear();
+
+		Reservation reloaded = reservationRepository.findById(saved.getId()).orElseThrow();
+
+		assertThat(reloaded.getCheckInAt()).isEqualTo(checkInAt);
+		assertThat(reloaded.getCheckOutAt()).isEqualTo(checkOutAt);
+		assertThat(reloaded.getExpiresAt()).isEqualTo(expiresAt);
+	}
+
+	@Test
+	@DisplayName("상태 변경용 예약 조회는 비관적 쓰기 잠금을 건다")
+	void lockedLookupUsesForUpdate() {
+		Member member = memberRepository.save(Member.builder()
+			.email("reservation-lock-query@test.com")
+			.nickname("reservation-lock-query")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "lock-target");
+		Reservation reservation = saveReservation(
+			accommodation,
+			member,
+			ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 1),
+			LocalDate.of(2030, 2, 2)
+		);
+		reservationRepository.flush();
+		sqlInspector.clear();
+
+		assertThat(reservationRepository.findByReservationUidWithLock(
+			reservation.getReservationUid())).contains(reservation);
+
+		assertThat(sqlInspector.singleSelect()).contains(" for update");
+	}
+
+	@Test
+	@DisplayName("예약 생성용 숙소 조회는 비관적 쓰기 잠금을 건다")
+	void reservationAccommodationLookupUsesForUpdate() {
+		Member member = memberRepository.save(Member.builder()
+			.email("reservation-accommodation-lock@test.com")
+			.nickname("reservation-accommodation-lock")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "reservation-accommodation-lock-target");
+		accommodationRepository.flush();
+		entityManager.clear();
+		sqlInspector.clear();
+
+		assertThat(accommodationRepository.findByIdAndStatusForUpdate(
+			accommodation.getId(), AccommodationStatus.PUBLISHED)).isPresent();
+
+		assertThat(sqlInspector.singleSelect()).contains(" for update");
+	}
+
+	@Test
+	@DisplayName("숙소 수정용 소유자 조회는 비관적 쓰기 잠금을 건다")
+	void updateAccommodationLookupUsesForUpdate() {
+		Member member = memberRepository.save(Member.builder()
+			.email("update-accommodation-lock@test.com")
+			.nickname("update-accommodation-lock")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "update-accommodation-lock-target");
+		accommodationRepository.flush();
+		entityManager.clear();
+		sqlInspector.clear();
+
+		assertThat(accommodationRepository.findByIdAndMemberIdAndStatusNotForUpdate(
+			accommodation.getId(), member.getId(), AccommodationStatus.DELETED)).isPresent();
+
+		assertThat(sqlInspector.singleSelect()).contains(" for update");
+	}
+
+	@Test
+	@DisplayName("미래 재고를 점유하는 상태와 미만료 결제 대기만 시간 설정 변경을 차단한다")
+	void futureInventoryReservationUsesStatusExpiryAndCheckoutBoundaries() {
+		Member member = memberRepository.save(Member.builder()
+			.email("future-inventory-guard@test.com")
+			.nickname("future-inventory-guard")
+			.build());
+		Instant now = Instant.parse("2030-02-03T02:00:00Z");
+
+		for (ReservationStatus status : List.of(
+			ReservationStatus.PAYMENT_PROCESSING,
+			ReservationStatus.CONFIRMED,
+			ReservationStatus.CANCELLATION_PENDING,
+			ReservationStatus.CANCELLATION_FAILED
+		)) {
+			Accommodation accommodation = saveAccommodation(member, "future-active-" + status);
+			saveReservation(
+				accommodation, member, status,
+				LocalDate.of(2030, 2, 3), LocalDate.of(2030, 2, 4),
+				now, now.plusSeconds(1), now.minusSeconds(1));
+			reservationRepository.flush();
+
+			assertThat(reservationRepository.existsFutureInventoryReservation(
+				accommodation.getId(), now))
+				.as("status=%s", status)
+				.isTrue();
+		}
+
+		Accommodation pending = saveAccommodation(member, "future-pending");
+		saveReservation(
+			pending, member, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 3), LocalDate.of(2030, 2, 4),
+			now, now.plusSeconds(1), now.plusSeconds(1));
+		reservationRepository.flush();
+		assertThat(reservationRepository.existsFutureInventoryReservation(pending.getId(), now)).isTrue();
+
+		Accommodation expiredPending = saveAccommodation(member, "expired-pending-boundary");
+		saveReservation(
+			expiredPending, member, ReservationStatus.PAYMENT_PENDING,
+			LocalDate.of(2030, 2, 3), LocalDate.of(2030, 2, 4),
+			now, now.plusSeconds(1), now);
+		reservationRepository.flush();
+		assertThat(reservationRepository.existsFutureInventoryReservation(
+			expiredPending.getId(), now)).isFalse();
+
+		Accommodation checkoutBoundary = saveAccommodation(member, "checkout-boundary");
+		saveReservation(
+			checkoutBoundary, member, ReservationStatus.CONFIRMED,
+			LocalDate.of(2030, 2, 2), LocalDate.of(2030, 2, 3),
+			now.minusSeconds(1), now, now.minusSeconds(1));
+		reservationRepository.flush();
+		assertThat(reservationRepository.existsFutureInventoryReservation(
+			checkoutBoundary.getId(), now)).isFalse();
+
+		for (ReservationStatus status : List.of(ReservationStatus.CANCELLED, ReservationStatus.EXPIRED)) {
+			Accommodation accommodation = saveAccommodation(member, "terminal-" + status);
+			saveReservation(
+				accommodation, member, status,
+				LocalDate.of(2030, 2, 3), LocalDate.of(2030, 2, 4),
+				now, now.plusSeconds(1), now.plusSeconds(1));
+			reservationRepository.flush();
+
+			assertThat(reservationRepository.existsFutureInventoryReservation(
+				accommodation.getId(), now))
+				.as("status=%s", status)
+				.isFalse();
+		}
+	}
+
+	@Test
+	@DisplayName("결제 취소 결과 반영용 결제 조회는 비관적 쓰기 잠금을 건다")
+	void paymentCancellationLookupUsesForUpdate() {
+		Member member = memberRepository.save(Member.builder()
+			.email("payment-lock-query@test.com")
+			.nickname("payment-lock-query")
+			.build());
+		Accommodation accommodation = saveAccommodation(member, "payment-lock-target");
+		Reservation reservation = saveReservation(
+			accommodation, member, ReservationStatus.CANCELLATION_PENDING,
+			LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 2));
+		Payment payment = paymentRepository.save(Payment.builder()
+			.paymentKey("payment-lock-key")
+			.orderId(reservation.getReservationUid().toString())
+			.amount(100_000L)
+			.method(PaymentMethod.CARD)
+			.approvedAt(Instant.parse("2030-01-01T12:00:00Z"))
+			.reservation(reservation)
+			.status(PaymentStatus.DONE)
+			.balanceAmount(100_000L)
+			.build());
+		paymentRepository.flush();
+		sqlInspector.clear();
+
+		assertThat(paymentRepository.findByReservationReservationUidWithLock(
+			reservation.getReservationUid())).contains(payment);
+
+		assertThat(sqlInspector.singleSelect()).contains(" for update");
+	}
 
     @Test
     @DisplayName("ID 조회는 지정 기간과 겹치는 확정 예약만 날짜 구간으로 반환한다")
@@ -84,10 +560,10 @@ class ReservationRepositoryQueryTest {
             .build());
         Accommodation target = saveAccommodation(member, "window-target");
         Accommodation other = saveAccommodation(member, "window-other");
-        LocalDateTime windowStart = LocalDateTime.of(2030, 1, 1, 0, 0);
-        LocalDateTime windowEndExclusive = LocalDateTime.of(2030, 4, 1, 0, 0);
+        LocalDate windowStart = LocalDate.of(2030, 1, 1);
+        LocalDate windowEndExclusive = LocalDate.of(2030, 4, 1);
 
-        ReservationDateRange overlapsStart = new ReservationDateRange(
+		ReservationDateRange overlapsStart = new ReservationDateRange(
             windowStart.minusDays(2), windowStart.plusDays(1));
         ReservationDateRange inside = new ReservationDateRange(
             windowStart.plusDays(10), windowStart.plusDays(12));
@@ -98,75 +574,113 @@ class ReservationRepositoryQueryTest {
             overlapsStart.checkIn(), overlapsStart.checkOut());
         saveReservation(target, member, ReservationStatus.CONFIRMED,
             windowStart.minusDays(2), windowStart);
-        saveReservation(target, member, ReservationStatus.CONFIRMED,
-            inside.checkIn(), inside.checkOut());
+		saveReservation(target, member, ReservationStatus.CONFIRMED,
+			inside.checkIn(), inside.checkOut());
+		saveReservation(target, member, ReservationStatus.CANCELLATION_PENDING,
+			inside.checkIn().plusDays(20), inside.checkOut().plusDays(20));
+		saveReservation(target, member, ReservationStatus.CANCELLATION_FAILED,
+			inside.checkIn().plusDays(30), inside.checkOut().plusDays(30));
         saveReservation(target, member, ReservationStatus.CONFIRMED,
             overlapsEnd.checkIn(), overlapsEnd.checkOut());
         saveReservation(target, member, ReservationStatus.CONFIRMED,
             windowEndExclusive, windowEndExclusive.plusDays(2));
-        saveReservation(target, member, ReservationStatus.PAYMENT_PENDING,
-            inside.checkIn(), inside.checkOut());
+		saveReservation(target, member, ReservationStatus.PAYMENT_PENDING,
+			inside.checkIn(), inside.checkOut());
+		saveReservation(target, member, ReservationStatus.CANCELLED,
+			inside.checkIn(), inside.checkOut());
+		saveReservation(target, member, ReservationStatus.EXPIRED,
+			inside.checkIn(), inside.checkOut());
         saveReservation(other, member, ReservationStatus.CONFIRMED,
             inside.checkIn(), inside.checkOut());
         reservationRepository.flush();
 
         sqlInspector.clear();
         List<ReservationDateRange> result = reservationRepository
-            .findConfirmedReservationRangesByAccommodationId(
+			.findActiveReservationRangesByAccommodationId(
                 target.getId(), windowStart, windowEndExclusive);
         String sql = sqlInspector.singleSelect();
 
-		assertThat(result).containsExactlyInAnyOrder(overlapsStart, inside, overlapsEnd);
+		assertThat(result).containsExactlyInAnyOrder(
+			overlapsStart,
+			inside,
+			overlapsEnd,
+			new ReservationDateRange(inside.checkIn().plusDays(20), inside.checkOut().plusDays(20)),
+			new ReservationDateRange(inside.checkIn().plusDays(30), inside.checkOut().plusDays(30))
+		);
         assertDateRangeProjection(sql);
         assertThat(sql)
             .contains(".accommodation_id=?")
-            .contains(".check_in<?")
-            .contains(".check_out>?")
+			.contains(".check_in_date<?")
+			.contains(".check_out_date>?")
 			.doesNotContain(" join accommodation ")
 			.doesNotContain(" order by ");
     }
 
     @Test
-    @DisplayName("UUID 조회는 날짜 두 컬럼만 projection하고 대상 숙소의 모든 미래 확정 예약을 반환한다")
-    void uidQueryProjectsAllFutureConfirmedReservationRanges() {
+	@DisplayName("UUID 조회도 지정 기간과 겹치는 활성 예약만 날짜 두 컬럼으로 반환한다")
+	void uidQueryProjectsOnlyActiveReservationRangesOverlappingWindow() {
         Member member = memberRepository.save(Member.builder()
             .email("reservation-query@test.com")
             .nickname("reservation-query")
             .build());
         Accommodation target = saveAccommodation(member, "target");
         Accommodation other = saveAccommodation(member, "other");
-        LocalDateTime base = LocalDateTime.now().withNano(0);
+		LocalDate base = LocalDate.of(2030, 6, 1);
 
         ReservationDateRange first = new ReservationDateRange(
             base.plusDays(1), base.plusDays(3));
         ReservationDateRange second = new ReservationDateRange(
             base.plusDays(4), base.plusDays(6));
+		ReservationDateRange past = new ReservationDateRange(
+			base.minusDays(3), base.minusDays(1));
+		ReservationDateRange overlapsStart = new ReservationDateRange(
+			base.minusDays(2), base.plusDays(1));
+		LocalDate windowEndExclusive = base.plusDays(10);
 
         saveReservation(target, member, ReservationStatus.CONFIRMED,
             first.checkIn(), first.checkOut());
-        saveReservation(target, member, ReservationStatus.CONFIRMED,
-            second.checkIn(), second.checkOut());
-        saveReservation(
-            target, member, ReservationStatus.CONFIRMED,
-            base.minusDays(3), base.minusDays(1));
-        saveReservation(
-            target, member, ReservationStatus.PAYMENT_PENDING,
-            base.plusDays(1), base.plusDays(3));
+		saveReservation(target, member, ReservationStatus.CONFIRMED,
+			second.checkIn(), second.checkOut());
+		ReservationDateRange cancellationPending = new ReservationDateRange(
+			base.plusDays(7), base.plusDays(9));
+		ReservationDateRange cancellationFailed = new ReservationDateRange(
+			base.plusDays(10), base.plusDays(12));
+		saveReservation(target, member, ReservationStatus.CANCELLATION_PENDING,
+			cancellationPending.checkIn(), cancellationPending.checkOut());
+		saveReservation(target, member, ReservationStatus.CANCELLATION_FAILED,
+			cancellationFailed.checkIn(), cancellationFailed.checkOut());
+		saveReservation(
+			target, member, ReservationStatus.CONFIRMED,
+			past.checkIn(), past.checkOut());
+		saveReservation(target, member, ReservationStatus.CONFIRMED,
+			overlapsStart.checkIn(), overlapsStart.checkOut());
+		saveReservation(target, member, ReservationStatus.CONFIRMED,
+			base.minusDays(2), base);
+		saveReservation(
+			target, member, ReservationStatus.PAYMENT_PENDING,
+			base.plusDays(1), base.plusDays(3));
+		saveReservation(target, member, ReservationStatus.CANCELLED,
+			base.plusDays(13), base.plusDays(14));
+		saveReservation(target, member, ReservationStatus.EXPIRED,
+			base.plusDays(15), base.plusDays(16));
         saveReservation(
             other, member, ReservationStatus.CONFIRMED,
             base.plusDays(1), base.plusDays(3));
         reservationRepository.flush();
 
         sqlInspector.clear();
-        List<ReservationDateRange> byUid = reservationRepository
-            .findFutureConfirmedReservationRangesByAccommodationUid(
-                target.getAccommodationUid());
+		List<ReservationDateRange> byUid = reservationRepository
+			.findActiveReservationRangesByAccommodationUid(
+				target.getAccommodationUid(), base, windowEndExclusive);
         String uidSql = sqlInspector.singleSelect();
 
-        assertThat(byUid).containsExactlyInAnyOrder(first, second);
-        assertDateRangeProjection(uidSql);
-        assertThat(uidSql)
-            .contains(".check_out>=?")
+		assertThat(byUid).containsExactlyInAnyOrder(
+			overlapsStart, first, second, cancellationPending);
+		assertDateRangeProjection(uidSql);
+		assertThat(uidSql)
+			.contains(".check_in_date<?")
+			.contains(".check_out_date>?")
+			.doesNotContain(".check_out_at")
             .doesNotContain(" order by ");
     }
 
@@ -178,8 +692,8 @@ class ReservationRepositoryQueryTest {
             sql.substring("select ".length(), fromIndex).split(","));
 
         assertThat(selectedColumns).hasSize(2);
-        assertThat(selectedColumns.get(0)).contains(".check_in");
-        assertThat(selectedColumns.get(1)).contains(".check_out");
+		assertThat(selectedColumns.get(0)).contains(".check_in_date");
+		assertThat(selectedColumns.get(1)).contains(".check_out_date");
     }
 
     private Accommodation saveAccommodation(Member member, String name) {
@@ -188,6 +702,7 @@ class ReservationRepositoryQueryTest {
             .name(name)
             .checkInTime(LocalTime.of(15, 0))
             .checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId("UTC")
             .status(AccommodationStatus.PUBLISHED)
             .build());
     }
@@ -196,19 +711,44 @@ class ReservationRepositoryQueryTest {
         Accommodation accommodation,
         Member guest,
         ReservationStatus status,
-        LocalDateTime checkIn,
-        LocalDateTime checkOut
+		LocalDate checkIn,
+		LocalDate checkOut
     ) {
+		return saveReservation(
+			accommodation,
+			guest,
+			status,
+			checkIn,
+			checkOut,
+			checkIn.atTime(15, 0).toInstant(ZoneOffset.UTC),
+			checkOut.atTime(11, 0).toInstant(ZoneOffset.UTC),
+			Instant.parse("2029-01-01T00:15:00Z")
+		);
+	}
+
+	private Reservation saveReservation(
+		Accommodation accommodation,
+		Member guest,
+		ReservationStatus status,
+		LocalDate checkIn,
+		LocalDate checkOut,
+		Instant checkInAt,
+		Instant checkOutAt,
+		Instant expiresAt
+	) {
         return reservationRepository.save(Reservation.builder()
             .accommodation(accommodation)
             .guest(guest)
-            .checkIn(checkIn)
-            .checkOut(checkOut)
+			.checkInDate(checkIn)
+			.checkOutDate(checkOut)
+			.checkInAt(checkInAt)
+			.checkOutAt(checkOutAt)
+			.timeZoneId("UTC")
             .guestCount(1)
             .totalPrice(100_000L)
             .currency("KRW")
             .status(status)
-            .expiresAt(LocalDateTime.now().plusMinutes(15))
+			.expiresAt(expiresAt)
             .build());
     }
 

--- a/src/test/java/kr/kro/airbob/domain/reservation/service/ExpiredReservationCleanupServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/service/ExpiredReservationCleanupServiceTest.java
@@ -12,6 +12,10 @@ import static org.mockito.Mockito.inOrder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -36,6 +40,7 @@ import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ExpiredReservationCleanupService 테스트")
 class ExpiredReservationCleanupServiceTest {
+	private static final Instant NOW = Instant.parse("2026-07-21T10:00:00Z");
 
 	@Mock
 	private ReservationRepository reservationRepository;
@@ -50,24 +55,46 @@ class ExpiredReservationCleanupServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		service = new ExpiredReservationCleanupService(reservationRepository, batchWriter, holdService);
+		service = new ExpiredReservationCleanupService(
+			reservationRepository,
+			batchWriter,
+			holdService,
+			Clock.fixed(NOW, ZoneOffset.UTC)
+		);
 		first = pendingReservation(1L, 11L, LocalDate.of(2026, 8, 1));
 		second = pendingReservation(2L, 12L, LocalDate.of(2026, 8, 3));
 	}
 
 	@Test
+	@DisplayName("만료 시각과 현재 시각이 같으면 만료 대상으로 조회한다")
+	void expiresReservationAtExactBoundary() {
+		given(reservationRepository.findAllByStatusAndExpiresAtLessThanEqual(
+			ReservationStatus.PAYMENT_PENDING,
+			NOW
+		)).willReturn(List.of(first));
+
+		int cleaned = service.cleanupExpiredPendingReservations();
+
+		assertThat(cleaned).isEqualTo(1);
+		then(reservationRepository).should().findAllByStatusAndExpiresAtLessThanEqual(
+			ReservationStatus.PAYMENT_PENDING,
+			NOW
+		);
+	}
+
+	@Test
 	@DisplayName("모든 history batch가 성공한 뒤 hold를 제거한다")
 	void removesHoldsOnlyAfterHistoryBatchSucceeds() {
-		given(reservationRepository.findAllByStatusAndExpiresAtBefore(
+		given(reservationRepository.findAllByStatusAndExpiresAtLessThanEqual(
 			eq(ReservationStatus.PAYMENT_PENDING),
-			any(LocalDateTime.class)
+			any(Instant.class)
 		)).willReturn(List.of(first, second));
 
 		int cleaned = service.cleanupExpiredPendingReservations();
 
 		assertThat(cleaned).isEqualTo(2);
 		ArgumentCaptor<List<ReservationHistory>> histories = ArgumentCaptor.forClass(List.class);
-		ArgumentCaptor<LocalDateTime> historyCreatedAt = ArgumentCaptor.forClass(LocalDateTime.class);
+		ArgumentCaptor<Instant> historyCreatedAt = ArgumentCaptor.forClass(Instant.class);
 		InOrder order = inOrder(batchWriter, holdService);
 		order.verify(batchWriter).writeAll(histories.capture(), historyCreatedAt.capture());
 		order.verify(holdService).removeHold(
@@ -78,8 +105,8 @@ class ExpiredReservationCleanupServiceTest {
 		);
 		assertThat(histories.getValue()).extracting(ReservationHistory::getStatus)
 			.containsOnly(ReservationStatus.EXPIRED);
-		ArgumentCaptor<LocalDateTime> cutoff = ArgumentCaptor.forClass(LocalDateTime.class);
-		then(reservationRepository).should().findAllByStatusAndExpiresAtBefore(
+		ArgumentCaptor<Instant> cutoff = ArgumentCaptor.forClass(Instant.class);
+		then(reservationRepository).should().findAllByStatusAndExpiresAtLessThanEqual(
 			eq(ReservationStatus.PAYMENT_PENDING),
 			cutoff.capture()
 		);
@@ -89,10 +116,10 @@ class ExpiredReservationCleanupServiceTest {
 	@Test
 	@DisplayName("history batch 실패 시 hold를 제거하지 않는다")
 	void doesNotRemoveHoldsWhenHistoryBatchFails() {
-		given(reservationRepository.findAllByStatusAndExpiresAtBefore(any(), any()))
+		given(reservationRepository.findAllByStatusAndExpiresAtLessThanEqual(any(), any()))
 			.willReturn(List.of(first, second));
 		willThrow(new DataIntegrityViolationException("intentional"))
-			.given(batchWriter).writeAll(anyList(), any(LocalDateTime.class));
+			.given(batchWriter).writeAll(anyList(), any(Instant.class));
 
 		assertThatThrownBy(service::cleanupExpiredPendingReservations)
 			.isInstanceOf(DataIntegrityViolationException.class);
@@ -103,7 +130,7 @@ class ExpiredReservationCleanupServiceTest {
 	@Test
 	@DisplayName("만료된 예약이 없으면 history를 저장하거나 hold를 제거하지 않는다")
 	void doesNothingWhenNoExpiredReservationsExist() {
-		given(reservationRepository.findAllByStatusAndExpiresAtBefore(any(), any()))
+		given(reservationRepository.findAllByStatusAndExpiresAtLessThanEqual(any(), any()))
 			.willReturn(List.of());
 
 		int cleaned = service.cleanupExpiredPendingReservations();
@@ -126,13 +153,16 @@ class ExpiredReservationCleanupServiceTest {
 			.reservationCode("R" + reservationId)
 			.accommodation(accommodation)
 			.guest(guest)
-			.checkIn(checkIn.atTime(15, 0))
-			.checkOut(checkIn.plusDays(1).atTime(11, 0))
+			.checkInDate(checkIn)
+			.checkOutDate(checkIn.plusDays(1))
+			.checkInAt(checkIn.atTime(15, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant())
+			.checkOutAt(checkIn.plusDays(1).atTime(11, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant())
+			.timeZoneId("Asia/Seoul")
 			.guestCount(2)
 			.totalPrice(100_000L)
 			.currency("KRW")
 			.status(ReservationStatus.PAYMENT_PENDING)
-			.expiresAt(LocalDateTime.of(2026, 7, 21, 10, 0))
+			.expiresAt(NOW)
 			.createdAt(LocalDateTime.of(2026, 7, 1, 9, 0))
 			.updatedAt(LocalDateTime.of(2026, 7, 1, 9, 0))
 			.build();

--- a/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationHistoryInsertBeforeBenchmarkServiceProfileTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationHistoryInsertBeforeBenchmarkServiceProfileTest.java
@@ -3,6 +3,8 @@ package kr.kro.airbob.domain.reservation.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Clock;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -55,6 +57,11 @@ class ReservationHistoryInsertBeforeBenchmarkServiceProfileTest {
 		@Bean
 		ReservationHistoryRepository reservationHistoryRepository() {
 			return mock(ReservationHistoryRepository.class);
+		}
+
+		@Bean
+		Clock clock() {
+			return Clock.systemUTC();
 		}
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.*;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.api.RLock;
 
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
+import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
+import kr.kro.airbob.domain.accommodation.exception.AccommodationNotFoundException;
+import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
+import kr.kro.airbob.domain.accommodation.repository.projection.AccommodationBookingProjection;
 import kr.kro.airbob.domain.member.entity.Member;
 import kr.kro.airbob.domain.payment.dto.PaymentRequest;
 import kr.kro.airbob.domain.payment.event.PaymentEvent;
@@ -31,10 +36,14 @@ import kr.kro.airbob.domain.reservation.exception.InvalidReservationDateExceptio
 import kr.kro.airbob.domain.reservation.exception.ReservationLockException;
 import kr.kro.airbob.domain.reservation.exception.ReservationOutsideBookingWindowException;
 import kr.kro.airbob.domain.reservation.policy.BookingWindow;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReservationService 테스트")
 class ReservationServiceTest {
+	private static final String TIME_ZONE_ID = "Asia/Seoul";
+	private static final LocalDate WINDOW_START = LocalDate.of(2026, 8, 12);
+	private static final BookingWindow BOOKING_WINDOW = BookingWindow.startingOn(WINDOW_START);
 
 	@InjectMocks
 	private ReservationService reservationService;
@@ -49,6 +58,12 @@ class ReservationServiceTest {
 	private ReservationTransactionService transactionService;
 
 	@Mock
+	private AccommodationRepository accommodationRepository;
+
+	@Mock
+	private BookingWindowProvider bookingWindowProvider;
+
+	@Mock
 	private RLock mockLock;
 
 	private ReservationRequest.Create validRequest;
@@ -58,7 +73,7 @@ class ReservationServiceTest {
 	@BeforeEach
 	void setUp() {
 		memberId = 1L;
-		LocalDate checkInDate = BookingWindow.current().startInclusive().plusDays(1);
+		LocalDate checkInDate = WINDOW_START.plusDays(1);
 		validRequest = new ReservationRequest.Create(
 			1L,
 			checkInDate,
@@ -99,6 +114,7 @@ class ReservationServiceTest {
 		@DisplayName("정상적인 예약 생성 시 Ready 응답이 반환된다")
 		void 정상_예약_생성_성공() {
 			// given
+			givenPublishedBookingWindow();
 			given(holdService.isAnyDateHeld(anyLong(), any(LocalDate.class), any(LocalDate.class)))
 				.willReturn(false);
 			given(lockManager.acquireLocks(anyList()))
@@ -127,6 +143,9 @@ class ReservationServiceTest {
 				validRequest.checkInDate(),
 				validRequest.checkOutDate()
 			);
+			then(accommodationRepository).should()
+				.findBookingProjectionByIdAndStatus(1L, AccommodationStatus.PUBLISHED);
+			then(bookingWindowProvider).should().currentFor(TIME_ZONE_ID);
 			then(lockManager).should().releaseLocks(mockLock);
 		}
 
@@ -134,6 +153,7 @@ class ReservationServiceTest {
 		@DisplayName("Redis Hold가 존재하면 ReservationLockException이 발생한다")
 		void 예외_Redis_Hold_존재() {
 			// given
+			givenPublishedBookingWindow();
 			given(holdService.isAnyDateHeld(anyLong(), any(LocalDate.class), any(LocalDate.class)))
 				.willReturn(true);
 
@@ -149,13 +169,14 @@ class ReservationServiceTest {
 		@Test
 		@DisplayName("3개월 예약 가능 기간을 벗어나면 Redis와 DB 처리 전에 거부한다")
 		void 예외_예약_가능_기간_초과() {
-			LocalDate windowEndExclusive = BookingWindow.current().endExclusive();
+			LocalDate windowEndExclusive = BOOKING_WINDOW.endExclusive();
 			ReservationRequest.Create request = new ReservationRequest.Create(
 				1L,
 				windowEndExclusive,
 				windowEndExclusive.plusDays(1),
 				2
 			);
+			givenPublishedBookingWindow(request.accommodationId(), TIME_ZONE_ID, BOOKING_WINDOW);
 
 			assertThatThrownBy(() -> reservationService.createPendingReservation(request, memberId))
 				.isInstanceOf(ReservationOutsideBookingWindowException.class);
@@ -166,9 +187,46 @@ class ReservationServiceTest {
 		}
 
 		@Test
+		@DisplayName("경량 조회한 숙소 시간대를 예약 가능 기간 계산에 그대로 사용한다")
+		void 숙소_시간대_전달() {
+			String newYorkTimeZoneId = "America/New_York";
+			BookingWindow newYorkWindow = BookingWindow.startingOn(LocalDate.of(2026, 8, 11));
+			ReservationRequest.Create request = new ReservationRequest.Create(
+				1L,
+				LocalDate.of(2026, 8, 12),
+				LocalDate.of(2026, 8, 14),
+				2
+			);
+			givenPublishedBookingWindow(request.accommodationId(), newYorkTimeZoneId, newYorkWindow);
+			given(holdService.isAnyDateHeld(anyLong(), any(LocalDate.class), any(LocalDate.class)))
+				.willReturn(true);
+
+			assertThatThrownBy(() -> reservationService.createPendingReservation(request, memberId))
+				.isInstanceOf(ReservationLockException.class);
+
+			then(bookingWindowProvider).should().currentFor(newYorkTimeZoneId);
+		}
+
+		@Test
+		@DisplayName("숙소가 없거나 게시 상태가 아니면 Redis 처리 전에 거부한다")
+		void 예외_예약_가능_숙소_미존재() {
+			given(accommodationRepository.findBookingProjectionByIdAndStatus(
+				validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
+				.willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> reservationService.createPendingReservation(validRequest, memberId))
+				.isInstanceOf(AccommodationNotFoundException.class);
+
+			then(bookingWindowProvider).shouldHaveNoInteractions();
+			then(holdService).shouldHaveNoInteractions();
+			then(lockManager).shouldHaveNoInteractions();
+			then(transactionService).shouldHaveNoInteractions();
+		}
+
+		@Test
 		@DisplayName("체크아웃이 체크인보다 이후가 아니면 Redis와 DB 처리 전에 거부한다")
 		void 예외_잘못된_숙박_기간() {
-			LocalDate checkInDate = BookingWindow.current().startInclusive().plusDays(1);
+			LocalDate checkInDate = WINDOW_START.plusDays(1);
 			ReservationRequest.Create request = new ReservationRequest.Create(
 				1L,
 				checkInDate,
@@ -182,12 +240,15 @@ class ReservationServiceTest {
 			then(holdService).shouldHaveNoInteractions();
 			then(lockManager).shouldHaveNoInteractions();
 			then(transactionService).shouldHaveNoInteractions();
+			then(accommodationRepository).shouldHaveNoInteractions();
+			then(bookingWindowProvider).shouldHaveNoInteractions();
 		}
 
 		@Test
 		@DisplayName("락 획득 실패 시 ReservationLockException이 발생한다")
 		void 예외_락_획득_타임아웃() {
 			// given
+			givenPublishedBookingWindow();
 			given(holdService.isAnyDateHeld(anyLong(), any(LocalDate.class), any(LocalDate.class)))
 				.willReturn(false);
 			given(lockManager.acquireLocks(anyList()))
@@ -204,6 +265,7 @@ class ReservationServiceTest {
 		@DisplayName("예외 발생 시에도 락 해제가 보장된다")
 		void 락_해제_보장() {
 			// given
+			givenPublishedBookingWindow();
 			given(holdService.isAnyDateHeld(anyLong(), any(LocalDate.class), any(LocalDate.class)))
 				.willReturn(false);
 			given(lockManager.acquireLocks(anyList()))
@@ -221,9 +283,10 @@ class ReservationServiceTest {
 		}
 
 		@Test
-		@DisplayName("Hold 설정은 락 해제 후에 호출된다")
+		@DisplayName("락 해제 전에 Hold를 설정한다")
 		void Hold_설정_시점() {
 			// given
+			givenPublishedBookingWindow();
 			given(holdService.isAnyDateHeld(anyLong(), any(LocalDate.class), any(LocalDate.class)))
 				.willReturn(false);
 			given(lockManager.acquireLocks(anyList()))
@@ -245,6 +308,7 @@ class ReservationServiceTest {
 		@DisplayName("락 키가 올바르게 생성되어 전달된다")
 		void 락_키_생성_확인() {
 			// given
+			givenPublishedBookingWindow();
 			given(holdService.isAnyDateHeld(anyLong(), any(LocalDate.class), any(LocalDate.class)))
 				.willReturn(false);
 			given(lockManager.acquireLocks(anyList()))
@@ -263,6 +327,21 @@ class ReservationServiceTest {
 					keys.contains("LOCK:RESERVATION:1:" + validRequest.checkInDate().plusDays(1));
 			}));
 		}
+	}
+
+	private void givenPublishedBookingWindow() {
+		givenPublishedBookingWindow(validRequest.accommodationId(), TIME_ZONE_ID, BOOKING_WINDOW);
+	}
+
+	private void givenPublishedBookingWindow(
+		Long accommodationId,
+		String timeZoneId,
+		BookingWindow bookingWindow
+	) {
+		given(accommodationRepository.findBookingProjectionByIdAndStatus(
+			accommodationId, AccommodationStatus.PUBLISHED))
+			.willReturn(Optional.of(new AccommodationBookingProjection(timeZoneId)));
+		given(bookingWindowProvider.currentFor(timeZoneId)).willReturn(bookingWindow);
 	}
 
 	@Nested

--- a/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationServiceTest.java
@@ -426,4 +426,21 @@ class ReservationServiceTest {
 			then(transactionService).should().revertCancellationInTx(reservationUid, "환불 처리 실패");
 		}
 	}
+
+	@Nested
+	@DisplayName("예약 취소 완료 테스트")
+	class CompleteCancellationTest {
+
+		@Test
+		@DisplayName("결제 취소 완료 이벤트 수신 시 잠금 트랜잭션 처리에 위임한다")
+		void 정상_취소완료_위임() {
+			String reservationUid = UUID.randomUUID().toString();
+			ReservationEvent.ReservationCancellationCompleteRequestedEvent event =
+				new ReservationEvent.ReservationCancellationCompleteRequestedEvent(reservationUid);
+
+			reservationService.completeCancellation(event);
+
+			then(transactionService).should().completeCancellationInTx(reservationUid);
+		}
+	}
 }

--- a/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationTransactionServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationTransactionServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import kr.kro.airbob.cursor.util.CursorPageInfoCreator;
+import kr.kro.airbob.common.exception.InvalidInputException;
 import kr.kro.airbob.domain.accommodation.entity.Accommodation;
 import kr.kro.airbob.domain.accommodation.entity.AccommodationStatus;
 import kr.kro.airbob.domain.accommodation.exception.AccommodationNotFoundException;
@@ -31,6 +34,8 @@ import kr.kro.airbob.domain.member.exception.MemberNotFoundException;
 import kr.kro.airbob.domain.coupon.service.CouponUsageService;
 import kr.kro.airbob.domain.member.repository.MemberRepository;
 import kr.kro.airbob.domain.payment.dto.PaymentRequest;
+import kr.kro.airbob.domain.payment.entity.Payment;
+import kr.kro.airbob.domain.payment.entity.PaymentStatus;
 import kr.kro.airbob.domain.payment.repository.PaymentTransactionRepository;
 import kr.kro.airbob.domain.payment.repository.PaymentRepository;
 import kr.kro.airbob.domain.reservation.dto.ReservationRequest;
@@ -41,6 +46,7 @@ import kr.kro.airbob.domain.reservation.entity.ReservationHistory;
 import kr.kro.airbob.domain.reservation.event.ReservationEvent;
 import kr.kro.airbob.domain.reservation.exception.ReservationAccessDeniedException;
 import kr.kro.airbob.domain.reservation.exception.ReservationConflictException;
+import kr.kro.airbob.domain.reservation.exception.ExpiredReservationConfirmationException;
 import kr.kro.airbob.domain.reservation.exception.InvalidReservationDateException;
 import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
 import kr.kro.airbob.domain.reservation.exception.ReservationOutsideBookingWindowException;
@@ -51,14 +57,15 @@ import kr.kro.airbob.domain.reservation.repository.ReservationHistoryRepository;
 import kr.kro.airbob.domain.review.repository.ReviewRepository;
 import kr.kro.airbob.outbox.EventType;
 import kr.kro.airbob.outbox.OutboxEventPublisher;
+import kr.kro.airbob.search.event.AccommodationIndexingEvents;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReservationTransactionService 테스트")
 class ReservationTransactionServiceTest {
 	private static final String TIME_ZONE_ID = "America/New_York";
 	private static final LocalDate WINDOW_START = LocalDate.of(2026, 8, 11);
+	private static final Instant NOW = Instant.parse("2026-08-14T15:00:00Z");
 
-	@InjectMocks
 	private ReservationTransactionService transactionService;
 
 	@Mock
@@ -98,6 +105,20 @@ class ReservationTransactionServiceTest {
 
 	@BeforeEach
 	void setUp() {
+		transactionService = new ReservationTransactionService(
+			outboxEventPublisher,
+			cursorPageInfoCreator,
+			memberRepository,
+			reviewRepository,
+			paymentRepository,
+			reservationRepository,
+			accommodationRepository,
+			paymentTransactionRepository,
+			historyRepository,
+			couponUsageService,
+			bookingWindowProvider,
+			Clock.fixed(NOW, ZoneOffset.UTC)
+		);
 		memberId = 1L;
 
 		guest = Member.builder()
@@ -135,6 +156,70 @@ class ReservationTransactionServiceTest {
 			.thenReturn(BookingWindow.startingOn(WINDOW_START));
 	}
 
+	@Test
+	@DisplayName("체크아웃 시각과 현재 시각이 같으면 리뷰를 작성할 수 있다")
+	void allowsReviewAtExactCheckoutInstant() {
+		UUID reservationUid = UUID.randomUUID();
+		Reservation reservation = Reservation.builder()
+			.id(1L)
+			.reservationUid(reservationUid)
+			.reservationCode("ABC123")
+			.accommodation(accommodation)
+			.guest(guest)
+			.checkInDate(LocalDate.of(2026, 8, 12))
+			.checkOutDate(LocalDate.of(2026, 8, 14))
+			.checkInAt(Instant.parse("2026-08-12T19:00:00Z"))
+			.checkOutAt(NOW)
+			.timeZoneId(TIME_ZONE_ID)
+			.guestCount(2)
+			.totalPrice(200_000L)
+			.currency("KRW")
+			.status(ReservationStatus.CONFIRMED)
+			.expiresAt(Instant.parse("2026-08-12T18:15:00Z"))
+			.build();
+		given(reservationRepository.findReservationDetailByUidAndGuestId(reservationUid, memberId))
+			.willReturn(Optional.of(reservation));
+		given(reviewRepository.existsByAccommodationIdAndAuthorIdAndStatus(
+			accommodation.getId(), memberId, kr.kro.airbob.domain.review.entity.ReviewStatus.PUBLISHED))
+			.willReturn(false);
+
+		var response = transactionService.findMyReservationDetail(reservationUid.toString(), memberId);
+
+		assertThat(response.canWriteReview()).isTrue();
+	}
+
+	@Test
+	@DisplayName("체크아웃했어도 취소 처리 중이면 리뷰를 작성할 수 없다")
+	void cancellationPendingIsNotReviewable() {
+		UUID reservationUid = UUID.randomUUID();
+		Reservation reservation = createReservationWithStatus(
+			reservationUid, ReservationStatus.CANCELLATION_PENDING);
+		given(reservationRepository.findReservationDetailByUidAndGuestId(reservationUid, memberId))
+			.willReturn(Optional.of(reservation));
+
+		var response = transactionService.findMyReservationDetail(reservationUid.toString(), memberId);
+
+		assertThat(response.canWriteReview()).isFalse();
+		then(reviewRepository).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("취소 실패로 예약이 유효하면 체크아웃 후 리뷰를 작성할 수 있다")
+	void cancellationFailedIsReviewable() {
+		UUID reservationUid = UUID.randomUUID();
+		Reservation reservation = createReservationWithStatus(
+			reservationUid, ReservationStatus.CANCELLATION_FAILED);
+		given(reservationRepository.findReservationDetailByUidAndGuestId(reservationUid, memberId))
+			.willReturn(Optional.of(reservation));
+		given(reviewRepository.existsByAccommodationIdAndAuthorIdAndStatus(
+			accommodation.getId(), memberId, kr.kro.airbob.domain.review.entity.ReviewStatus.PUBLISHED))
+			.willReturn(false);
+
+		var response = transactionService.findMyReservationDetail(reservationUid.toString(), memberId);
+
+		assertThat(response.canWriteReview()).isTrue();
+	}
+
 	@Nested
 	@DisplayName("예약 생성 트랜잭션 테스트")
 	class CreatePendingReservationInTxTest {
@@ -145,9 +230,11 @@ class ReservationTransactionServiceTest {
 			// given
 			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
 				.willReturn(Optional.of(guest));
-			given(accommodationRepository.findByIdAndStatus(validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
+			given(accommodationRepository.findByIdAndStatusForUpdate(
+				validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
 				.willReturn(Optional.of(accommodation));
-			given(reservationRepository.existsConflictingReservation(anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
+			given(reservationRepository.existsConflictingReservation(
+				anyLong(), any(LocalDate.class), any(LocalDate.class), any(Instant.class)))
 				.willReturn(false);
 			given(reservationRepository.existsByReservationCode(anyString()))
 				.willReturn(false);
@@ -172,6 +259,14 @@ class ReservationTransactionServiceTest {
 			assertThat(result.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
 			assertThat(result.getTotalPrice()).isEqualTo(200_000L); // 2박 * 100,000원
 			assertThat(result.getGuestCount()).isEqualTo(2);
+			assertThat(result.getCheckInDate()).isEqualTo(validRequest.checkInDate());
+			assertThat(result.getCheckOutDate()).isEqualTo(validRequest.checkOutDate());
+			assertThat(result.getCheckInAt()).isEqualTo(Instant.parse("2026-08-12T19:00:00Z"));
+			assertThat(result.getCheckOutAt()).isEqualTo(Instant.parse("2026-08-14T15:00:00Z"));
+			assertThat(result.getTimeZoneId()).isEqualTo(TIME_ZONE_ID);
+			assertThat(result.getExpiresAt()).isEqualTo(NOW.plusSeconds(15 * 60));
+			then(accommodationRepository).should().findByIdAndStatusForUpdate(
+				validRequest.accommodationId(), AccommodationStatus.PUBLISHED);
 
 			// verify reservation saved
 			then(reservationRepository).should().save(any(Reservation.class));
@@ -182,9 +277,56 @@ class ReservationTransactionServiceTest {
 			assertThat(savedHistory.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
 			assertThat(savedHistory.getChangeType()).isEqualTo(ChangeType.CREATE);
 			assertThat(savedHistory.getReservationId()).isEqualTo(result.getId());
+			assertThat(savedHistory.getCheckInDate()).isEqualTo(result.getCheckInDate());
+			assertThat(savedHistory.getCheckOutDate()).isEqualTo(result.getCheckOutDate());
+			assertThat(savedHistory.getCheckInAt()).isEqualTo(result.getCheckInAt());
+			assertThat(savedHistory.getCheckOutAt()).isEqualTo(result.getCheckOutAt());
+			assertThat(savedHistory.getTimeZoneId()).isEqualTo(result.getTimeZoneId());
+			assertThat(savedHistory.getExpiresAt()).isEqualTo(result.getExpiresAt());
 
 			// verify event published
 			then(outboxEventPublisher).should().save(eq(EventType.RESERVATION_PENDING), any(ReservationEvent.ReservationPendingEvent.class));
+		}
+
+		@Test
+		@DisplayName("DST 전환을 지나는 숙박도 숙소 현지 시각을 정확한 절대 시각으로 변환한다")
+		void conflictCheckUsesAccommodationZoneInstantsAcrossDst() {
+			ReservationRequest.Create dstRequest = new ReservationRequest.Create(
+				accommodation.getId(),
+				LocalDate.of(2026, 3, 7),
+				LocalDate.of(2026, 3, 9),
+				2
+			);
+			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
+				.willReturn(Optional.of(guest));
+			given(accommodationRepository.findByIdAndStatusForUpdate(
+				dstRequest.accommodationId(), AccommodationStatus.PUBLISHED))
+				.willReturn(Optional.of(accommodation));
+			given(bookingWindowProvider.currentFor(TIME_ZONE_ID))
+				.willReturn(BookingWindow.startingOn(LocalDate.of(2026, 3, 1)));
+			given(reservationRepository.existsConflictingReservation(
+				anyLong(), any(LocalDate.class), any(LocalDate.class), any(Instant.class)))
+				.willReturn(false);
+			given(reservationRepository.existsByReservationCode(anyString()))
+				.willReturn(false);
+			given(reservationRepository.save(any(Reservation.class)))
+				.willAnswer(invocation -> {
+					Reservation reservation = invocation.getArgument(0);
+					java.lang.reflect.Field uidField = Reservation.class.getDeclaredField("reservationUid");
+					uidField.setAccessible(true);
+					uidField.set(reservation, UUID.randomUUID());
+					return reservation;
+				});
+
+			Reservation result = transactionService.createPendingReservationInTx(
+				dstRequest, memberId, "DST 경계 예약 생성");
+
+			Instant expectedCheckInAt = Instant.parse("2026-03-07T20:00:00Z");
+			Instant expectedCheckOutAt = Instant.parse("2026-03-09T15:00:00Z");
+			then(reservationRepository).should().existsConflictingReservation(
+				accommodation.getId(), dstRequest.checkInDate(), dstRequest.checkOutDate(), NOW);
+			assertThat(result.getCheckInAt()).isEqualTo(expectedCheckInAt);
+			assertThat(result.getCheckOutAt()).isEqualTo(expectedCheckOutAt);
 		}
 
 		@Test
@@ -207,7 +349,8 @@ class ReservationTransactionServiceTest {
 			// given
 			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
 				.willReturn(Optional.of(guest));
-			given(accommodationRepository.findByIdAndStatus(validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
+			given(accommodationRepository.findByIdAndStatusForUpdate(
+				validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
 				.willReturn(Optional.empty());
 
 			// when & then
@@ -228,7 +371,7 @@ class ReservationTransactionServiceTest {
 			);
 			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
 				.willReturn(Optional.of(guest));
-			given(accommodationRepository.findByIdAndStatus(
+			given(accommodationRepository.findByIdAndStatusForUpdate(
 				invalidRequest.accommodationId(), AccommodationStatus.PUBLISHED))
 				.willReturn(Optional.of(accommodation));
 
@@ -253,7 +396,7 @@ class ReservationTransactionServiceTest {
 			);
 			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
 				.willReturn(Optional.of(guest));
-			given(accommodationRepository.findByIdAndStatus(
+			given(accommodationRepository.findByIdAndStatusForUpdate(
 				outsideRequest.accommodationId(), AccommodationStatus.PUBLISHED))
 				.willReturn(Optional.of(accommodation));
 
@@ -273,9 +416,11 @@ class ReservationTransactionServiceTest {
 			// given
 			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
 				.willReturn(Optional.of(guest));
-			given(accommodationRepository.findByIdAndStatus(validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
+			given(accommodationRepository.findByIdAndStatusForUpdate(
+				validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
 				.willReturn(Optional.of(accommodation));
-			given(reservationRepository.existsConflictingReservation(anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
+			given(reservationRepository.existsConflictingReservation(
+				anyLong(), any(LocalDate.class), any(LocalDate.class), any(Instant.class)))
 				.willReturn(true);
 
 			// when & then
@@ -291,9 +436,11 @@ class ReservationTransactionServiceTest {
 			// given
 			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
 				.willReturn(Optional.of(guest));
-			given(accommodationRepository.findByIdAndStatus(validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
+			given(accommodationRepository.findByIdAndStatusForUpdate(
+				validRequest.accommodationId(), AccommodationStatus.PUBLISHED))
 				.willReturn(Optional.of(accommodation));
-			given(reservationRepository.existsConflictingReservation(anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
+			given(reservationRepository.existsConflictingReservation(
+				anyLong(), any(LocalDate.class), any(LocalDate.class), any(Instant.class)))
 				.willReturn(false);
 			// 첫 번째 코드는 중복, 두 번째는 유일
 			given(reservationRepository.existsByReservationCode(anyString()))
@@ -326,14 +473,19 @@ class ReservationTransactionServiceTest {
 	class ConfirmReservationInTxTest {
 
 		@Test
-		@DisplayName("PAYMENT_PENDING 상태에서 확정 시 CONFIRMED로 변경된다")
+		@DisplayName("PAYMENT_PROCESSING 상태에서 확정 시 CONFIRMED로 변경된다")
 		void 정상_확정() {
 			// given
 			UUID reservationUid = UUID.randomUUID();
-			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.PAYMENT_PENDING);
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.PAYMENT_PROCESSING);
+			Payment payment = mock(Payment.class);
+			given(payment.getApprovedAt()).willReturn(NOW);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
 
 			// when
 			transactionService.confirmReservationInTx(reservationUid.toString());
@@ -351,13 +503,47 @@ class ReservationTransactionServiceTest {
 		}
 
 		@Test
+		@DisplayName("이벤트 처리가 늦어도 PG 승인 시각이 만료 전이면 예약을 확정한다")
+		void confirmsUsingPgApprovalTimeInsteadOfEventProcessingTime() {
+			UUID reservationUid = UUID.randomUUID();
+			Instant expiresAt = NOW.minusSeconds(5);
+			Reservation reservation = Reservation.builder()
+				.id(1L)
+				.reservationUid(reservationUid)
+				.reservationCode("ABC123")
+				.accommodation(accommodation)
+				.guest(guest)
+				.checkInDate(LocalDate.of(2026, 8, 15))
+				.checkOutDate(LocalDate.of(2026, 8, 16))
+				.checkInAt(Instant.parse("2026-08-15T19:00:00Z"))
+				.checkOutAt(Instant.parse("2026-08-16T15:00:00Z"))
+				.timeZoneId(TIME_ZONE_ID)
+				.guestCount(2)
+				.totalPrice(100_000L)
+				.currency("KRW")
+				.status(ReservationStatus.PAYMENT_PROCESSING)
+				.expiresAt(expiresAt)
+				.build();
+			Payment payment = mock(Payment.class);
+			given(payment.getApprovedAt()).willReturn(expiresAt.minusNanos(1));
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			transactionService.confirmReservationInTx(reservationUid.toString());
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+		}
+
+		@Test
 		@DisplayName("이미 CONFIRMED 상태면 조기 반환한다 (멱등성)")
 		void 멱등성_이미_확정() {
 			// given
 			UUID reservationUid = UUID.randomUUID();
 			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CONFIRMED);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.of(reservation));
 
 			// when
@@ -370,11 +556,80 @@ class ReservationTransactionServiceTest {
 		}
 
 		@Test
+		@DisplayName("확정 후 취소 처리 중인 예약에 중복 결제 완료 이벤트가 와도 보상 대상으로 만들지 않는다")
+		void skipsDuplicateConfirmationAfterCancellationStarted() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.CANCELLATION_FAILED);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+
+			transactionService.confirmReservationInTx(reservationUid.toString());
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_FAILED);
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("결제 만료 시각과 정확히 같으면 예약을 확정하지 않는다")
+		void rejectsConfirmationAtExactExpiryInstant() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = Reservation.builder()
+				.id(1L)
+				.reservationUid(reservationUid)
+				.reservationCode("ABC123")
+				.accommodation(accommodation)
+				.guest(guest)
+				.checkInDate(LocalDate.of(2026, 8, 15))
+				.checkOutDate(LocalDate.of(2026, 8, 16))
+				.checkInAt(Instant.parse("2026-08-15T19:00:00Z"))
+				.checkOutAt(Instant.parse("2026-08-16T15:00:00Z"))
+				.timeZoneId(TIME_ZONE_ID)
+				.guestCount(2)
+				.totalPrice(100_000L)
+				.currency("KRW")
+				.status(ReservationStatus.PAYMENT_PROCESSING)
+				.expiresAt(NOW)
+				.build();
+			Payment payment = mock(Payment.class);
+			given(payment.getApprovedAt()).willReturn(NOW);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			assertThatThrownBy(() -> transactionService.confirmReservationInTx(reservationUid.toString()))
+				.isInstanceOf(ExpiredReservationConfirmationException.class);
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PROCESSING);
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("결제 선점 없이 PAYMENT_PENDING인 예약은 확정하지 않는다")
+		void rejectsConfirmationWithoutPaymentClaim() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.PAYMENT_PENDING);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+
+			assertThatThrownBy(() -> transactionService.confirmReservationInTx(reservationUid.toString()))
+				.isInstanceOf(ExpiredReservationConfirmationException.class);
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_PENDING);
+			then(paymentRepository).shouldHaveNoInteractions();
+			then(historyRepository).shouldHaveNoInteractions();
+		}
+
+		@Test
 		@DisplayName("예약이 존재하지 않으면 ReservationNotFoundException이 발생한다")
 		void 예외_예약_미존재() {
 			// given
 			UUID reservationUid = UUID.randomUUID();
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.empty());
 
 			// when & then
@@ -394,7 +649,7 @@ class ReservationTransactionServiceTest {
 			UUID reservationUid = UUID.randomUUID();
 			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.PAYMENT_PENDING);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.of(reservation));
 
 			// when
@@ -419,7 +674,7 @@ class ReservationTransactionServiceTest {
 			UUID reservationUid = UUID.randomUUID();
 			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.EXPIRED);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.of(reservation));
 
 			// when
@@ -436,7 +691,7 @@ class ReservationTransactionServiceTest {
 		void 예외_예약_미존재() {
 			// given
 			UUID reservationUid = UUID.randomUUID();
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.empty());
 
 			// when & then
@@ -446,33 +701,181 @@ class ReservationTransactionServiceTest {
 	}
 
 	@Nested
+	@DisplayName("결제 보상 준비 트랜잭션 테스트")
+	class PreparePaymentCompensationInTxTest {
+
+		@Test
+		@DisplayName("PAYMENT_PENDING 예약은 잠근 뒤 EXPIRED로 전환해 결제 보상을 허용한다")
+		void pendingReservationIsFencedBeforeCompensation() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.PAYMENT_PENDING);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+
+			boolean shouldCompensate = transactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패");
+
+			assertThat(shouldCompensate).isTrue();
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.EXPIRED);
+			then(historyRepository).should().save(any(ReservationHistory.class));
+			then(outboxEventPublisher).should().save(
+				eq(EventType.RESERVATION_EXPIRED),
+					any(ReservationEvent.ReservationExpiredEvent.class));
+		}
+
+		@Test
+		@DisplayName("PAYMENT_PROCESSING 예약도 잠근 뒤 EXPIRED로 전환해 결제 보상을 허용한다")
+		void processingReservationIsFencedBeforeCompensation() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.PAYMENT_PROCESSING);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+
+			boolean shouldCompensate = transactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "승인 시각 만료");
+
+			assertThat(shouldCompensate).isTrue();
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.EXPIRED);
+			then(historyRepository).should().save(any(ReservationHistory.class));
+			then(outboxEventPublisher).should().save(
+				eq(EventType.RESERVATION_EXPIRED),
+				any(ReservationEvent.ReservationExpiredEvent.class));
+		}
+
+		@Test
+		@DisplayName("이미 CONFIRMED인 예약은 결제 보상을 허용하지 않는다")
+		void confirmedReservationCannotBeCompensated() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.CONFIRMED);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+
+			boolean shouldCompensate = transactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패");
+
+			assertThat(shouldCompensate).isFalse();
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("이미 EXPIRED인 예약은 결제 보상을 계속 허용한다")
+		void expiredReservationCanBeCompensatedIdempotently() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.EXPIRED);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+
+			boolean shouldCompensate = transactionService.preparePaymentCompensationInTx(
+				reservationUid.toString(), "예약 확정 최종 실패");
+
+			assertThat(shouldCompensate).isTrue();
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
+	}
+
+	@Nested
 	@DisplayName("예약 취소 트랜잭션 테스트")
 	class CancelReservationInTxTest {
 
 		@Test
-		@DisplayName("CONFIRMED 상태에서 본인이 취소 시 CANCELLED로 변경된다")
-		void 정상_취소() {
+		@DisplayName("CONFIRMED 상태에서 본인이 취소 요청 시 CANCELLATION_PENDING으로 변경된다")
+		void 정상_취소요청() {
 			// given
 			UUID reservationUid = UUID.randomUUID();
 			Reservation reservation = createConfirmedReservationWithGuest(reservationUid, guest);
-			PaymentRequest.Cancel cancelRequest = new PaymentRequest.Cancel("사용자 취소 요청", 200_000L);
+			PaymentRequest.Cancel cancelRequest = new PaymentRequest.Cancel("사용자 취소 요청", null);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.of(reservation));
 
 			// when
 			transactionService.cancelReservationInTx(reservationUid.toString(), cancelRequest, memberId);
 
 			// then
-			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_PENDING);
 
 			then(historyRepository).should().save(historyCaptor.capture());
 			ReservationHistory savedHistory = historyCaptor.getValue();
-			assertThat(savedHistory.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
-			assertThat(savedHistory.getChangeType()).isEqualTo(ChangeType.CANCEL);
+			assertThat(savedHistory.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_PENDING);
+			assertThat(savedHistory.getChangeType()).isEqualTo(ChangeType.STATUS_CHANGE);
 			assertThat(savedHistory.getChangeReason()).isEqualTo("사용자 취소 요청");
 
-			then(outboxEventPublisher).should().save(eq(EventType.RESERVATION_CANCELLED), any(ReservationEvent.ReservationCancelledEvent.class));
+			then(outboxEventPublisher).should().save(
+				eq(EventType.RESERVATION_CANCELLATION_REQUESTED),
+				any(ReservationEvent.ReservationCancellationRequestedEvent.class));
+			then(couponUsageService).shouldHaveNoInteractions();
+			then(outboxEventPublisher).should(never()).save(eq(EventType.RESERVATION_CHANGED), any());
+		}
+
+		@Test
+		@DisplayName("이미 CANCELLATION_PENDING이면 중복 PG 취소 요청을 발행하지 않는다")
+		void 중복_취소요청_멱등() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.CANCELLATION_PENDING);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+
+			transactionService.cancelReservationInTx(
+				reservationUid.toString(), new PaymentRequest.Cancel("중복 요청", null), memberId);
+
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+			then(couponUsageService).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("명시한 취소 금액이 현재 결제 잔액보다 작으면 예약 취소를 시작하지 않는다")
+		void 부분취소_금액_거부() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createConfirmedReservationWithGuest(reservationUid, guest);
+			Payment payment = Payment.builder()
+				.reservation(reservation)
+				.balanceAmount(200_000L)
+				.build();
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUid(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			assertThatThrownBy(() -> transactionService.cancelReservationInTx(
+				reservationUid.toString(), new PaymentRequest.Cancel("부분 환불", 100_000L), memberId))
+				.isInstanceOf(InvalidInputException.class);
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("명시한 취소 금액이 현재 결제 잔액 전액이면 취소 요청을 시작한다")
+		void 현재잔액_전액취소_허용() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createConfirmedReservationWithGuest(reservationUid, guest);
+			Payment payment = Payment.builder()
+				.reservation(reservation)
+				.balanceAmount(200_000L)
+				.build();
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUid(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			transactionService.cancelReservationInTx(
+				reservationUid.toString(), new PaymentRequest.Cancel("전액 환불", 200_000L), memberId);
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_PENDING);
+			then(outboxEventPublisher).should().save(
+				eq(EventType.RESERVATION_CANCELLATION_REQUESTED),
+				argThat(event -> event instanceof ReservationEvent.ReservationCancellationRequestedEvent requested
+					&& requested.cancelAmount().equals(200_000L)));
 		}
 
 		@Test
@@ -480,9 +883,9 @@ class ReservationTransactionServiceTest {
 		void 예외_예약_미존재() {
 			// given
 			UUID reservationUid = UUID.randomUUID();
-			PaymentRequest.Cancel cancelRequest = new PaymentRequest.Cancel("사용자 취소 요청", 200_000L);
+			PaymentRequest.Cancel cancelRequest = new PaymentRequest.Cancel("사용자 취소 요청", null);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.empty());
 
 			// when & then
@@ -501,9 +904,9 @@ class ReservationTransactionServiceTest {
 				.nickname("AnotherGuest")
 				.build();
 			Reservation reservation = createConfirmedReservationWithGuest(reservationUid, anotherGuest);
-			PaymentRequest.Cancel cancelRequest = new PaymentRequest.Cancel("사용자 취소 요청", 200_000L);
+			PaymentRequest.Cancel cancelRequest = new PaymentRequest.Cancel("사용자 취소 요청", null);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.of(reservation));
 
 			// when & then
@@ -513,17 +916,146 @@ class ReservationTransactionServiceTest {
 	}
 
 	@Nested
-	@DisplayName("취소 보상 트랜잭션 테스트")
+	@DisplayName("예약 취소 성공 확정 트랜잭션 테스트")
+	class CompleteCancellationInTxTest {
+
+		@Test
+		@DisplayName("CANCELLATION_PENDING에서 성공 이벤트를 받으면 CANCELLED 확정 후 쿠폰과 재고를 갱신한다")
+		void 정상_취소성공_확정() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.CANCELLATION_PENDING);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			givenFullyCancelledPayment(reservationUid);
+
+			transactionService.completeCancellationInTx(reservationUid.toString());
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			then(couponUsageService).should().restore(reservation.getId());
+			then(historyRepository).should().save(historyCaptor.capture());
+			assertThat(historyCaptor.getValue().getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			assertThat(historyCaptor.getValue().getChangeType()).isEqualTo(ChangeType.CANCEL);
+			then(outboxEventPublisher).should().save(
+				eq(EventType.RESERVATION_CHANGED),
+				argThat(event -> event instanceof AccommodationIndexingEvents.ReservationChangedEvent changed
+					&& changed.accommodationUid().equals(accommodation.getAccommodationUid().toString()))
+			);
+		}
+
+		@Test
+		@DisplayName("실패 이벤트 뒤 전액 환불 성공이 확인되면 CANCELLED로 수렴한다")
+		void lateSuccessAfterFailureConvergesToCancelled() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.CANCELLATION_FAILED);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			givenFullyCancelledPayment(reservationUid);
+
+			transactionService.completeCancellationInTx(reservationUid.toString());
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			then(couponUsageService).should().restore(reservation.getId());
+		}
+
+		@Test
+		@DisplayName("PG 전액 환불이 확인되지 않으면 예약 재고를 해제하지 않는다")
+		void doesNotReleaseInventoryWithoutFullRefund() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.CANCELLATION_PENDING);
+			Payment payment = mock(Payment.class);
+			given(payment.getStatus()).willReturn(PaymentStatus.PARTIAL_CANCELED);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			assertThatThrownBy(() -> transactionService.completeCancellationInTx(reservationUid.toString()))
+				.isInstanceOf(IllegalStateException.class);
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_PENDING);
+			then(couponUsageService).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("이미 CANCELLED인 레거시 예약도 전액 환불을 확인하고 ES 예약 범위를 갱신한다")
+		void 레거시_취소성공_ES갱신() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLED);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			givenFullyCancelledPayment(reservationUid);
+
+			transactionService.completeCancellationInTx(reservationUid.toString());
+
+			then(couponUsageService).shouldHaveNoInteractions();
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).should().save(
+				eq(EventType.RESERVATION_CHANGED),
+				argThat(event -> event instanceof AccommodationIndexingEvents.ReservationChangedEvent changed
+					&& changed.accommodationUid().equals(accommodation.getAccommodationUid().toString()))
+			);
+		}
+
+		@Test
+		@DisplayName("이미 CANCELLED여도 전액 환불이 확인되지 않으면 ES 예약 범위를 갱신하지 않는다")
+		void 레거시_취소성공_결제검증() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLED);
+			Payment payment = mock(Payment.class);
+			given(payment.getStatus()).willReturn(PaymentStatus.CANCELED);
+			given(payment.getBalanceAmount()).willReturn(100_000L);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			assertThatThrownBy(() -> transactionService.completeCancellationInTx(reservationUid.toString()))
+				.isInstanceOf(IllegalStateException.class);
+
+			then(couponUsageService).shouldHaveNoInteractions();
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("CANCELLED 성공 이벤트가 다시 와도 상태 부수 효과 없이 같은 ES 갱신으로 수렴한다")
+		void 중복_성공_멱등() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLED);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			givenFullyCancelledPayment(reservationUid);
+
+			transactionService.completeCancellationInTx(reservationUid.toString());
+			transactionService.completeCancellationInTx(reservationUid.toString());
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			then(couponUsageService).shouldHaveNoInteractions();
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).should(times(2)).save(
+				eq(EventType.RESERVATION_CHANGED),
+				argThat(event -> event instanceof AccommodationIndexingEvents.ReservationChangedEvent changed
+					&& changed.accommodationUid().equals(accommodation.getAccommodationUid().toString()))
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("취소 실패 확정 트랜잭션 테스트")
 	class RevertCancellationInTxTest {
 
 		@Test
-		@DisplayName("CANCELLED 상태에서 보상 시 CANCELLATION_FAILED로 변경된다")
-		void 정상_보상() {
+		@DisplayName("CANCELLATION_PENDING 상태에서 실패 시 CANCELLATION_FAILED로 변경된다")
+		void 정상_실패확정() {
 			// given
 			UUID reservationUid = UUID.randomUUID();
-			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLED);
+			Reservation reservation = createReservationWithStatus(
+				reservationUid, ReservationStatus.CANCELLATION_PENDING);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.of(reservation));
 
 			// when
@@ -537,6 +1069,8 @@ class ReservationTransactionServiceTest {
 			assertThat(savedHistory.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_FAILED);
 			assertThat(savedHistory.getChangeType()).isEqualTo(ChangeType.STATUS_CHANGE);
 			assertThat(savedHistory.getSourceSystem()).isEqualTo("KAFKA");
+			then(couponUsageService).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
 		}
 
 		@Test
@@ -546,7 +1080,7 @@ class ReservationTransactionServiceTest {
 			UUID reservationUid = UUID.randomUUID();
 			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLATION_FAILED);
 
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.of(reservation));
 
 			// when
@@ -558,11 +1092,96 @@ class ReservationTransactionServiceTest {
 		}
 
 		@Test
+		@DisplayName("레거시 CANCELLED에서 결제가 남아 있으면 예약과 쿠폰을 복구한다")
+		void 레거시_전액환불_실패_복구() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLED);
+			Payment payment = mock(Payment.class);
+			given(payment.getStatus()).willReturn(PaymentStatus.DONE);
+			given(payment.getBalanceAmount()).willReturn(200_000L);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			transactionService.revertCancellationInTx(reservationUid.toString(), "환불 처리 실패");
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_FAILED);
+			then(couponUsageService).should().reuse(reservation.getId());
+			then(historyRepository).should().save(historyCaptor.capture());
+			assertThat(historyCaptor.getValue().getStatus()).isEqualTo(ReservationStatus.CANCELLATION_FAILED);
+			var lockOrder = inOrder(reservationRepository, paymentRepository);
+			lockOrder.verify(reservationRepository).findByReservationUidWithLock(reservationUid);
+			lockOrder.verify(paymentRepository).findByReservationReservationUidWithLock(reservationUid);
+		}
+
+		@Test
+		@DisplayName("레거시 CANCELLED의 부분 환불 실패도 예약과 쿠폰을 복구한다")
+		void 레거시_부분환불_실패_복구() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLED);
+			Payment payment = mock(Payment.class);
+			given(payment.getStatus()).willReturn(PaymentStatus.PARTIAL_CANCELED);
+			given(payment.getBalanceAmount()).willReturn(100_000L);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			transactionService.revertCancellationInTx(reservationUid.toString(), "부분 환불");
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLATION_FAILED);
+			then(couponUsageService).should().reuse(reservation.getId());
+		}
+
+		@Test
+		@DisplayName("전액 환불 성공 뒤 도착한 느은 실패 이벤트는 무시한다")
+		void 전액환불_후_느은실패_무시() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLED);
+			Payment payment = mock(Payment.class);
+			given(payment.getStatus()).willReturn(PaymentStatus.CANCELED);
+			given(payment.getBalanceAmount()).willReturn(0L);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			transactionService.revertCancellationInTx(reservationUid.toString(), "느은 실패");
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			then(couponUsageService).shouldHaveNoInteractions();
+			then(historyRepository).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("레거시 CANCELLED의 모순된 결제 상태는 임의로 복구하지 않는다")
+		void 레거시_모순상태_복구거부() {
+			UUID reservationUid = UUID.randomUUID();
+			Reservation reservation = createReservationWithStatus(reservationUid, ReservationStatus.CANCELLED);
+			Payment payment = mock(Payment.class);
+			given(payment.getStatus()).willReturn(PaymentStatus.CANCELED);
+			given(payment.getBalanceAmount()).willReturn(1L);
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(reservation));
+			given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+				.willReturn(Optional.of(payment));
+
+			assertThatThrownBy(() -> transactionService.revertCancellationInTx(
+				reservationUid.toString(), "모순된 실패"))
+				.isInstanceOf(IllegalStateException.class);
+
+			assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+			then(couponUsageService).shouldHaveNoInteractions();
+			then(historyRepository).shouldHaveNoInteractions();
+		}
+
+		@Test
 		@DisplayName("예약이 존재하지 않으면 ReservationNotFoundException이 발생한다")
 		void 예외_예약_미존재() {
 			// given
 			UUID reservationUid = UUID.randomUUID();
-			given(reservationRepository.findByReservationUid(reservationUid))
+			given(reservationRepository.findByReservationUidWithLock(reservationUid))
 				.willReturn(Optional.empty());
 
 			// when & then
@@ -578,14 +1197,25 @@ class ReservationTransactionServiceTest {
 			.reservationCode("ABC123")
 			.accommodation(accommodation)
 			.guest(guest)
-			.checkIn(LocalDateTime.of(2025, 1, 26, 15, 0))
-			.checkOut(LocalDateTime.of(2025, 1, 28, 11, 0))
+			.checkInDate(LocalDate.of(2025, 1, 26))
+			.checkOutDate(LocalDate.of(2025, 1, 28))
+			.checkInAt(Instant.parse("2025-01-26T20:00:00Z"))
+			.checkOutAt(Instant.parse("2025-01-28T16:00:00Z"))
+			.timeZoneId(TIME_ZONE_ID)
 			.guestCount(2)
 			.totalPrice(200_000L)
 			.currency("KRW")
 			.status(status)
-			.expiresAt(LocalDateTime.now().plusMinutes(15))
+			.expiresAt(NOW.plusSeconds(15 * 60))
 			.build();
+	}
+
+	private void givenFullyCancelledPayment(UUID reservationUid) {
+		Payment payment = mock(Payment.class);
+		given(payment.getStatus()).willReturn(PaymentStatus.CANCELED);
+		given(payment.getBalanceAmount()).willReturn(0L);
+		given(paymentRepository.findByReservationReservationUidWithLock(reservationUid))
+			.willReturn(Optional.of(payment));
 	}
 
 	private Reservation createConfirmedReservationWithGuest(UUID reservationUid, Member guestMember) {
@@ -595,13 +1225,16 @@ class ReservationTransactionServiceTest {
 			.reservationCode("ABC123")
 			.accommodation(accommodation)
 			.guest(guestMember)
-			.checkIn(LocalDateTime.of(2025, 1, 26, 15, 0))
-			.checkOut(LocalDateTime.of(2025, 1, 28, 11, 0))
+			.checkInDate(LocalDate.of(2025, 1, 26))
+			.checkOutDate(LocalDate.of(2025, 1, 28))
+			.checkInAt(Instant.parse("2025-01-26T20:00:00Z"))
+			.checkOutAt(Instant.parse("2025-01-28T16:00:00Z"))
+			.timeZoneId(TIME_ZONE_ID)
 			.guestCount(2)
 			.totalPrice(200_000L)
 			.currency("KRW")
 			.status(ReservationStatus.CONFIRMED)
-			.expiresAt(LocalDateTime.now().plusMinutes(15))
+			.expiresAt(NOW.plusSeconds(15 * 60))
 			.build();
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationTransactionServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/service/ReservationTransactionServiceTest.java
@@ -41,7 +41,11 @@ import kr.kro.airbob.domain.reservation.entity.ReservationHistory;
 import kr.kro.airbob.domain.reservation.event.ReservationEvent;
 import kr.kro.airbob.domain.reservation.exception.ReservationAccessDeniedException;
 import kr.kro.airbob.domain.reservation.exception.ReservationConflictException;
+import kr.kro.airbob.domain.reservation.exception.InvalidReservationDateException;
 import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
+import kr.kro.airbob.domain.reservation.exception.ReservationOutsideBookingWindowException;
+import kr.kro.airbob.domain.reservation.policy.BookingWindow;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.domain.reservation.repository.ReservationHistoryRepository;
 import kr.kro.airbob.domain.review.repository.ReviewRepository;
@@ -51,6 +55,8 @@ import kr.kro.airbob.outbox.OutboxEventPublisher;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReservationTransactionService 테스트")
 class ReservationTransactionServiceTest {
+	private static final String TIME_ZONE_ID = "America/New_York";
+	private static final LocalDate WINDOW_START = LocalDate.of(2026, 8, 11);
 
 	@InjectMocks
 	private ReservationTransactionService transactionService;
@@ -75,6 +81,8 @@ class ReservationTransactionServiceTest {
 	private ReservationHistoryRepository historyRepository;
 	@Mock
 	private CouponUsageService couponUsageService;
+	@Mock
+	private BookingWindowProvider bookingWindowProvider;
 
 	@Captor
 	private ArgumentCaptor<Reservation> reservationCaptor;
@@ -111,16 +119,20 @@ class ReservationTransactionServiceTest {
 			.basePrice(100_000L)
 			.checkInTime(LocalTime.of(15, 0))
 			.checkOutTime(LocalTime.of(11, 0))
+			.timeZoneId(TIME_ZONE_ID)
 			.status(AccommodationStatus.PUBLISHED)
 			.member(host)
 			.build();
 
 		validRequest = new ReservationRequest.Create(
 			1L,
-			LocalDate.of(2025, 1, 26),
-			LocalDate.of(2025, 1, 28),
+			LocalDate.of(2026, 8, 12),
+			LocalDate.of(2026, 8, 14),
 			2
 		);
+
+		lenient().when(bookingWindowProvider.currentFor(TIME_ZONE_ID))
+			.thenReturn(BookingWindow.startingOn(WINDOW_START));
 	}
 
 	@Nested
@@ -203,6 +215,56 @@ class ReservationTransactionServiceTest {
 				.isInstanceOf(AccommodationNotFoundException.class);
 
 			then(reservationRepository).should(never()).save(any());
+		}
+
+		@Test
+		@DisplayName("체크아웃이 체크인보다 이후가 아니면 범위와 충돌 검사 전에 거부한다")
+		void 예외_잘못된_숙박_기간() {
+			ReservationRequest.Create invalidRequest = new ReservationRequest.Create(
+				1L,
+				LocalDate.of(2026, 8, 12),
+				LocalDate.of(2026, 8, 12),
+				2
+			);
+			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
+				.willReturn(Optional.of(guest));
+			given(accommodationRepository.findByIdAndStatus(
+				invalidRequest.accommodationId(), AccommodationStatus.PUBLISHED))
+				.willReturn(Optional.of(accommodation));
+
+			assertThatThrownBy(() -> transactionService.createPendingReservationInTx(
+				invalidRequest, memberId, "사용자 예약 생성"))
+				.isInstanceOf(InvalidReservationDateException.class);
+
+			then(bookingWindowProvider).shouldHaveNoInteractions();
+			then(reservationRepository).shouldHaveNoInteractions();
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("숙소 현지 예약 가능 기간을 벗어나면 충돌과 쓰기 전에 거부한다")
+		void 예외_예약_가능_기간_초과() {
+			ReservationRequest.Create outsideRequest = new ReservationRequest.Create(
+				1L,
+				WINDOW_START.plusMonths(3),
+				WINDOW_START.plusMonths(3).plusDays(1),
+				2
+			);
+			given(memberRepository.findByIdAndStatus(memberId, MemberStatus.ACTIVE))
+				.willReturn(Optional.of(guest));
+			given(accommodationRepository.findByIdAndStatus(
+				outsideRequest.accommodationId(), AccommodationStatus.PUBLISHED))
+				.willReturn(Optional.of(accommodation));
+
+			assertThatThrownBy(() -> transactionService.createPendingReservationInTx(
+				outsideRequest, memberId, "사용자 예약 생성"))
+				.isInstanceOf(ReservationOutsideBookingWindowException.class);
+
+			then(bookingWindowProvider).should().currentFor(TIME_ZONE_ID);
+			then(reservationRepository).shouldHaveNoInteractions();
+			then(historyRepository).shouldHaveNoInteractions();
+			then(outboxEventPublisher).shouldHaveNoInteractions();
 		}
 
 		@Test

--- a/src/test/java/kr/kro/airbob/domain/review/ReviewSummaryAtomicUpdateTest.java
+++ b/src/test/java/kr/kro/airbob/domain/review/ReviewSummaryAtomicUpdateTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -39,6 +40,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("리뷰 요약 원자적 갱신(낙관적 락 → upsert) 테스트")
 class ReviewSummaryAtomicUpdateTest {
 
@@ -69,8 +71,6 @@ class ReviewSummaryAtomicUpdateTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private TransactionTemplate tx;

--- a/src/test/java/kr/kro/airbob/domain/review/ReviewSummaryReadSourceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/review/ReviewSummaryReadSourceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -34,6 +35,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 	"benchmark.read-model.token=test-token"
 })
 @ActiveProfiles({"test", "read-model-benchmark"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("리뷰 요약 조회 before 직접 집계와 after 반정규화 결과 일치 테스트")
 class ReviewSummaryReadSourceTest {
 
@@ -64,8 +66,6 @@ class ReviewSummaryReadSourceTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private long accId;

--- a/src/test/java/kr/kro/airbob/domain/settlement/SettlementGenerationConcurrencyTest.java
+++ b/src/test/java/kr/kro/airbob/domain/settlement/SettlementGenerationConcurrencyTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -38,6 +39,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("정산 생성 동시성 테스트(월 단위 분산 락)")
 class SettlementGenerationConcurrencyTest {
 
@@ -67,8 +69,6 @@ class SettlementGenerationConcurrencyTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private static final YearMonth MAY = YearMonth.of(2026, 5);
@@ -162,9 +162,11 @@ class SettlementGenerationConcurrencyTest {
 	private long insertReservation(String code, long accommodationId, long guestId) {
 		jdbc.update("""
 			INSERT INTO reservation
-				(reservation_uid, reservation_code, accommodation_id, guest_id, check_in, check_out,
+				(reservation_uid, reservation_code, accommodation_id, guest_id,
+				 check_in_date, check_out_date, check_in_at, check_out_at, time_zone_id,
 				 guest_count, total_price, status, expires_at, currency, created_at, updated_at)
-			VALUES (UUID_TO_BIN(UUID()), ?, ?, ?, '2026-07-01 15:00:00', '2026-07-03 11:00:00',
+			VALUES (UUID_TO_BIN(UUID()), ?, ?, ?,
+				 '2026-07-01', '2026-07-03', '2026-07-01 15:00:00', '2026-07-03 11:00:00', 'UTC',
 				 2, 200000, 'CONFIRMED', '2026-07-01 00:00:00', 'KRW', NOW(6), NOW(6))
 			""", code, accommodationId, guestId);
 		return jdbc.queryForObject("SELECT id FROM reservation WHERE reservation_code = ?", Long.class, code);

--- a/src/test/java/kr/kro/airbob/domain/settlement/SettlementServiceIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/settlement/SettlementServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -37,6 +38,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 @Testcontainers
 @SpringBootTest(properties = "spring.cloud.aws.s3.enabled=false")
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("호스트 정산 서비스 통합 테스트")
 class SettlementServiceIntegrationTest {
 
@@ -66,8 +68,6 @@ class SettlementServiceIntegrationTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private static final YearMonth MAY = YearMonth.of(2026, 5);
@@ -304,9 +304,11 @@ class SettlementServiceIntegrationTest {
 	private long insertReservation(String code, long accommodationId, long guestId) {
 		jdbc.update("""
 			INSERT INTO reservation
-				(reservation_uid, reservation_code, accommodation_id, guest_id, check_in, check_out,
+				(reservation_uid, reservation_code, accommodation_id, guest_id,
+				 check_in_date, check_out_date, check_in_at, check_out_at, time_zone_id,
 				 guest_count, total_price, status, expires_at, currency, created_at, updated_at)
-			VALUES (UUID_TO_BIN(UUID()), ?, ?, ?, '2026-07-01 15:00:00', '2026-07-03 11:00:00',
+			VALUES (UUID_TO_BIN(UUID()), ?, ?, ?,
+				 '2026-07-01', '2026-07-03', '2026-07-01 15:00:00', '2026-07-03 11:00:00', 'UTC',
 				 2, 200000, 'CONFIRMED', '2026-07-01 00:00:00', 'KRW', NOW(6), NOW(6))
 			""", code, accommodationId, guestId);
 		return jdbc.queryForObject("SELECT id FROM reservation WHERE reservation_code = ?", Long.class, code);

--- a/src/test/java/kr/kro/airbob/domain/settlement/dto/SettlementResponseJsonTest.java
+++ b/src/test/java/kr/kro/airbob/domain/settlement/dto/SettlementResponseJsonTest.java
@@ -1,0 +1,55 @@
+package kr.kro.airbob.domain.settlement.dto;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.kro.airbob.domain.settlement.entity.Settlement;
+
+@JsonTest
+@DisplayName("정산 응답 JSON 테스트")
+class SettlementResponseJsonTest {
+
+	private static final Instant SETTLED_AT = Instant.parse("2026-08-12T05:30:00Z");
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("절대 지급 시각을 모든 응답에 UTC Instant 형식으로 반환한다")
+	void serializesSettledAtAsUtcInstant() {
+		Settlement settlement = Settlement.createPending(
+			1L,
+			LocalDate.of(2026, 7, 1),
+			100_000L,
+			0L,
+			new BigDecimal("0.03")
+		);
+		settlement.markPaid(SETTLED_AT);
+
+		SettlementResponse.HostSettlement host = SettlementResponse.HostSettlement.from(settlement);
+		SettlementResponse.SettlementDetail detail = SettlementResponse.SettlementDetail.of(settlement, List.of());
+		SettlementResponse.AdminSettlement admin = SettlementResponse.AdminSettlement.from(settlement);
+
+		Instant hostSettledAt = host.settledAt();
+		Instant detailSettledAt = detail.settledAt();
+		Instant adminSettledAt = admin.settledAt();
+		assertThat(hostSettledAt).isEqualTo(SETTLED_AT);
+		assertThat(detailSettledAt).isEqualTo(SETTLED_AT);
+		assertThat(adminSettledAt).isEqualTo(SETTLED_AT);
+
+		JsonNode json = objectMapper.valueToTree(admin);
+		assertThat(json.path("settled_at").asText()).isEqualTo("2026-08-12T05:30:00Z");
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/settlement/scheduler/SettlementSchedulerTest.java
+++ b/src/test/java/kr/kro/airbob/domain/settlement/scheduler/SettlementSchedulerTest.java
@@ -1,0 +1,47 @@
+package kr.kro.airbob.domain.settlement.scheduler;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import kr.kro.airbob.domain.settlement.service.SettlementService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("월 정산 스케줄러 테스트")
+class SettlementSchedulerTest {
+
+	@Mock
+	private SettlementService settlementService;
+
+	@Test
+	@DisplayName("UTC 월 경계를 기준으로 전월 정산을 생성한다")
+	void generatesPreviousUtcMonth() {
+		Clock clock = Clock.fixed(Instant.parse("2099-01-01T00:30:00Z"), ZoneOffset.UTC);
+		SettlementScheduler scheduler = new SettlementScheduler(settlementService, clock);
+
+		scheduler.generatePreviousMonthSettlement();
+
+		verify(settlementService).generateMonth(YearMonth.of(2098, 12));
+	}
+
+	@Test
+	@DisplayName("스케줄 실행 시간대를 UTC로 고정한다")
+	void schedulesInUtc() throws NoSuchMethodException {
+		Method method = SettlementScheduler.class.getMethod("generatePreviousMonthSettlement");
+		Scheduled scheduled = method.getAnnotation(Scheduled.class);
+
+		assertThat(scheduled.zone()).isEqualTo("UTC");
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/settlement/service/SettlementServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/settlement/service/SettlementServiceTest.java
@@ -1,0 +1,87 @@
+package kr.kro.airbob.domain.settlement.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RedissonClient;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import kr.kro.airbob.domain.settlement.entity.Settlement;
+import kr.kro.airbob.domain.settlement.exception.SettlementMonthNotClosedException;
+import kr.kro.airbob.domain.settlement.repository.SettlementHistoryRepository;
+import kr.kro.airbob.domain.settlement.repository.SettlementRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("정산 시간 정책 테스트")
+class SettlementServiceTest {
+
+	private static final Instant NOW = Instant.parse("2099-01-01T00:30:00Z");
+
+	@Mock private SettlementRepository settlementRepository;
+	@Mock private SettlementHistoryRepository settlementHistoryRepository;
+	@Mock private RedissonClient redissonClient;
+	@Mock private PlatformTransactionManager transactionManager;
+
+	private SettlementService settlementService;
+
+	@BeforeEach
+	void setUp() {
+		Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+		settlementService = new SettlementService(
+			settlementRepository,
+			settlementHistoryRepository,
+			redissonClient,
+			transactionManager,
+			clock
+		);
+	}
+
+	@Test
+	@DisplayName("UTC 월 경계에서 종료된 전월 정산을 현재 Instant로 지급 처리한다")
+	void marksPreviousMonthPaidAtCurrentInstant() {
+		Settlement settlement = Settlement.createPending(
+			1L,
+			LocalDate.of(2098, 12, 1),
+			100_000L,
+			0L,
+			new BigDecimal("0.03")
+		);
+		when(settlementRepository.findById(1L)).thenReturn(Optional.of(settlement));
+
+		settlementService.markPaid(1L);
+
+		assertThat(settlement.isPaid()).isTrue();
+		assertThat(settlement.getSettledAt()).isEqualTo(NOW);
+	}
+
+	@Test
+	@DisplayName("UTC 기준 현재 월 정산은 지급 처리하지 않는다")
+	void rejectsCurrentUtcMonth() {
+		Settlement settlement = Settlement.createPending(
+			1L,
+			LocalDate.of(2099, 1, 1),
+			100_000L,
+			0L,
+			new BigDecimal("0.03")
+		);
+		when(settlementRepository.findById(1L)).thenReturn(Optional.of(settlement));
+
+		assertThatThrownBy(() -> settlementService.markPaid(1L))
+			.isInstanceOf(SettlementMonthNotClosedException.class);
+		assertThat(settlement.isPaid()).isFalse();
+		assertThat(settlement.getSettledAt()).isNull();
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/statistics/DailyRevenueStatsIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/statistics/DailyRevenueStatsIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -37,6 +38,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 	"benchmark.read-model.token=test-token"
 })
 @ActiveProfiles({"test", "read-model-benchmark"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("일일 매출 사전집계(daily_revenue_stats) 통합 테스트")
 class DailyRevenueStatsIntegrationTest {
 
@@ -67,8 +69,6 @@ class DailyRevenueStatsIntegrationTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private static final LocalDate D1 = LocalDate.of(2026, 6, 10);
@@ -194,9 +194,11 @@ class DailyRevenueStatsIntegrationTest {
 	private long insertReservation(String code, long accommodationId, long guestId) {
 		jdbc.update("""
 			INSERT INTO reservation
-				(reservation_uid, reservation_code, accommodation_id, guest_id, check_in, check_out,
+				(reservation_uid, reservation_code, accommodation_id, guest_id,
+				 check_in_date, check_out_date, check_in_at, check_out_at, time_zone_id,
 				 guest_count, total_price, status, expires_at, currency, created_at, updated_at)
-			VALUES (UUID_TO_BIN(UUID()), ?, ?, ?, '2026-07-01 15:00:00', '2026-07-03 11:00:00',
+			VALUES (UUID_TO_BIN(UUID()), ?, ?, ?,
+				 '2026-07-01', '2026-07-03', '2026-07-01 15:00:00', '2026-07-03 11:00:00', 'UTC',
 				 2, 200000, 'CONFIRMED', '2026-07-01 00:00:00', 'KRW', NOW(6), NOW(6))
 			""", code, accommodationId, guestId);
 		return jdbc.queryForObject("SELECT id FROM reservation WHERE reservation_code = ?", Long.class, code);

--- a/src/test/java/kr/kro/airbob/domain/statistics/scheduler/StatisticsSchedulerTest.java
+++ b/src/test/java/kr/kro/airbob/domain/statistics/scheduler/StatisticsSchedulerTest.java
@@ -1,0 +1,47 @@
+package kr.kro.airbob.domain.statistics.scheduler;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import kr.kro.airbob.domain.statistics.service.RevenueStatsService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("일일 매출 집계 스케줄러 테스트")
+class StatisticsSchedulerTest {
+
+	@Mock
+	private RevenueStatsService revenueStatsService;
+
+	@Test
+	@DisplayName("UTC 날짜 경계를 기준으로 전일을 집계한다")
+	void aggregatesPreviousUtcDate() {
+		Clock clock = Clock.fixed(Instant.parse("2099-01-01T00:30:00Z"), ZoneOffset.UTC);
+		StatisticsScheduler scheduler = new StatisticsScheduler(revenueStatsService, clock);
+
+		scheduler.aggregateDailyRevenue();
+
+		verify(revenueStatsService).recompute(LocalDate.of(2098, 12, 31));
+	}
+
+	@Test
+	@DisplayName("스케줄 실행 시간대를 UTC로 고정한다")
+	void schedulesInUtc() throws NoSuchMethodException {
+		Method method = StatisticsScheduler.class.getMethod("aggregateDailyRevenue");
+		Scheduled scheduled = method.getAnnotation(Scheduled.class);
+
+		assertThat(scheduled.zone()).isEqualTo("UTC");
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/wishlist/WishlistDeleteBenchmarkIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/wishlist/WishlistDeleteBenchmarkIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -58,6 +59,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 	"benchmark.bulk-write.allowed-schema=airbob_bulk_write_benchmark"
 })
 @ActiveProfiles({"test", "bulk-write-benchmark"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Import(WishlistDeleteBenchmarkIntegrationTest.RollbackProbeConfiguration.class)
 @DisplayName("Wishlist 삭제 Before/After 벌크 쓰기 비교 통합 테스트")
 class WishlistDeleteBenchmarkIntegrationTest {
@@ -85,8 +87,6 @@ class WishlistDeleteBenchmarkIntegrationTest {
 		registry.add("spring.datasource.password", MYSQL::getPassword);
 		registry.add("spring.data.redis.host", REDIS::getHost);
 		registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	@Autowired private WishlistDeleteBenchmarkService benchmarkService;

--- a/src/test/java/kr/kro/airbob/domain/wishlist/WishlistDenormalizationIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/wishlist/WishlistDenormalizationIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -39,6 +40,7 @@ import kr.kro.airbob.search.repository.AccommodationSearchRepository;
 	"benchmark.read-model.token=test-token"
 })
 @ActiveProfiles({"test", "read-model-benchmark"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("위시리스트 반정규화(개수/대표 썸네일) 통합 테스트")
 class WishlistDenormalizationIntegrationTest {
 
@@ -69,8 +71,6 @@ class WishlistDenormalizationIntegrationTest {
 		registry.add("spring.flyway.password", mySQLContainer::getPassword);
 		registry.add("spring.data.redis.host", redisContainer::getHost);
 		registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379).toString());
-		registry.add("spring.kafka.consumer.enabled", () -> "false");
-		registry.add("spring.kafka.producer.enabled", () -> "false");
 	}
 
 	private long host;

--- a/src/test/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolverTest.java
+++ b/src/test/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolverTest.java
@@ -1,10 +1,17 @@
 package kr.kro.airbob.geo.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import java.time.ZoneId;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import net.iakovlev.timeshape.TimeZoneEngine;
 
 class TimeShapeTimeZoneResolverTest {
 
@@ -25,5 +32,40 @@ class TimeShapeTimeZoneResolverTest {
 	@Test
 	void 범위를_벗어난_위도는_빈_결과를_반환한다() {
 		assertThat(resolver.resolve(91.0, 0.0)).isEmpty();
+	}
+
+	@Test
+	void NaN_좌표는_빈_결과를_반환한다() {
+		assertThat(resolver.resolve(Double.NaN, 126.9780)).isEmpty();
+		assertThat(resolver.resolve(37.5665, Double.NaN)).isEmpty();
+	}
+
+	@Test
+	void NaN_좌표는_시간대_엔진을_호출하지_않는다() {
+		TimeZoneEngine engine = mock(TimeZoneEngine.class);
+		when(engine.query(anyDouble(), anyDouble()))
+			.thenThrow(new AssertionError("유효하지 않은 좌표로 엔진을 호출하면 안 된다"));
+
+		try (MockedStatic<TimeZoneEngine> mockedEngine = mockStatic(TimeZoneEngine.class)) {
+			mockedEngine.when(TimeZoneEngine::initialize).thenReturn(engine);
+			TimeShapeTimeZoneResolver guardedResolver = new TimeShapeTimeZoneResolver();
+
+			assertThat(guardedResolver.resolve(Double.NaN, 126.9780)).isEmpty();
+			assertThat(guardedResolver.resolve(37.5665, Double.NaN)).isEmpty();
+		}
+	}
+
+	@Test
+	void 무한대_좌표는_빈_결과를_반환한다() {
+		assertThat(resolver.resolve(Double.POSITIVE_INFINITY, 126.9780)).isEmpty();
+		assertThat(resolver.resolve(Double.NEGATIVE_INFINITY, 126.9780)).isEmpty();
+		assertThat(resolver.resolve(37.5665, Double.POSITIVE_INFINITY)).isEmpty();
+		assertThat(resolver.resolve(37.5665, Double.NEGATIVE_INFINITY)).isEmpty();
+	}
+
+	@Test
+	void 범위를_벗어난_경도는_빈_결과를_반환한다() {
+		assertThat(resolver.resolve(0.0, 181.0)).isEmpty();
+		assertThat(resolver.resolve(0.0, -181.0)).isEmpty();
 	}
 }

--- a/src/test/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolverTest.java
+++ b/src/test/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolverTest.java
@@ -3,13 +3,11 @@ package kr.kro.airbob.geo.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.time.ZoneId;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import net.iakovlev.timeshape.TimeZoneEngine;
 
@@ -45,14 +43,10 @@ class TimeShapeTimeZoneResolverTest {
 		TimeZoneEngine engine = mock(TimeZoneEngine.class);
 		when(engine.query(anyDouble(), anyDouble()))
 			.thenThrow(new AssertionError("유효하지 않은 좌표로 엔진을 호출하면 안 된다"));
+		TimeShapeTimeZoneResolver guardedResolver = new TimeShapeTimeZoneResolver(engine);
 
-		try (MockedStatic<TimeZoneEngine> mockedEngine = mockStatic(TimeZoneEngine.class)) {
-			mockedEngine.when(TimeZoneEngine::initialize).thenReturn(engine);
-			TimeShapeTimeZoneResolver guardedResolver = new TimeShapeTimeZoneResolver();
-
-			assertThat(guardedResolver.resolve(Double.NaN, 126.9780)).isEmpty();
-			assertThat(guardedResolver.resolve(37.5665, Double.NaN)).isEmpty();
-		}
+		assertThat(guardedResolver.resolve(Double.NaN, 126.9780)).isEmpty();
+		assertThat(guardedResolver.resolve(37.5665, Double.NaN)).isEmpty();
 	}
 
 	@Test

--- a/src/test/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolverTest.java
+++ b/src/test/java/kr/kro/airbob/geo/impl/TimeShapeTimeZoneResolverTest.java
@@ -1,0 +1,29 @@
+package kr.kro.airbob.geo.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.Test;
+
+class TimeShapeTimeZoneResolverTest {
+
+	private final TimeShapeTimeZoneResolver resolver = new TimeShapeTimeZoneResolver();
+
+	@Test
+	void 서울_좌표를_AsiaSeoul로_해석한다() {
+		assertThat(resolver.resolve(37.5665, 126.9780))
+			.contains(ZoneId.of("Asia/Seoul"));
+	}
+
+	@Test
+	void 뉴욕_좌표를_AmericaNewYork로_해석한다() {
+		assertThat(resolver.resolve(40.7128, -74.0060))
+			.contains(ZoneId.of("America/New_York"));
+	}
+
+	@Test
+	void 범위를_벗어난_위도는_빈_결과를_반환한다() {
+		assertThat(resolver.resolve(91.0, 0.0)).isEmpty();
+	}
+}

--- a/src/test/java/kr/kro/airbob/kafka/consumer/CancellationSagaEventRoutingTest.java
+++ b/src/test/java/kr/kro/airbob/kafka/consumer/CancellationSagaEventRoutingTest.java
@@ -1,0 +1,177 @@
+package kr.kro.airbob.kafka.consumer;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import kr.kro.airbob.domain.payment.event.PaymentEvent;
+import kr.kro.airbob.domain.reservation.event.ReservationEvent;
+import kr.kro.airbob.domain.reservation.service.ReservationHoldService;
+import kr.kro.airbob.domain.reservation.service.ReservationService;
+import kr.kro.airbob.outbox.DebeziumEventParser;
+import kr.kro.airbob.outbox.EventEnvelope;
+import kr.kro.airbob.outbox.EventType;
+import kr.kro.airbob.outbox.OutboxEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("예약 취소 Saga 이벤트 라우팅 테스트")
+class CancellationSagaEventRoutingTest {
+
+	private static final Instant OCCURRED_AT = Instant.parse("2026-08-12T00:00:00Z");
+
+	@Mock private DebeziumEventParser parser;
+	@Mock private OutboxEventPublisher outboxEventPublisher;
+	@Mock private ReservationService reservationService;
+	@Mock private ReservationHoldService reservationHoldService;
+	@Mock private Acknowledgment acknowledgment;
+
+	@Test
+	@DisplayName("예약 취소 요청은 PG 취소 호출 요청으로 번역한다")
+	void translatesReservationCancellationRequest() {
+		String message = "reservation-cancellation-requested";
+		ReservationEvent.ReservationCancellationRequestedEvent payload =
+			new ReservationEvent.ReservationCancellationRequestedEvent(
+				"reservation-uid", "고객 요청", null);
+		EventEnvelope<ReservationEvent.ReservationCancellationRequestedEvent> envelope =
+			EventEnvelope.of(EventType.RESERVATION_CANCELLATION_REQUESTED, payload, OCCURRED_AT);
+		given(parser.getEventType(message))
+			.willReturn(EventType.RESERVATION_CANCELLATION_REQUESTED.name());
+		given(parser.parse(message, ReservationEvent.ReservationCancellationRequestedEvent.class))
+			.willReturn(envelope);
+
+		new ReservationEventTranslator(parser, outboxEventPublisher)
+			.translateReservationEvents(message, acknowledgment);
+
+		then(outboxEventPublisher).should().save(
+			eq(EventType.PG_CANCEL_CALL_REQUESTED),
+			argThat(event -> event instanceof PaymentEvent.PaymentCancellationRequestedEvent requested
+				&& requested.reservationUid().equals("reservation-uid")
+				&& requested.cancelReason().equals("고객 요청")
+				&& requested.cancelAmount() == null));
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("배포 전 발행된 RESERVATION_CANCELLED도 PG 취소 요청으로 변환한다")
+	void translatesLegacyReservationCancelled() {
+		String message = "legacy-reservation-cancelled";
+		ReservationEvent.ReservationCancelledEvent payload =
+			new ReservationEvent.ReservationCancelledEvent(
+				"reservation-uid", "사용자 요청", null);
+		EventEnvelope<ReservationEvent.ReservationCancelledEvent> envelope =
+			EventEnvelope.of(EventType.RESERVATION_CANCELLED, payload, OCCURRED_AT);
+		given(parser.getEventType(message))
+			.willReturn(EventType.RESERVATION_CANCELLED.name());
+		given(parser.parse(message, ReservationEvent.ReservationCancelledEvent.class))
+			.willReturn(envelope);
+
+		new ReservationEventTranslator(parser, outboxEventPublisher)
+			.translateReservationEvents(message, acknowledgment);
+
+		then(outboxEventPublisher).should().save(
+			eq(EventType.PG_CANCEL_CALL_REQUESTED),
+			argThat(event -> event instanceof PaymentEvent.PaymentCancellationRequestedEvent requested
+				&& requested.reservationUid().equals("reservation-uid")
+				&& requested.cancelReason().equals("사용자 요청"))
+		);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("결제 취소 완료는 예약 취소 완료 반영 요청으로 번역한다")
+	void translatesPaymentCancellationCompletion() {
+		String message = "payment-cancellation-completed";
+		PaymentEvent.PaymentCancellationCompletedEvent payload =
+			new PaymentEvent.PaymentCancellationCompletedEvent("reservation-uid");
+		EventEnvelope<PaymentEvent.PaymentCancellationCompletedEvent> envelope =
+			EventEnvelope.of(EventType.PAYMENT_CANCELLATION_COMPLETED, payload, OCCURRED_AT);
+		given(parser.getEventType(message))
+			.willReturn(EventType.PAYMENT_CANCELLATION_COMPLETED.name());
+		given(parser.parse(message, PaymentEvent.PaymentCancellationCompletedEvent.class))
+			.willReturn(envelope);
+
+		new PaymentEventTranslator(parser, outboxEventPublisher)
+			.translatePaymentEvents(message, acknowledgment);
+
+		then(outboxEventPublisher).should().save(
+			eq(EventType.RESERVATION_CANCELLATION_COMPLETE_REQUESTED),
+			argThat(event -> event instanceof ReservationEvent.ReservationCancellationCompleteRequestedEvent requested
+				&& requested.reservationUid().equals("reservation-uid")));
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("예약 취소 완료 반영 요청은 예약 서비스의 잠금 트랜잭션으로 전달한다")
+	void routesReservationCancellationCompletion() {
+		String message = "reservation-cancellation-complete-requested";
+		ReservationEvent.ReservationCancellationCompleteRequestedEvent payload =
+			new ReservationEvent.ReservationCancellationCompleteRequestedEvent("reservation-uid");
+		EventEnvelope<ReservationEvent.ReservationCancellationCompleteRequestedEvent> envelope =
+			EventEnvelope.of(EventType.RESERVATION_CANCELLATION_COMPLETE_REQUESTED, payload, OCCURRED_AT);
+		given(parser.getEventType(message))
+			.willReturn(EventType.RESERVATION_CANCELLATION_COMPLETE_REQUESTED.name());
+		given(parser.parse(message, ReservationEvent.ReservationCancellationCompleteRequestedEvent.class))
+			.willReturn(envelope);
+
+		new ReservationEventsConsumer(reservationService, reservationHoldService, parser)
+			.handleReservationEvents(message, acknowledgment);
+
+		then(reservationService).should().completeCancellation(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("결제 취소 실패는 예약 취소 실패 반영 요청으로 번역한다")
+	void translatesPaymentCancellationFailure() {
+		String message = "payment-cancellation-failed";
+		PaymentEvent.PaymentCancellationFailedEvent payload =
+			new PaymentEvent.PaymentCancellationFailedEvent("reservation-uid", "PG 취소 실패");
+		EventEnvelope<PaymentEvent.PaymentCancellationFailedEvent> envelope =
+			EventEnvelope.of(EventType.PAYMENT_CANCELLATION_FAILED, payload, OCCURRED_AT);
+		given(parser.getEventType(message))
+			.willReturn(EventType.PAYMENT_CANCELLATION_FAILED.name());
+		given(parser.parse(message, PaymentEvent.PaymentCancellationFailedEvent.class))
+			.willReturn(envelope);
+
+		new PaymentEventTranslator(parser, outboxEventPublisher)
+			.translatePaymentEvents(message, acknowledgment);
+
+		then(outboxEventPublisher).should().save(
+			eq(EventType.RESERVATION_CANCELLATION_REVERT_REQUESTED),
+			argThat(event -> event instanceof ReservationEvent.ReservationCancellationRevertRequestedEvent requested
+				&& requested.reservationUid().equals("reservation-uid")
+				&& requested.reason().equals("PG 취소 실패")));
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("예약 취소 실패 반영 요청은 예약 서비스의 잠금 트랜잭션으로 전달한다")
+	void routesReservationCancellationFailure() {
+		String message = "reservation-cancellation-revert-requested";
+		ReservationEvent.ReservationCancellationRevertRequestedEvent payload =
+			new ReservationEvent.ReservationCancellationRevertRequestedEvent(
+				"reservation-uid", "PG 취소 실패");
+		EventEnvelope<ReservationEvent.ReservationCancellationRevertRequestedEvent> envelope =
+			EventEnvelope.of(EventType.RESERVATION_CANCELLATION_REVERT_REQUESTED, payload, OCCURRED_AT);
+		given(parser.getEventType(message))
+			.willReturn(EventType.RESERVATION_CANCELLATION_REVERT_REQUESTED.name());
+		given(parser.parse(message, ReservationEvent.ReservationCancellationRevertRequestedEvent.class))
+			.willReturn(envelope);
+
+		new ReservationEventsConsumer(reservationService, reservationHoldService, parser)
+			.handleReservationEvents(message, acknowledgment);
+
+		then(reservationService).should().revertCancellation(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+}

--- a/src/test/java/kr/kro/airbob/kafka/consumer/DlqConsumerTest.java
+++ b/src/test/java/kr/kro/airbob/kafka/consumer/DlqConsumerTest.java
@@ -1,0 +1,441 @@
+package kr.kro.airbob.kafka.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.annotation.EnableKafkaRetryTopic;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.DltStrategy;
+import org.springframework.kafka.retrytopic.SameIntervalTopicReuseStrategy;
+import org.springframework.kafka.support.Acknowledgment;
+
+import kr.kro.airbob.common.exception.InvalidInputException;
+import kr.kro.airbob.config.KafkaConfig;
+import kr.kro.airbob.domain.payment.dto.PaymentRequest;
+import kr.kro.airbob.domain.payment.event.PaymentEvent;
+import kr.kro.airbob.domain.payment.service.PaymentApprovalService;
+import kr.kro.airbob.domain.payment.service.PaymentCancellationProcessor;
+import kr.kro.airbob.domain.payment.service.PaymentCompensationService;
+import kr.kro.airbob.domain.payment.service.PaymentConfirmationProcessor;
+import kr.kro.airbob.domain.reservation.event.ReservationEvent;
+import kr.kro.airbob.domain.reservation.exception.ReservationNotFoundException;
+import kr.kro.airbob.domain.reservation.service.ReservationService;
+import kr.kro.airbob.outbox.DebeziumEventParser;
+import kr.kro.airbob.outbox.EventEnvelope;
+import kr.kro.airbob.outbox.EventType;
+import kr.kro.airbob.outbox.OutboxEventPublisher;
+import kr.kro.airbob.outbox.SlackNotificationService;
+import kr.kro.airbob.outbox.exception.DebeziumEventParsingException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DLQ 소비자 테스트")
+class DlqConsumerTest {
+
+	@Mock private DebeziumEventParser debeziumEventParser;
+	@Mock private SlackNotificationService slackNotificationService;
+	@Mock private PaymentCompensationService paymentCompensationService;
+	@Mock private PaymentApprovalService paymentApprovalService;
+	@Mock private PaymentCancellationProcessor paymentCancellationProcessor;
+	@Mock private PaymentConfirmationProcessor paymentConfirmationProcessor;
+	@Mock private ReservationService reservationService;
+	@Mock private OutboxEventPublisher outboxEventPublisher;
+	@Mock private PaymentGatewayWorker paymentGatewayWorker;
+	@Mock private Acknowledgment acknowledgment;
+	@InjectMocks private DlqConsumer consumer;
+
+	@Test
+	@DisplayName("레거시 예약 취소 이벤트가 DLQ에 도착하면 PG 취소 요청으로 복구한다")
+	void recoversLegacyReservationCancellation() {
+		String message = "reservation-cancelled-dlt";
+		ReservationEvent.ReservationCancelledEvent payload =
+			new ReservationEvent.ReservationCancelledEvent(
+				"reservation-uid", "사용자 요청", null);
+		EventEnvelope<ReservationEvent.ReservationCancelledEvent> envelope =
+			EventEnvelope.of(EventType.RESERVATION_CANCELLED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.RESERVATION_CANCELLED.name());
+		given(debeziumEventParser.parse(message, ReservationEvent.ReservationCancelledEvent.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(outboxEventPublisher).should().save(
+			eq(EventType.PG_CANCEL_CALL_REQUESTED),
+			argThat(event -> event instanceof PaymentEvent.PaymentCancellationRequestedEvent requested
+				&& requested.reservationUid().equals("reservation-uid")
+				&& requested.cancelReason().equals("사용자 요청")
+				&& requested.cancelAmount() == null));
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("레거시 예약 취소 복구 실패는 비차단 재시도 토픽으로 전달한다")
+	void forwardsFailedLegacyCancellationRecoveryToRetryTopic() {
+		String message = "reservation-cancelled-dlt";
+		ReservationEvent.ReservationCancelledEvent payload =
+			new ReservationEvent.ReservationCancelledEvent(
+				"reservation-uid", "사용자 요청", null);
+		EventEnvelope<ReservationEvent.ReservationCancelledEvent> envelope =
+			EventEnvelope.of(EventType.RESERVATION_CANCELLED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.RESERVATION_CANCELLED.name());
+		given(debeziumEventParser.parse(message, ReservationEvent.ReservationCancelledEvent.class))
+			.willReturn(envelope);
+		willThrow(new IllegalStateException("outbox unavailable"))
+			.given(outboxEventPublisher)
+			.save(eq(EventType.PG_CANCEL_CALL_REQUESTED), argThat(event -> true));
+
+		assertThatThrownBy(() -> consumer.consumeDlqEvents(message, acknowledgment))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("outbox unavailable");
+
+		then(outboxEventPublisher).should().save(
+			eq(EventType.PG_CANCEL_CALL_REQUESTED), argThat(event -> true));
+		then(slackNotificationService).shouldHaveNoInteractions();
+		then(acknowledgment).should(never()).acknowledge();
+		then(acknowledgment).should(never()).nack(any(Duration.class));
+	}
+
+	@Test
+	@DisplayName("예약 확정 요청이 최종 실패하면 이미 승인된 결제를 보상 취소한다")
+	void compensatesFailedReservationConfirmation() {
+		String message = "reservation-confirm-requested-dlt";
+		PaymentEvent.PaymentCompletedEvent payload =
+			new PaymentEvent.PaymentCompletedEvent("reservation-uid");
+		EventEnvelope<PaymentEvent.PaymentCompletedEvent> envelope =
+			EventEnvelope.of(
+				EventType.RESERVATION_CONFIRM_REQUESTED,
+				payload,
+				java.time.Instant.parse("2026-08-12T00:00:00Z")
+			);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.RESERVATION_CONFIRM_REQUESTED.name());
+		given(debeziumEventParser.parse(message, PaymentEvent.PaymentCompletedEvent.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(paymentCompensationService).should().compensate("reservation-uid");
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("결제 보상 처리 실패는 비차단 재시도 토픽으로 전달한다")
+	void forwardsFailedPaymentCompensationToRetryTopic() {
+		String message = "payment-completed-dlt";
+		PaymentEvent.PaymentCompletedEvent payload =
+			new PaymentEvent.PaymentCompletedEvent("reservation-uid");
+		EventEnvelope<PaymentEvent.PaymentCompletedEvent> envelope =
+			EventEnvelope.of(EventType.PAYMENT_COMPLETED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PAYMENT_COMPLETED.name());
+		given(debeziumEventParser.parse(message, PaymentEvent.PaymentCompletedEvent.class))
+			.willReturn(envelope);
+		willThrow(new IllegalStateException("compensation unavailable"))
+			.given(paymentCompensationService)
+			.compensate("reservation-uid");
+
+		assertThatThrownBy(() -> consumer.consumeDlqEvents(message, acknowledgment))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("compensation unavailable");
+
+		then(paymentCompensationService).should().compensate("reservation-uid");
+		then(slackNotificationService).shouldHaveNoInteractions();
+		then(acknowledgment).should(never()).acknowledge();
+		then(acknowledgment).should(never()).nack(any(Duration.class));
+	}
+
+	@Test
+	@DisplayName("PG 환불 뒤 예약 취소 완료 반영이 최종 실패하면 DLQ에서 다시 완료 처리한다")
+	void retriesFailedCancellationCompletion() {
+		String message = "reservation-cancellation-complete-requested-dlt";
+		ReservationEvent.ReservationCancellationCompleteRequestedEvent payload =
+			new ReservationEvent.ReservationCancellationCompleteRequestedEvent("reservation-uid");
+		EventEnvelope<ReservationEvent.ReservationCancellationCompleteRequestedEvent> envelope =
+			EventEnvelope.of(
+				EventType.RESERVATION_CANCELLATION_COMPLETE_REQUESTED,
+				payload,
+				java.time.Instant.parse("2026-08-12T00:00:00Z")
+			);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.RESERVATION_CANCELLATION_COMPLETE_REQUESTED.name());
+		given(debeziumEventParser.parse(
+			message, ReservationEvent.ReservationCancellationCompleteRequestedEvent.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(reservationService).should().completeCancellation(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("PG 취소 호출 요청이 최종 실패해도 멱등키가 적용되는 워커로 한 번 더 복구한다")
+	void retriesFailedPgCancellationRequest() {
+		String message = "pg-cancel-call-requested-dlt";
+		PaymentEvent.PaymentCancellationRequestedEvent payload =
+			new PaymentEvent.PaymentCancellationRequestedEvent(
+				"reservation-uid", "사용자 요청", null);
+		EventEnvelope<PaymentEvent.PaymentCancellationRequestedEvent> envelope =
+			EventEnvelope.of(EventType.PG_CANCEL_CALL_REQUESTED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PG_CANCEL_CALL_REQUESTED.name());
+		given(debeziumEventParser.parse(
+			message, PaymentEvent.PaymentCancellationRequestedEvent.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(paymentGatewayWorker).should().processCancelRequest(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("PG 승인 요청이 최종 실패해도 같은 멱등키 워커로 승인 결과를 복구한다")
+	void retriesFailedPgConfirmRequest() {
+		String message = "pg-call-requested-dlt";
+		PaymentRequest.Confirm payload = new PaymentRequest.Confirm(
+			"payment-key", "reservation-uid", 100_000);
+		EventEnvelope<PaymentRequest.Confirm> envelope =
+			EventEnvelope.of(EventType.PG_CALL_REQUESTED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PG_CALL_REQUESTED.name());
+		given(debeziumEventParser.parse(message, PaymentRequest.Confirm.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(paymentGatewayWorker).should().processConfirmRequest(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("결제 승인 요청이 DLQ에 도착하면 승인 선점 로직을 다시 실행한다")
+	void recoversPaymentConfirmRequest() {
+		String message = "payment-confirm-requested-dlt";
+		PaymentRequest.Confirm payload = new PaymentRequest.Confirm(
+			"payment-key", "reservation-uid", 100_000);
+		EventEnvelope<PaymentRequest.Confirm> envelope = EventEnvelope.of(
+			EventType.PAYMENT_CONFIRM_REQUESTED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PAYMENT_CONFIRM_REQUESTED.name());
+		given(debeziumEventParser.parse(message, PaymentRequest.Confirm.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(paymentApprovalService).should().preparePgCall(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("결제 승인 선점의 일시 오류는 비차단 재시도 토픽으로 전달한다")
+	void retriesTransientPaymentConfirmFailure() {
+		String message = "payment-confirm-requested-dlt";
+		PaymentRequest.Confirm payload = new PaymentRequest.Confirm(
+			"payment-key", "reservation-uid", 100_000);
+		EventEnvelope<PaymentRequest.Confirm> envelope = EventEnvelope.of(
+			EventType.PAYMENT_CONFIRM_REQUESTED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PAYMENT_CONFIRM_REQUESTED.name());
+		given(debeziumEventParser.parse(message, PaymentRequest.Confirm.class))
+			.willReturn(envelope);
+		willThrow(new IllegalStateException("database unavailable"))
+			.given(paymentApprovalService)
+			.preparePgCall(payload);
+
+		assertThatThrownBy(() -> consumer.consumeDlqEvents(message, acknowledgment))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("database unavailable");
+
+		then(acknowledgment).should(never()).acknowledge();
+		then(slackNotificationService).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("PG 승인 복구 호출 실패는 비차단 재시도 토픽으로 전달한다")
+	void forwardsFailedPgConfirmRecoveryToRetryTopic() {
+		String message = "pg-call-requested-dlt";
+		PaymentRequest.Confirm payload = new PaymentRequest.Confirm(
+			"payment-key", "reservation-uid", 100_000);
+		EventEnvelope<PaymentRequest.Confirm> envelope =
+			EventEnvelope.of(EventType.PG_CALL_REQUESTED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PG_CALL_REQUESTED.name());
+		given(debeziumEventParser.parse(message, PaymentRequest.Confirm.class))
+			.willReturn(envelope);
+		willThrow(new IllegalStateException("pg unavailable"))
+			.given(paymentGatewayWorker)
+			.processConfirmRequest(payload);
+
+		assertThatThrownBy(() -> consumer.consumeDlqEvents(message, acknowledgment))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("pg unavailable");
+
+		then(paymentGatewayWorker).should().processConfirmRequest(payload);
+		then(slackNotificationService).shouldHaveNoInteractions();
+		then(acknowledgment).should(never()).acknowledge();
+		then(acknowledgment).should(never()).nack(any(Duration.class));
+	}
+
+	@Test
+	@DisplayName("DLQ 복구는 세 번 재시도한 뒤 보관 토픽으로 이동한다")
+	void configuresBoundedNonBlockingRetry() throws NoSuchMethodException {
+		RetryableTopic retryableTopic = DlqConsumer.class
+			.getMethod("consumeDlqEvents", String.class, Acknowledgment.class)
+			.getAnnotation(RetryableTopic.class);
+
+		assertThat(retryableTopic).isNotNull();
+		assertThat(retryableTopic.attempts()).isEqualTo("4");
+		assertThat(retryableTopic.backoff().delay()).isEqualTo(30_000L);
+		assertThat(retryableTopic.kafkaTemplate()).isEqualTo("deadLetterKafkaTemplate");
+		assertThat(retryableTopic.retryTopicSuffix()).isEqualTo(".RETRY");
+		assertThat(retryableTopic.dltTopicSuffix()).isEqualTo(".PARKING");
+		assertThat(retryableTopic.sameIntervalTopicReuseStrategy())
+			.isEqualTo(SameIntervalTopicReuseStrategy.SINGLE_TOPIC);
+		assertThat(retryableTopic.dltStrategy()).isEqualTo(DltStrategy.FAIL_ON_ERROR);
+		assertThat(retryableTopic.exclude())
+			.containsExactlyInAnyOrder(
+				InvalidInputException.class,
+				ReservationNotFoundException.class
+			);
+		assertThat(KafkaConfig.class.isAnnotationPresent(EnableKafkaRetryTopic.class)).isTrue();
+	}
+
+	@Test
+	@DisplayName("재시도를 모두 소진한 메시지는 한 번 알리고 보관 토픽 오프셋을 커밋한다")
+	void alertsOnceWhenRetriesAreExhausted() {
+		String message = "payment-completed-parking";
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PAYMENT_COMPLETED.name());
+		consumer.handleExhaustedRecovery(message, "database unavailable", acknowledgment);
+
+		then(slackNotificationService).should().sendAlert(argThat(alert ->
+			alert.contains(EventType.PAYMENT_COMPLETED.name())
+				&& alert.contains("database unavailable")));
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("PG 승인 성공 이벤트의 DB 반영이 최종 실패하면 DLQ에서 다시 반영한다")
+	void retriesFailedPgCallSucceeded() {
+		String message = "pg-call-succeeded-dlt";
+		PaymentEvent.PgCallSucceededEvent payload =
+			new PaymentEvent.PgCallSucceededEvent(null, "reservation-uid");
+		EventEnvelope<PaymentEvent.PgCallSucceededEvent> envelope =
+			EventEnvelope.of(EventType.PG_CALL_SUCCEEDED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PG_CALL_SUCCEEDED.name());
+		given(debeziumEventParser.parse(message, PaymentEvent.PgCallSucceededEvent.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(paymentConfirmationProcessor).should().processSuccess(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("PG 승인 실패 이벤트의 DB 반영이 최종 실패하면 DLQ에서 다시 반영한다")
+	void retriesFailedPgCallFailure() {
+		String message = "pg-call-failed-dlt";
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", "reservation-uid", 100_000);
+		PaymentEvent.PgCallFailedEvent payload =
+			new PaymentEvent.PgCallFailedEvent(
+				request, "reservation-uid", "REJECTED", "결제 거절");
+		EventEnvelope<PaymentEvent.PgCallFailedEvent> envelope =
+			EventEnvelope.of(EventType.PG_CALL_FAILED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PG_CALL_FAILED.name());
+		given(debeziumEventParser.parse(message, PaymentEvent.PgCallFailedEvent.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(paymentConfirmationProcessor).should().processFailure(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("결제 실패 이벤트 번역이 최종 실패하면 DLQ에서 예약을 만료 처리한다")
+	void expiresReservationForFailedPayment() {
+		String message = "payment-failed-dlt";
+		PaymentEvent.PaymentFailedEvent payload =
+			new PaymentEvent.PaymentFailedEvent("reservation-uid", "결제 거절");
+		EventEnvelope<PaymentEvent.PaymentFailedEvent> envelope =
+			EventEnvelope.of(EventType.PAYMENT_FAILED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PAYMENT_FAILED.name());
+		given(debeziumEventParser.parse(message, PaymentEvent.PaymentFailedEvent.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(reservationService).should().expireReservation(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("예약 만료 요청이 최종 실패하면 DLQ에서 예약을 다시 만료 처리한다")
+	void retriesFailedReservationExpiration() {
+		String message = "reservation-expire-requested-dlt";
+		PaymentEvent.PaymentFailedEvent payload =
+			new PaymentEvent.PaymentFailedEvent("reservation-uid", "결제 거절");
+		EventEnvelope<PaymentEvent.PaymentFailedEvent> envelope =
+			EventEnvelope.of(EventType.RESERVATION_EXPIRE_REQUESTED, payload, java.time.Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.RESERVATION_EXPIRE_REQUESTED.name());
+		given(debeziumEventParser.parse(message, PaymentEvent.PaymentFailedEvent.class))
+			.willReturn(envelope);
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(reservationService).should().expireReservation(payload);
+		then(acknowledgment).should().acknowledge();
+	}
+
+	@Test
+	@DisplayName("지원하지 않는 이벤트는 성공적으로 무시하고 DLQ에서 제거한다")
+	void acknowledgesSuccessfullyIgnoredUnsupportedEvent() {
+		String message = "accommodation-updated-dlt";
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.ACCOMMODATION_UPDATED.name());
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(acknowledgment).should().acknowledge();
+		then(acknowledgment).should(never()).nack(any(Duration.class));
+	}
+
+	@Test
+	@DisplayName("지원하는 이벤트라도 페이로드를 파싱할 수 없으면 무한 재시도하지 않는다")
+	void acknowledgesPoisonPayload() {
+		String message = "malformed-payment-completed-dlt";
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PAYMENT_COMPLETED.name());
+		given(debeziumEventParser.parse(message, PaymentEvent.PaymentCompletedEvent.class))
+			.willThrow(new DebeziumEventParsingException(new IOException("malformed payload")));
+
+		consumer.consumeDlqEvents(message, acknowledgment);
+
+		then(acknowledgment).should().acknowledge();
+		then(acknowledgment).should(never()).nack(any(Duration.class));
+	}
+}

--- a/src/test/java/kr/kro/airbob/kafka/consumer/PaymentEventsConsumerTest.java
+++ b/src/test/java/kr/kro/airbob/kafka/consumer/PaymentEventsConsumerTest.java
@@ -1,0 +1,57 @@
+package kr.kro.airbob.kafka.consumer;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import kr.kro.airbob.domain.payment.dto.PaymentRequest;
+import kr.kro.airbob.domain.payment.service.PaymentApprovalService;
+import kr.kro.airbob.domain.payment.service.PaymentCancellationProcessor;
+import kr.kro.airbob.domain.payment.service.PaymentConfirmationProcessor;
+import kr.kro.airbob.outbox.DebeziumEventParser;
+import kr.kro.airbob.outbox.EventEnvelope;
+import kr.kro.airbob.outbox.EventType;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("결제 이벤트 컨슈머 테스트")
+class PaymentEventsConsumerTest {
+
+	@Mock private DebeziumEventParser debeziumEventParser;
+	@Mock private PaymentApprovalService paymentApprovalService;
+	@Mock private PaymentConfirmationProcessor confirmationProcessor;
+	@Mock private PaymentCancellationProcessor cancellationProcessor;
+	@Mock private Acknowledgment acknowledgment;
+
+	@InjectMocks private PaymentEventsConsumer consumer;
+
+	@Test
+	@DisplayName("결제 승인 요청은 예약 선점 서비스에 위임하고 성공 후 ACK한다")
+	void delegatesConfirmationRequestToAtomicClaimService() {
+		String message = "payment-confirm-requested";
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		EventEnvelope<PaymentRequest.Confirm> envelope = EventEnvelope.of(
+			EventType.PAYMENT_CONFIRM_REQUESTED, request, Instant.EPOCH);
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PAYMENT_CONFIRM_REQUESTED.name());
+		given(debeziumEventParser.parse(message, PaymentRequest.Confirm.class))
+			.willReturn(envelope);
+		given(paymentApprovalService.preparePgCall(request)).willReturn(true);
+
+		consumer.handlePaymentEvents(message, acknowledgment);
+
+		then(paymentApprovalService).should().preparePgCall(request);
+		then(acknowledgment).should().acknowledge();
+	}
+}

--- a/src/test/java/kr/kro/airbob/kafka/consumer/PaymentGatewayWorkerTest.java
+++ b/src/test/java/kr/kro/airbob/kafka/consumer/PaymentGatewayWorkerTest.java
@@ -1,0 +1,459 @@
+package kr.kro.airbob.kafka.consumer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import kr.kro.airbob.domain.payment.dto.PaymentRequest;
+import kr.kro.airbob.domain.payment.dto.TossPaymentResponse;
+import kr.kro.airbob.domain.payment.entity.Payment;
+import kr.kro.airbob.domain.payment.event.PaymentEvent;
+import kr.kro.airbob.domain.payment.exception.TossPaymentException;
+import kr.kro.airbob.domain.payment.exception.code.PaymentInquiryErrorCode;
+import kr.kro.airbob.domain.payment.repository.PaymentRepository;
+import kr.kro.airbob.domain.payment.service.PaymentCompensationService;
+import kr.kro.airbob.domain.payment.service.TossPaymentsAdapter;
+import kr.kro.airbob.domain.reservation.entity.Reservation;
+import kr.kro.airbob.domain.reservation.entity.ReservationStatus;
+import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
+import kr.kro.airbob.outbox.DebeziumEventParser;
+import kr.kro.airbob.outbox.EventEnvelope;
+import kr.kro.airbob.outbox.EventPayload;
+import kr.kro.airbob.outbox.EventType;
+import kr.kro.airbob.outbox.OutboxEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PG 호출 워커 테스트")
+class PaymentGatewayWorkerTest {
+	private static final Instant NOW = Instant.parse("2026-08-12T00:00:00Z");
+
+	@Mock private DebeziumEventParser debeziumEventParser;
+	@Mock private TossPaymentsAdapter tossPaymentsAdapter;
+	@Mock private OutboxEventPublisher outboxEventPublisher;
+	@Mock private PaymentRepository paymentRepository;
+	@Mock private ReservationRepository reservationRepository;
+	@Mock private PaymentCompensationService paymentCompensationService;
+	@Mock private Acknowledgment acknowledgment;
+
+	private PaymentGatewayWorker worker;
+
+	@BeforeEach
+	void setUp() {
+		worker = new PaymentGatewayWorker(
+			debeziumEventParser,
+			tossPaymentsAdapter,
+			outboxEventPublisher,
+			paymentRepository,
+			reservationRepository,
+			paymentCompensationService,
+			Clock.fixed(NOW, ZoneOffset.UTC)
+		);
+	}
+
+	@Test
+	@DisplayName("예약 금액과 다른 승인 요청은 PG를 호출하기 전에 거부한다")
+	void rejectsConfirmRequestWithMismatchedReservationAmount() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 90_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.PAYMENT_PROCESSING)
+			.expiresAt(NOW.plusSeconds(60))
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+
+		assertThatThrownBy(() -> worker.processConfirmRequest(request))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("결제 승인 요청");
+
+		verify(tossPaymentsAdapter, never()).confirmPayment(any(), any(), any());
+		verify(outboxEventPublisher, never())
+			.save(eq(EventType.PG_CALL_SUCCEEDED), any(EventPayload.class));
+	}
+
+	@Test
+	@DisplayName("PG 승인 응답이 원 요청과 다르면 성공 이벤트를 발행하지 않는다")
+	void rejectsMismatchedConfirmResponse() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.PAYMENT_PROCESSING)
+			.expiresAt(NOW.plusSeconds(60))
+			.build();
+		TossPaymentResponse response = TossPaymentResponse.builder()
+			.paymentKey("another-payment-key")
+			.orderId(reservationUid.toString())
+			.totalAmount(100_000L)
+			.balanceAmount(100_000L)
+			.method("카드")
+			.status("DONE")
+			.approvedAt(ZonedDateTime.now())
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+		given(tossPaymentsAdapter.confirmPayment(
+			"payment-key", reservationUid.toString(), 100_000))
+			.willReturn(response);
+
+		assertThatThrownBy(() -> worker.processConfirmRequest(request))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("PG 승인 응답");
+
+		verify(outboxEventPublisher, never())
+			.save(eq(EventType.PG_CALL_SUCCEEDED), any(EventPayload.class));
+	}
+
+	@Test
+	@DisplayName("원 요청과 일치하는 PG 승인 결과만 성공 이벤트로 발행한다")
+	void publishesCorrelatedConfirmResponse() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.PAYMENT_PROCESSING)
+			.expiresAt(NOW.plusSeconds(60))
+			.build();
+		TossPaymentResponse response = TossPaymentResponse.builder()
+			.paymentKey("payment-key")
+			.orderId(reservationUid.toString())
+			.totalAmount(100_000L)
+			.balanceAmount(100_000L)
+			.method("카드")
+			.status("DONE")
+			.approvedAt(ZonedDateTime.now())
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+		given(tossPaymentsAdapter.confirmPayment(
+			"payment-key", reservationUid.toString(), 100_000))
+			.willReturn(response);
+
+		worker.processConfirmRequest(request);
+
+		verify(outboxEventPublisher).save(
+			eq(EventType.PG_CALL_SUCCEEDED),
+			any(PaymentEvent.PgCallSucceededEvent.class));
+	}
+
+	@Test
+	@DisplayName("PG 호출 이벤트 처리가 예약 만료 뒤로 지연되면 승인 API를 호출하지 않는다")
+	void skipsDelayedConfirmRequestAfterExpiration() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.PAYMENT_PROCESSING)
+			.expiresAt(NOW)
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+		given(tossPaymentsAdapter.getPaymentByPaymentKey("payment-key"))
+			.willThrow(new TossPaymentException(PaymentInquiryErrorCode.NOT_FOUND_PAYMENT));
+
+		worker.processConfirmRequest(request);
+
+		verify(tossPaymentsAdapter, never()).confirmPayment(any(), any(), any());
+		verify(tossPaymentsAdapter).getPaymentByPaymentKey("payment-key");
+		verify(outboxEventPublisher).save(
+			eq(EventType.PG_CALL_FAILED),
+			any(PaymentEvent.PgCallFailedEvent.class));
+	}
+
+	@Test
+	@DisplayName("만료 뒤 재처리라도 PG에 이미 승인된 결제는 조회 결과로 복구한다")
+	void recoversAlreadyApprovedPaymentAfterExpiration() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.PAYMENT_PROCESSING)
+			.expiresAt(NOW)
+			.build();
+		TossPaymentResponse approvedPayment = TossPaymentResponse.builder()
+			.paymentKey("payment-key")
+			.orderId(reservationUid.toString())
+			.totalAmount(100_000L)
+			.balanceAmount(100_000L)
+			.method("카드")
+			.status("DONE")
+			.approvedAt(ZonedDateTime.parse("2026-08-11T23:59:59Z"))
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+		given(tossPaymentsAdapter.getPaymentByPaymentKey("payment-key"))
+			.willReturn(approvedPayment);
+
+		worker.processConfirmRequest(request);
+
+		verify(tossPaymentsAdapter, never()).confirmPayment(any(), any(), any());
+		verify(outboxEventPublisher).save(
+			eq(EventType.PG_CALL_SUCCEEDED),
+			any(PaymentEvent.PgCallSucceededEvent.class));
+		verify(outboxEventPublisher, never()).save(
+			eq(EventType.PG_CALL_FAILED),
+			any(PaymentEvent.PgCallFailedEvent.class));
+	}
+
+	@Test
+	@DisplayName("처리 중 만료된 예약의 결제가 이미 환불됐다면 예약 만료 흐름으로 넘긴다")
+	void expiresProcessingReservationWhenPaymentWasAlreadyRefunded() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.PAYMENT_PROCESSING)
+			.expiresAt(NOW)
+			.build();
+		TossPaymentResponse canceledPayment = TossPaymentResponse.builder()
+			.paymentKey("payment-key")
+			.orderId(reservationUid.toString())
+			.totalAmount(100_000L)
+			.balanceAmount(0L)
+			.status("CANCELED")
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+		given(tossPaymentsAdapter.getPaymentByPaymentKey("payment-key"))
+			.willReturn(canceledPayment);
+
+		worker.processConfirmRequest(request);
+
+		verify(tossPaymentsAdapter, never()).confirmPayment(any(), any(), any());
+		verify(outboxEventPublisher).save(
+			eq(EventType.PG_CALL_FAILED),
+			any(PaymentEvent.PgCallFailedEvent.class));
+	}
+
+	@Test
+	@DisplayName("결제 처리 상태가 아닌 예약은 PG 승인 API를 호출하지 않는다")
+	void rejectsReservationThatDidNotClaimPayment() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.PAYMENT_PENDING)
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+
+		assertThatThrownBy(() -> worker.processConfirmRequest(request))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("결제 처리 상태");
+
+		verify(tossPaymentsAdapter, never()).confirmPayment(any(), any(), any());
+		verify(outboxEventPublisher, never())
+			.save(eq(EventType.PG_CALL_SUCCEEDED), any(EventPayload.class));
+	}
+
+	@Test
+	@DisplayName("이미 결제가 확정된 예약의 중복 PG 호출 이벤트는 성공 처리로 간주한다")
+	void ignoresDuplicateConfirmRequestAfterReservationConfirmed() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.CONFIRMED)
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+
+		worker.processConfirmRequest(request);
+
+		verify(tossPaymentsAdapter, never()).confirmPayment(any(), any(), any());
+		verify(tossPaymentsAdapter, never()).getPaymentByPaymentKey(any());
+		verify(outboxEventPublisher, never()).save(any(), any());
+	}
+
+	@Test
+	@DisplayName("이미 만료된 예약의 PG 호출 이벤트는 기존 승인 여부만 조회한다")
+	void recoversDuplicateConfirmRequestAfterReservationExpired() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.EXPIRED)
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+		given(tossPaymentsAdapter.getPaymentByPaymentKey("payment-key"))
+			.willThrow(new TossPaymentException(PaymentInquiryErrorCode.NOT_FOUND_PAYMENT));
+
+		worker.processConfirmRequest(request);
+
+		verify(tossPaymentsAdapter, never()).confirmPayment(any(), any(), any());
+		verify(tossPaymentsAdapter).getPaymentByPaymentKey("payment-key");
+		verify(outboxEventPublisher).save(
+			eq(EventType.PG_CALL_FAILED),
+			any(PaymentEvent.PgCallFailedEvent.class));
+	}
+
+	@Test
+	@DisplayName("이미 만료되고 전액 환불된 결제의 중복 PG 호출 이벤트는 종료한다")
+	void ignoresDuplicateConfirmRequestAfterFullRefund() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.EXPIRED)
+			.build();
+		TossPaymentResponse canceledPayment = TossPaymentResponse.builder()
+			.paymentKey("payment-key")
+			.orderId(reservationUid.toString())
+			.totalAmount(100_000L)
+			.balanceAmount(0L)
+			.status("CANCELED")
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+		given(tossPaymentsAdapter.getPaymentByPaymentKey("payment-key"))
+			.willReturn(canceledPayment);
+
+		worker.processConfirmRequest(request);
+
+		verify(tossPaymentsAdapter, never()).confirmPayment(any(), any(), any());
+		verify(outboxEventPublisher, never()).save(any(), any());
+	}
+
+	@Test
+	@DisplayName("잔액이 남은 부분 취소 결제는 보상 취소를 이어서 수행한다")
+	void compensatesDuplicateConfirmRequestWithRemainingBalance() {
+		UUID reservationUid = UUID.randomUUID();
+		PaymentRequest.Confirm request = new PaymentRequest.Confirm(
+			"payment-key", reservationUid.toString(), 100_000);
+		Reservation reservation = Reservation.builder()
+			.reservationUid(reservationUid)
+			.totalPrice(100_000L)
+			.status(ReservationStatus.EXPIRED)
+			.build();
+		TossPaymentResponse partiallyCanceledPayment = TossPaymentResponse.builder()
+			.paymentKey("payment-key")
+			.orderId(reservationUid.toString())
+			.totalAmount(100_000L)
+			.balanceAmount(50_000L)
+			.status("PARTIAL_CANCELED")
+			.build();
+		given(reservationRepository.findByReservationUid(reservationUid))
+			.willReturn(Optional.of(reservation));
+		given(tossPaymentsAdapter.getPaymentByPaymentKey("payment-key"))
+			.willReturn(partiallyCanceledPayment);
+
+		worker.processConfirmRequest(request);
+
+		verify(paymentCompensationService).compensate(reservationUid.toString());
+		verify(outboxEventPublisher, never()).save(any(), any());
+	}
+
+	@Test
+	@DisplayName("PG 취소 성공 후 성공 이벤트 저장이 실패하면 취소 실패 이벤트로 바꾸지 않는다")
+	void doesNotConvertSuccessfulPgCancellationIntoFailure() {
+		String message = "pg-cancel-request";
+		UUID reservationUid = UUID.randomUUID();
+		PaymentEvent.PaymentCancellationRequestedEvent request =
+			new PaymentEvent.PaymentCancellationRequestedEvent(
+				reservationUid.toString(), "사용자 요청", null);
+		EventEnvelope<PaymentEvent.PaymentCancellationRequestedEvent> envelope =
+			EventEnvelope.of(EventType.PG_CANCEL_CALL_REQUESTED, request, Instant.EPOCH);
+		Payment payment = mock(Payment.class);
+		TossPaymentResponse response = TossPaymentResponse.builder()
+			.paymentKey("payment-key")
+			.orderId(reservationUid.toString())
+			.status("CANCELED")
+			.balanceAmount(0L)
+			.build();
+
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PG_CANCEL_CALL_REQUESTED.name());
+		given(debeziumEventParser.parse(
+			message, PaymentEvent.PaymentCancellationRequestedEvent.class))
+			.willReturn(envelope);
+		given(paymentRepository.findByReservationReservationUid(reservationUid))
+			.willReturn(Optional.of(payment));
+		given(payment.getPaymentKey()).willReturn("payment-key");
+		given(tossPaymentsAdapter.cancelPayment("payment-key", "사용자 요청", null))
+			.willReturn(response);
+		doThrow(new RuntimeException("outbox 저장 실패"))
+			.when(outboxEventPublisher)
+			.save(eq(EventType.PG_CANCEL_CALL_SUCCEEDED), any(EventPayload.class));
+
+		assertThatThrownBy(() -> worker.handlePgCallRequest(message, acknowledgment))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage("outbox 저장 실패");
+
+		verify(outboxEventPublisher, never())
+			.save(eq(EventType.PG_CANCEL_CALL_FAILED), any(EventPayload.class));
+		verify(acknowledgment, never()).acknowledge();
+	}
+
+	@Test
+	@DisplayName("결과를 알 수 없는 PG 통신 오류는 실패로 확정하지 않고 Kafka 재시도로 넘긴다")
+	void retriesUnknownPgCancellationResult() {
+		String message = "pg-cancel-request";
+		UUID reservationUid = UUID.randomUUID();
+		PaymentEvent.PaymentCancellationRequestedEvent request =
+			new PaymentEvent.PaymentCancellationRequestedEvent(
+				reservationUid.toString(), "사용자 요청", null);
+		EventEnvelope<PaymentEvent.PaymentCancellationRequestedEvent> envelope =
+			EventEnvelope.of(EventType.PG_CANCEL_CALL_REQUESTED, request, Instant.EPOCH);
+		Payment payment = mock(Payment.class);
+
+		given(debeziumEventParser.getEventType(message))
+			.willReturn(EventType.PG_CANCEL_CALL_REQUESTED.name());
+		given(debeziumEventParser.parse(
+			message, PaymentEvent.PaymentCancellationRequestedEvent.class))
+			.willReturn(envelope);
+		given(paymentRepository.findByReservationReservationUid(reservationUid))
+			.willReturn(Optional.of(payment));
+		given(payment.getPaymentKey()).willReturn("payment-key");
+		given(tossPaymentsAdapter.cancelPayment("payment-key", "사용자 요청", null))
+			.willThrow(new RuntimeException("응답 유실"));
+
+		assertThatThrownBy(() -> worker.handlePgCallRequest(message, acknowledgment))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage("응답 유실");
+
+		verify(outboxEventPublisher, never())
+			.save(eq(EventType.PG_CANCEL_CALL_FAILED), any(EventPayload.class));
+	}
+}

--- a/src/test/java/kr/kro/airbob/migration/AccommodationTimeZoneMigrationIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/migration/AccommodationTimeZoneMigrationIntegrationTest.java
@@ -19,18 +19,18 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-@DisplayName("숙소 시간대 V15 마이그레이션 통합 테스트")
+@DisplayName("숙소와 예약 시간 모델 마이그레이션 통합 테스트")
 class AccommodationTimeZoneMigrationIntegrationTest {
 
 	@Container
-	private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.33")
+	private final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.33")
 		.withDatabaseName("airbobdb_accommodation_time_zone")
 		.withUsername("airbob")
 		.withPassword("airbob");
 
 	@Test
-	@DisplayName("기존 숙소와 이력은 서울로 백필하고 새 DRAFT는 null 시간대를 허용한다")
-	void backfillsLegacyRowsAndKeepsNewDraftNullable() throws SQLException {
+	@DisplayName("시간대 컬럼을 추가하고 기존 행과 새 DRAFT 모두 null 시간대를 허용한다")
+	void addsNullableTimeZoneColumnsWithoutBackfill() throws SQLException {
 		migrateTo("14");
 		long memberId = insertMember("legacy-host@test.com");
 		long legacyAccommodationId = insertAccommodation(memberId, "00112233445566778899AABBCCDDEEFF");
@@ -44,9 +44,9 @@ class AccommodationTimeZoneMigrationIntegrationTest {
 			assertThat(columnNullable(connection, "accommodation", "time_zone_id")).isTrue();
 			assertThat(columnNullable(connection, "accommodation_history", "time_zone_id")).isTrue();
 			assertThat(readTimeZone(connection, "accommodation", legacyAccommodationId))
-				.isEqualTo("Asia/Seoul");
+				.isNull();
 			assertThat(readTimeZone(connection, "accommodation_history", legacyHistoryId))
-				.isEqualTo("Asia/Seoul");
+				.isNull();
 		}
 
 		long draftAccommodationId = insertAccommodation(memberId, "FFEEDDCCBBAA99887766554433221100");
@@ -55,18 +55,42 @@ class AccommodationTimeZoneMigrationIntegrationTest {
 		}
 	}
 
+	@Test
+	@DisplayName("예약 숙박일은 DATE로, 절대 시각과 시간대 스냅샷은 필수 컬럼으로 생성한다")
+	void migratesReservationDateAndInstantColumns() throws SQLException {
+		migrateAll();
+
+		try (Connection connection = connection()) {
+			assertThat(columnExists(connection, "reservation", "check_in")).isFalse();
+			assertThat(columnType(connection, "reservation", "check_in_date")).isEqualTo("DATE");
+			assertThat(columnType(connection, "reservation", "check_out_date")).isEqualTo("DATE");
+			assertThat(columnType(connection, "reservation", "check_in_at")).isEqualTo("DATETIME");
+			assertThat(columnType(connection, "reservation", "check_out_at")).isEqualTo("DATETIME");
+			assertThat(columnNullable(connection, "reservation", "check_in_at")).isFalse();
+			assertThat(columnNullable(connection, "reservation", "check_out_at")).isFalse();
+			assertThat(columnNullable(connection, "reservation", "time_zone_id")).isFalse();
+
+			assertThat(columnType(connection, "reservation_history", "check_in_date")).isEqualTo("DATE");
+			assertThat(columnType(connection, "reservation_history", "check_out_date")).isEqualTo("DATE");
+			assertThat(columnNullable(connection, "reservation_history", "check_in_at")).isTrue();
+			assertThat(columnNullable(connection, "reservation_history", "check_out_at")).isTrue();
+			assertThat(columnNullable(connection, "reservation_history", "time_zone_id")).isTrue();
+		}
+	}
+
 	private void migrateTo(String version) {
-		Flyway.configure()
-			.dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+		Flyway flyway = Flyway.configure()
+			.dataSource(mysql.getJdbcUrl(), mysql.getUsername(), mysql.getPassword())
 			.locations("classpath:db/migration")
 			.target(MigrationVersion.fromVersion(version))
-			.load()
-			.migrate();
+			.load();
+		flyway.migrate();
+		assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo(version);
 	}
 
 	private void migrateAll() {
 		Flyway.configure()
-			.dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+			.dataSource(mysql.getJdbcUrl(), mysql.getUsername(), mysql.getPassword())
 			.locations("classpath:db/migration")
 			.load()
 			.migrate();
@@ -145,7 +169,15 @@ class AccommodationTimeZoneMigrationIntegrationTest {
 		}
 	}
 
+	private String columnType(Connection connection, String table, String column) throws SQLException {
+		try (ResultSet columns = connection.getMetaData().getColumns(
+			connection.getCatalog(), null, table, column)) {
+			assertThat(columns.next()).isTrue();
+			return columns.getString("TYPE_NAME");
+		}
+	}
+
 	private Connection connection() throws SQLException {
-		return DriverManager.getConnection(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+		return DriverManager.getConnection(mysql.getJdbcUrl(), mysql.getUsername(), mysql.getPassword());
 	}
 }

--- a/src/test/java/kr/kro/airbob/migration/AccommodationTimeZoneMigrationIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/migration/AccommodationTimeZoneMigrationIntegrationTest.java
@@ -1,0 +1,151 @@
+package kr.kro.airbob.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@DisplayName("숙소 시간대 V15 마이그레이션 통합 테스트")
+class AccommodationTimeZoneMigrationIntegrationTest {
+
+	@Container
+	private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.33")
+		.withDatabaseName("airbobdb_accommodation_time_zone")
+		.withUsername("airbob")
+		.withPassword("airbob");
+
+	@Test
+	@DisplayName("기존 숙소와 이력은 서울로 백필하고 새 DRAFT는 null 시간대를 허용한다")
+	void backfillsLegacyRowsAndKeepsNewDraftNullable() throws SQLException {
+		migrateTo("14");
+		long memberId = insertMember("legacy-host@test.com");
+		long legacyAccommodationId = insertAccommodation(memberId, "00112233445566778899AABBCCDDEEFF");
+		long legacyHistoryId = insertAccommodationHistory(legacyAccommodationId);
+
+		migrateAll();
+
+		try (Connection connection = connection()) {
+			assertThat(columnExists(connection, "accommodation", "time_zone_id")).isTrue();
+			assertThat(columnExists(connection, "accommodation_history", "time_zone_id")).isTrue();
+			assertThat(columnNullable(connection, "accommodation", "time_zone_id")).isTrue();
+			assertThat(columnNullable(connection, "accommodation_history", "time_zone_id")).isTrue();
+			assertThat(readTimeZone(connection, "accommodation", legacyAccommodationId))
+				.isEqualTo("Asia/Seoul");
+			assertThat(readTimeZone(connection, "accommodation_history", legacyHistoryId))
+				.isEqualTo("Asia/Seoul");
+		}
+
+		long draftAccommodationId = insertAccommodation(memberId, "FFEEDDCCBBAA99887766554433221100");
+		try (Connection connection = connection()) {
+			assertThat(readTimeZone(connection, "accommodation", draftAccommodationId)).isNull();
+		}
+	}
+
+	private void migrateTo(String version) {
+		Flyway.configure()
+			.dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+			.locations("classpath:db/migration")
+			.target(MigrationVersion.fromVersion(version))
+			.load()
+			.migrate();
+	}
+
+	private void migrateAll() {
+		Flyway.configure()
+			.dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+			.locations("classpath:db/migration")
+			.load()
+			.migrate();
+	}
+
+	private long insertMember(String email) throws SQLException {
+		try (Connection connection = connection();
+			PreparedStatement statement = connection.prepareStatement("""
+				insert into member (email, nickname, status, updated_at)
+				values (?, 'host', 'ACTIVE', current_timestamp(6))
+				""", Statement.RETURN_GENERATED_KEYS)) {
+			statement.setString(1, email);
+			statement.executeUpdate();
+			return generatedId(statement);
+		}
+	}
+
+	private long insertAccommodation(long memberId, String uidHex) throws SQLException {
+		try (Connection connection = connection();
+			PreparedStatement statement = connection.prepareStatement("""
+				insert into accommodation (
+				  member_id, check_in_time, check_out_time, accommodation_uid, updated_at, status
+				) values (?, '15:00:00', '11:00:00', unhex(?), current_timestamp(6), 'DRAFT')
+				""", Statement.RETURN_GENERATED_KEYS)) {
+			statement.setLong(1, memberId);
+			statement.setString(2, uidHex);
+			statement.executeUpdate();
+			return generatedId(statement);
+		}
+	}
+
+	private long insertAccommodationHistory(long accommodationId) throws SQLException {
+		try (Connection connection = connection();
+			PreparedStatement statement = connection.prepareStatement("""
+				insert into accommodation_history (
+				  accommodation_id, status, history_created_at, change_type, valid_from, valid_to
+				) values (?, 'DRAFT', current_timestamp(6), 'CREATE', current_timestamp(6),
+				  '9999-12-31 23:59:59')
+				""", Statement.RETURN_GENERATED_KEYS)) {
+			statement.setLong(1, accommodationId);
+			statement.executeUpdate();
+			return generatedId(statement);
+		}
+	}
+
+	private long generatedId(PreparedStatement statement) throws SQLException {
+		try (ResultSet keys = statement.getGeneratedKeys()) {
+			assertThat(keys.next()).isTrue();
+			return keys.getLong(1);
+		}
+	}
+
+	private String readTimeZone(Connection connection, String table, long id) throws SQLException {
+		try (PreparedStatement statement = connection.prepareStatement(
+			"select time_zone_id from " + table + " where id = ?")) {
+			statement.setLong(1, id);
+			try (ResultSet result = statement.executeQuery()) {
+				assertThat(result.next()).isTrue();
+				return result.getString("time_zone_id");
+			}
+		}
+	}
+
+	private boolean columnExists(Connection connection, String table, String column) throws SQLException {
+		try (ResultSet columns = connection.getMetaData().getColumns(
+			connection.getCatalog(), null, table, column)) {
+			return columns.next();
+		}
+	}
+
+	private boolean columnNullable(Connection connection, String table, String column) throws SQLException {
+		try (ResultSet columns = connection.getMetaData().getColumns(
+			connection.getCatalog(), null, table, column)) {
+			assertThat(columns.next()).isTrue();
+			return columns.getInt("NULLABLE") == DatabaseMetaData.columnNullable;
+		}
+	}
+
+	private Connection connection() throws SQLException {
+		return DriverManager.getConnection(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+	}
+}

--- a/src/test/java/kr/kro/airbob/outbox/EventEnvelopeTest.java
+++ b/src/test/java/kr/kro/airbob/outbox/EventEnvelopeTest.java
@@ -1,0 +1,126 @@
+package kr.kro.airbob.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.kro.airbob.domain.payment.event.PaymentEvent;
+
+@JsonTest
+@DisplayName("이벤트 봉투 시간 테스트")
+class EventEnvelopeTest {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("이벤트 발생 시각은 UTC 절대 시각으로 보존한다")
+	void timestampIsAnInstant() {
+		Instant occurredAt = Instant.parse("2026-08-12T05:30:00.123456Z");
+		PaymentEvent.PaymentCompletedEvent payload =
+			new PaymentEvent.PaymentCompletedEvent("reservation-uid");
+
+		EventEnvelope<PaymentEvent.PaymentCompletedEvent> envelope = EventEnvelope.of(
+			EventType.PAYMENT_COMPLETED,
+			payload,
+			occurredAt
+		);
+
+		assertThat(envelope.timestamp()).isEqualTo(occurredAt);
+	}
+
+	@Test
+	@DisplayName("호환 기간에는 UTC 시각을 오프셋 없는 기존 형식으로 직렬화한다")
+	void serializesTimestampAsLegacyBareUtc() throws JsonProcessingException {
+		EventEnvelope<PaymentEvent.PaymentCompletedEvent> envelope = envelopeAt(
+			Instant.parse("2026-08-12T05:30:00.123456Z")
+		);
+
+		JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(envelope));
+
+		assertThat(json.path("timestamp").asText()).isEqualTo("2026-08-12T05:30:00.123456");
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("compatibleTimestamps")
+	@DisplayName("기존 UTC 문자열과 Z·오프셋 문자열을 동일한 Instant로 역직렬화한다")
+	void deserializesLegacyAndOffsetTimestamps(String timestamp, Instant expected) throws JsonProcessingException {
+		EventEnvelope<PaymentEvent.PaymentCompletedEvent> envelope = objectMapper.readValue(
+			envelopeJson(timestamp),
+			envelopeType()
+		);
+
+		assertThat(envelope.timestamp()).isEqualTo(expected);
+	}
+
+	@ParameterizedTest(name = "timestamp={0}")
+	@MethodSource("invalidTimestamps")
+	@DisplayName("null과 잘못된 시각은 EventEnvelope로 역직렬화할 수 없다")
+	void rejectsNullAndInvalidTimestamps(String timestampJson) {
+		assertThatThrownBy(() -> objectMapper.readValue(envelopeJsonValue(timestampJson), envelopeType()))
+			.isInstanceOf(JsonProcessingException.class)
+			.hasMessageContaining("timestamp");
+	}
+
+	private EventEnvelope<PaymentEvent.PaymentCompletedEvent> envelopeAt(Instant timestamp) {
+		return EventEnvelope.of(
+			EventType.PAYMENT_COMPLETED,
+			new PaymentEvent.PaymentCompletedEvent("reservation-uid"),
+			timestamp
+		);
+	}
+
+	private JavaType envelopeType() {
+		return objectMapper.getTypeFactory().constructParametricType(
+			EventEnvelope.class,
+			PaymentEvent.PaymentCompletedEvent.class
+		);
+	}
+
+	private String envelopeJson(String timestamp) {
+		return envelopeJsonValue('"' + timestamp + '"');
+	}
+
+	private String envelopeJsonValue(String timestampJson) {
+		return """
+			{
+			  "event_id": "12f4c680-6c60-4b60-a1c8-8ef1ea285207",
+			  "trace_id": "reservation-uid",
+			  "event_type": "PAYMENT_COMPLETED",
+			  "event_version": "1.0",
+			  "timestamp": %s,
+			  "payload": {"reservation_uid": "reservation-uid"}
+			}
+			""".formatted(timestampJson);
+	}
+
+	private static java.util.stream.Stream<Arguments> compatibleTimestamps() {
+		Instant expected = Instant.parse("2026-08-12T05:30:00.123456Z");
+		return java.util.stream.Stream.of(
+			Arguments.of("2026-08-12T05:30:00.123456", expected),
+			Arguments.of("2026-08-12T05:30:00.123456Z", expected),
+			Arguments.of("2026-08-12T14:30:00.123456+09:00", expected)
+		);
+	}
+
+	private static java.util.stream.Stream<Arguments> invalidTimestamps() {
+		return java.util.stream.Stream.of(
+			Arguments.of("null"),
+			Arguments.of("\"not-a-timestamp\"")
+		);
+	}
+}

--- a/src/test/java/kr/kro/airbob/search/dto/AccommodationSearchRequestValidationTest.java
+++ b/src/test/java/kr/kro/airbob/search/dto/AccommodationSearchRequestValidationTest.java
@@ -1,0 +1,71 @@
+package kr.kro.airbob.search.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+@DisplayName("숙소 검색 요청 검증 테스트")
+class AccommodationSearchRequestValidationTest {
+
+	private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+	@Test
+	@DisplayName("날짜의 과거 여부는 DTO가 아니라 숙소 현지 예약 창으로 검증한다")
+	void allowsPastDatesForAccommodationLocalDateValidation() {
+		AccommodationSearchRequest.AccommodationSearchRequestDto request = requestWithDates(
+			LocalDate.of(2000, 1, 1),
+			LocalDate.of(2000, 1, 2)
+		);
+
+		assertThat(validator.validate(request)).isEmpty();
+	}
+
+	@ParameterizedTest
+	@MethodSource("invalidDateRanges")
+	@DisplayName("체크인과 체크아웃은 함께 입력하고 체크아웃이 더 뒤여야 한다")
+	void rejectsNonIncreasingDateRanges(LocalDate checkIn, LocalDate checkOut) {
+		AccommodationSearchRequest.AccommodationSearchRequestDto request = requestWithDates(checkIn, checkOut);
+
+		assertThat(validator.validate(request))
+			.extracting(violation -> violation.getPropertyPath().toString())
+			.containsExactly("validDateRange");
+	}
+
+	private static Stream<Arguments> invalidDateRanges() {
+		return Stream.of(
+			Arguments.of(LocalDate.of(2026, 8, 12), LocalDate.of(2026, 8, 12)),
+			Arguments.of(LocalDate.of(2026, 8, 13), LocalDate.of(2026, 8, 12)),
+			Arguments.of(LocalDate.of(2026, 8, 13), null),
+			Arguments.of(null, LocalDate.of(2026, 8, 14))
+		);
+	}
+
+	@Test
+	@DisplayName("체크인과 체크아웃을 모두 생략하면 날짜 조건 없는 검색으로 허용한다")
+	void allowsBothDatesToBeOmitted() {
+		AccommodationSearchRequest.AccommodationSearchRequestDto request = requestWithDates(null, null);
+
+		assertThat(validator.validate(request)).isEmpty();
+	}
+
+	private AccommodationSearchRequest.AccommodationSearchRequestDto requestWithDates(
+		LocalDate checkIn,
+		LocalDate checkOut
+	) {
+		AccommodationSearchRequest.AccommodationSearchRequestDto request =
+			new AccommodationSearchRequest.AccommodationSearchRequestDto();
+		request.setCheckIn(checkIn);
+		request.setCheckOut(checkOut);
+		return request;
+	}
+}

--- a/src/test/java/kr/kro/airbob/search/dto/AccommodationSearchResponseTest.java
+++ b/src/test/java/kr/kro/airbob/search/dto/AccommodationSearchResponseTest.java
@@ -1,0 +1,23 @@
+package kr.kro.airbob.search.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("숙소 검색 응답 테스트")
+class AccommodationSearchResponseTest {
+
+	@Test
+	@DisplayName("빈 결과도 요청 페이지 번호에 맞는 이전 페이지 정보를 반환한다")
+	void emptyPageKeepsRequestedPageMetadata() {
+		AccommodationSearchResponse.PageInfo pageInfo =
+			AccommodationSearchResponse.PageInfo.fail(18, 5);
+
+		assertThat(pageInfo.currentPage()).isEqualTo(5);
+		assertThat(pageInfo.isFirst()).isFalse();
+		assertThat(pageInfo.isLast()).isTrue();
+		assertThat(pageInfo.hasPrevious()).isTrue();
+		assertThat(pageInfo.hasNext()).isFalse();
+	}
+}

--- a/src/test/java/kr/kro/airbob/search/service/AccommodationDocumentBuilderTest.java
+++ b/src/test/java/kr/kro/airbob/search/service/AccommodationDocumentBuilderTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -24,6 +25,8 @@ import kr.kro.airbob.domain.accommodation.entity.OccupancyPolicy;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationAmenityRepository;
 import kr.kro.airbob.domain.accommodation.repository.AccommodationRepository;
 import kr.kro.airbob.domain.reservation.dto.ReservationDateRange;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
+import kr.kro.airbob.domain.reservation.policy.ReservationIndexingWindow;
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.domain.review.repository.AccommodationReviewSummaryRepository;
 import kr.kro.airbob.search.document.AccommodationDocument;
@@ -44,6 +47,9 @@ class AccommodationDocumentBuilderTest {
 	@Mock
 	private AccommodationReviewSummaryRepository reviewSummaryRepository;
 
+	@Mock
+	private BookingWindowProvider bookingWindowProvider;
+
 	@InjectMocks
 	private AccommodationDocumentBuilder documentBuilder;
 
@@ -51,6 +57,8 @@ class AccommodationDocumentBuilderTest {
 	@DisplayName("예약 범위는 숙소 UID로 조회하고 병합, 중복 제거, 정렬 없이 날짜 범위로 변환한다")
 	void preserveEachReservationRangeFromUidProjection() {
 		UUID accommodationUid = UUID.fromString("8df7d116-42d1-44f4-87f5-ab87295caf23");
+		ReservationIndexingWindow window = new ReservationIndexingWindow(
+			LocalDate.of(2026, 8, 11), LocalDate.of(2026, 11, 13));
 		Accommodation accommodation = Accommodation.builder()
 			.id(41L)
 			.accommodationUid(accommodationUid)
@@ -60,6 +68,7 @@ class AccommodationDocumentBuilderTest {
 			.currency("KRW")
 			.type("HOUSE")
 			.status(AccommodationStatus.PUBLISHED)
+			.timeZoneId("Asia/Seoul")
 			.createdAt(LocalDateTime.of(2026, 8, 1, 9, 0))
 			.address(Address.builder()
 				.country("KR")
@@ -78,21 +87,23 @@ class AccommodationDocumentBuilderTest {
 				.petOccupancy(0)
 				.build())
 			.build();
-		List<ReservationDateRange> projectedRanges = List.of(
-			new ReservationDateRange(
-				LocalDateTime.of(2026, 8, 12, 15, 0),
-				LocalDateTime.of(2026, 8, 15, 11, 0)),
-			new ReservationDateRange(
-				LocalDateTime.of(2026, 8, 12, 15, 0),
-				LocalDateTime.of(2026, 8, 15, 11, 0)),
-			new ReservationDateRange(
-				LocalDateTime.of(2026, 8, 10, 15, 0),
-				LocalDateTime.of(2026, 8, 13, 11, 0))
-		);
+			List<ReservationDateRange> projectedRanges = List.of(
+				new ReservationDateRange(
+					LocalDate.of(2026, 8, 12),
+					LocalDate.of(2026, 8, 15)),
+				new ReservationDateRange(
+					LocalDate.of(2026, 8, 12),
+					LocalDate.of(2026, 8, 15)),
+				new ReservationDateRange(
+					LocalDate.of(2026, 8, 10),
+					LocalDate.of(2026, 8, 13))
+			);
 		when(accommodationRepository.findWithDetailsByAccommodationUid(accommodationUid))
 			.thenReturn(Optional.of(accommodation));
+		when(bookingWindowProvider.currentIndexingWindow()).thenReturn(window);
 		when(reservationRepository
-			.findFutureConfirmedReservationRangesByAccommodationUid(accommodationUid))
+			.findActiveReservationRangesByAccommodationId(
+				accommodation.getId(), window.startInclusive(), window.endExclusive()))
 			.thenReturn(projectedRanges);
 
 		AccommodationDocument document =
@@ -106,7 +117,10 @@ class AccommodationDocumentBuilderTest {
 			new AccommodationDocument.DateRange(
 				LocalDate.of(2026, 8, 10), LocalDate.of(2026, 8, 13))
 		);
+		assertThat(document.createdAt()).isEqualTo(Instant.parse("2026-08-01T09:00:00Z"));
+		assertThat(document.timeZoneId()).isEqualTo("Asia/Seoul");
 		verify(reservationRepository)
-			.findFutureConfirmedReservationRangesByAccommodationUid(accommodationUid);
+			.findActiveReservationRangesByAccommodationId(
+				accommodation.getId(), window.startInclusive(), window.endExclusive());
 	}
 }

--- a/src/test/java/kr/kro/airbob/search/service/AccommodationIndexUpdaterTest.java
+++ b/src/test/java/kr/kro/airbob/search/service/AccommodationIndexUpdaterTest.java
@@ -2,11 +2,13 @@ package kr.kro.airbob.search.service;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +24,8 @@ import org.springframework.data.elasticsearch.core.query.ScriptType;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 
 import kr.kro.airbob.domain.reservation.dto.ReservationDateRange;
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
+import kr.kro.airbob.domain.reservation.policy.ReservationIndexingWindow;
 import kr.kro.airbob.domain.reservation.repository.ReservationRepository;
 import kr.kro.airbob.domain.review.repository.AccommodationReviewSummaryRepository;
 
@@ -38,25 +42,32 @@ class AccommodationIndexUpdaterTest {
 	@Mock
 	private ReservationRepository reservationRepository;
 
+	@Mock
+	private BookingWindowProvider bookingWindowProvider;
+
 	@InjectMocks
 	private AccommodationIndexUpdater indexUpdater;
 
 	@Test
-	@DisplayName("숙소 UID 예약 범위의 모든 숙박일을 전역 중복 제거하고 정렬한 ISO 문자열로 갱신한다")
-	void updateReservedDatesFromUidProjectionWithDistinctAscendingDates() {
+	@DisplayName("숙소 UID 예약 범위를 반열린 날짜 구간으로 갱신한다")
+	void updateReservationRangesFromUidProjection() {
 		UUID accommodationUid = UUID.fromString("8df7d116-42d1-44f4-87f5-ab87295caf23");
+		ReservationIndexingWindow window = new ReservationIndexingWindow(
+			LocalDate.of(2026, 8, 11), LocalDate.of(2026, 11, 13));
+		when(bookingWindowProvider.currentIndexingWindow()).thenReturn(window);
 		when(reservationRepository
-			.findFutureConfirmedReservationRangesByAccommodationUid(accommodationUid))
+			.findActiveReservationRangesByAccommodationUid(
+				accommodationUid, window.startInclusive(), window.endExclusive()))
 			.thenReturn(List.of(
 				new ReservationDateRange(
-					LocalDateTime.of(2026, 8, 12, 15, 0),
-					LocalDateTime.of(2026, 8, 15, 11, 0)),
+					LocalDate.of(2026, 8, 12),
+					LocalDate.of(2026, 8, 15)),
 				new ReservationDateRange(
-					LocalDateTime.of(2026, 8, 10, 15, 0),
-					LocalDateTime.of(2026, 8, 13, 11, 0))
+					LocalDate.of(2026, 8, 10),
+					LocalDate.of(2026, 8, 13))
 			));
 
-		indexUpdater.updateReservedDatesInIndex(accommodationUid.toString());
+		indexUpdater.updateReservationRangesInIndex(accommodationUid.toString());
 
 		ArgumentCaptor<UpdateQuery> queryCaptor = ArgumentCaptor.forClass(UpdateQuery.class);
 		ArgumentCaptor<IndexCoordinates> indexCaptor = ArgumentCaptor.forClass(IndexCoordinates.class);
@@ -65,16 +76,34 @@ class AccommodationIndexUpdaterTest {
 		assertThat(updateQuery.getId()).isEqualTo(accommodationUid.toString());
 		assertThat(updateQuery.getScriptType()).isEqualTo(ScriptType.INLINE);
 		assertThat(updateQuery.getScript())
-			.isEqualTo("ctx._source.reservedDates = params.reservedDates");
-		assertThat(updateQuery.getParams()).containsOnly(entry("reservedDates", List.of(
-			"2026-08-10",
-			"2026-08-11",
-			"2026-08-12",
-			"2026-08-13",
-			"2026-08-14"
+			.isEqualTo("ctx._source.reservationRanges = params.reservationRanges");
+		assertThat(updateQuery.getParams()).containsOnly(entry("reservationRanges", List.of(
+			Map.of("gte", "2026-08-12", "lt", "2026-08-15"),
+			Map.of("gte", "2026-08-10", "lt", "2026-08-13")
 		)));
 		assertThat(indexCaptor.getValue().getIndexNames()).containsExactly("accommodations");
 		verify(reservationRepository)
-			.findFutureConfirmedReservationRangesByAccommodationUid(accommodationUid);
+			.findActiveReservationRangesByAccommodationUid(
+				accommodationUid, window.startInclusive(), window.endExclusive());
+	}
+
+	@Test
+	@DisplayName("활성 예약이 없으면 기존 예약 범위를 빈 목록으로 초기화한다")
+	void clearsReservationRangesWhenNoConfirmedReservationExists() {
+		UUID accommodationUid = UUID.fromString("8df7d116-42d1-44f4-87f5-ab87295caf23");
+		ReservationIndexingWindow window = new ReservationIndexingWindow(
+			LocalDate.of(2026, 8, 11), LocalDate.of(2026, 11, 13));
+		when(bookingWindowProvider.currentIndexingWindow()).thenReturn(window);
+		when(reservationRepository
+			.findActiveReservationRangesByAccommodationUid(
+				accommodationUid, window.startInclusive(), window.endExclusive()))
+			.thenReturn(List.of());
+
+		indexUpdater.updateReservationRangesInIndex(accommodationUid.toString());
+
+		ArgumentCaptor<UpdateQuery> queryCaptor = ArgumentCaptor.forClass(UpdateQuery.class);
+		verify(elasticsearchOperations).update(queryCaptor.capture(), any(IndexCoordinates.class));
+		assertThat(queryCaptor.getValue().getParams())
+			.containsOnly(entry("reservationRanges", List.of()));
 	}
 }

--- a/src/test/java/kr/kro/airbob/search/service/AccommodationSearchServiceTest.java
+++ b/src/test/java/kr/kro/airbob/search/service/AccommodationSearchServiceTest.java
@@ -1,0 +1,100 @@
+package kr.kro.airbob.search.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeRelation;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+
+import kr.kro.airbob.domain.reservation.policy.BookingWindowProvider;
+import kr.kro.airbob.domain.wishlist.repository.WishlistAccommodationRepository;
+import kr.kro.airbob.search.dto.AccommodationSearchRequest;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("숙소 검색 서비스 테스트")
+class AccommodationSearchServiceTest {
+
+	@Mock
+	private ElasticsearchClient esClient;
+
+	@Mock
+	private WishlistAccommodationRepository wishlistRepository;
+
+	@Mock
+	private BookingWindowProvider bookingWindowProvider;
+
+	@InjectMocks
+	private AccommodationSearchService accommodationSearchService;
+
+	@Test
+	@DisplayName("어느 숙소 현지 3개월 예약 창에도 들지 않는 날짜는 빈 결과를 반환한다")
+	void returnsEmptyWhenNoTimeZoneCanBookStay() {
+		AccommodationSearchRequest.AccommodationSearchRequestDto request = dateRequest(
+			LocalDate.of(2026, 11, 12), LocalDate.of(2026, 11, 13));
+		request.setDestination("Seoul");
+		given(bookingWindowProvider.eligibleTimeZonesForStay(
+			request.getCheckIn(), request.getCheckOut())).willReturn(Set.of());
+
+		var result = accommodationSearchService.searchAccommodations(
+			request,
+			new AccommodationSearchRequest.MapBoundsDto(),
+			PageRequest.of(0, 18),
+			null
+		);
+
+		assertThat(result.staySearchResultListing()).isEmpty();
+		assertThat(result.pageInfo().totalElements()).isZero();
+		verifyNoInteractions(esClient);
+	}
+
+	@Test
+	@DisplayName("날짜 검색은 숙박일이 현지 3개월 창 안에 있는 시간대의 숙소만 대상으로 한다")
+	void filtersDateSearchByEligibleAccommodationTimeZones() {
+		AccommodationSearchRequest.AccommodationSearchRequestDto request = dateRequest(
+			LocalDate.of(2026, 8, 12), LocalDate.of(2026, 8, 13));
+
+		Query query = accommodationSearchService.buildQuery(
+			request, null, Set.of("Asia/Seoul", "Pacific/Auckland"));
+
+		assertThat(query.bool().filter())
+			.anySatisfy(filter -> {
+				assertThat(filter.isTerms()).isTrue();
+				assertThat(filter.terms().field()).isEqualTo("timeZoneId");
+				assertThat(filter.terms().terms().value())
+					.extracting(value -> value.stringValue())
+					.containsExactly("Asia/Seoul", "Pacific/Auckland");
+			});
+		assertThat(query.bool().mustNot())
+			.anySatisfy(mustNot -> {
+				assertThat(mustNot.isRange()).isTrue();
+				assertThat(mustNot.range().date().field()).isEqualTo("reservationRanges");
+				assertThat(mustNot.range().date().gte()).isEqualTo("2026-08-12");
+				assertThat(mustNot.range().date().lt()).isEqualTo("2026-08-13");
+				assertThat(mustNot.range().date().relation()).isEqualTo(RangeRelation.Intersects);
+			});
+	}
+
+	private AccommodationSearchRequest.AccommodationSearchRequestDto dateRequest(
+		LocalDate checkIn,
+		LocalDate checkOut
+	) {
+		AccommodationSearchRequest.AccommodationSearchRequestDto request =
+			new AccommodationSearchRequest.AccommodationSearchRequestDto();
+		request.setCheckIn(checkIn);
+		request.setCheckOut(checkOut);
+		return request;
+	}
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -18,6 +18,8 @@ spring:
   # [Kafka]
   kafka:
     bootstrap-servers: localhost:9092
+    listener:
+      auto-startup: false
 
   # [Elasticsearch]
   elasticsearch:
@@ -56,5 +58,4 @@ payment:
 toss:
   client-key: dummy-client-key
   secret-key: dummy-toss-secret-key
-
 


### PR DESCRIPTION
## 작업한 이유

서버가 UTC로 실행되더라도 숙소의 예약 가능 날짜는 숙소가 위치한 지역의 날짜를 기준으로 판단해야 합니다. 기존처럼 서버 시간이나 요청자의 시간대에 의존하면 한국과 해외 숙소의 날짜 경계가 달라지고, 자정 전후에는 상세 화면·검색·실제 예약 검증 결과가 서로 어긋날 수 있었습니다.

이번 작업에서는 숙소 좌표로 IANA 시간대를 결정하고, 날짜와 시각의 의미를 분리했습니다. 이 과정에서 결제 승인과 취소 이벤트를 점검하면서 일시적인 PG 오류가 최종 실패로 확정되거나 DLQ 한 건이 파티션을 계속 막을 수 있는 문제도 함께 보완했습니다.

## 주요 변경 내용

### 숙소 현지 날짜와 UTC 시간 모델

- 숙소 생성 시 위도·경도를 TimeShape에 전달해 `Asia/Seoul`, `America/New_York` 같은 IANA 시간대를 저장합니다.
- 숙소별 현재 날짜를 기준으로 오늘부터 3개월의 예약 가능 범위를 계산합니다.
- 체크인·체크아웃은 숙소의 달력 날짜인 `LocalDate`, 생성·만료·승인 시각은 UTC `Instant`로 구분했습니다.
- JVM, Hibernate, JDBC 세션과 감사·이력·정산·통계 시각을 UTC 기준으로 통일했습니다.
- API의 절대 시각은 UTC 오프셋이 포함된 값으로 반환하고, 프론트엔드가 사용자 환경에 맞게 표시할 수 있도록 했습니다.

### 예약·검색·색인의 동일한 기준 적용

- 숙소 상세, 예약 생성, MySQL 검색, Elasticsearch 검색이 같은 예약 가능 범위를 사용합니다.
- 예약 불가 정보는 날짜를 하루씩 펼치지 않고 `[checkIn, checkOut)` 구간으로 유지합니다.
- 예약 생성 시 숙소 현지 날짜 기준으로 과거 날짜와 3개월 범위 초과 요청을 거절합니다.
- 검색 요청은 체크인과 체크아웃을 함께 입력한 경우에만 날짜 필터를 적용합니다.
- Logstash와 실시간 색인 갱신도 활성 예약 상태와 같은 날짜 구간을 사용하도록 맞췄습니다.

### 결제와 DLQ 복구 안정성

- 결제 승인 전 예약을 잠그고 `PAYMENT_PROCESSING` 상태를 선점해 중복 PG 호출을 방지합니다.
- Toss 승인·취소 요청에 안정적인 멱등키를 적용했습니다.
- `IDEMPOTENT_REQUEST_PROCESSING` 응답은 최종 실패가 아닌 일시 오류로 분류해 같은 멱등키로 최대 3번 시도합니다.
- DLQ 복구는 30초 간격으로 3회 재시도한 뒤 `.PARKING` 토픽으로 이동하도록 제한했습니다.
- 재시도를 모두 소진한 경우에만 Slack 알림을 보내고, 잘못된 입력이나 존재하지 않는 예약은 반복 재시도하지 않습니다.
- 결제·예약 취소 흐름의 이벤트 타입과 보상 경로를 명시해 중간 단계 실패 후에도 이어서 처리할 수 있도록 했습니다.

## 설계하면서 고민한 점

- 날짜만 필요한 예약 규칙에는 `LocalDate`, 실제 발생 시각에는 `Instant`를 사용해 타입만 보고도 의미를 구분할 수 있도록 했습니다.
- 시간대는 국가명이나 고정 오프셋 대신 DST 변경을 반영할 수 있는 IANA 지역 ID로 저장했습니다.
- 외부 Time Zone API를 매 요청마다 호출하지 않고, 숙소 등록 시 좌표 기반으로 한 번 결정해 조회 경로의 외부 의존성을 없앴습니다.
- DLQ 메시지를 같은 파티션에서 계속 `nack`하지 않고 retry/parking 토픽으로 분리해 뒤 메시지 처리를 막지 않도록 했습니다.

## 확인한 내용

- 숙소 좌표별 시간대 결정과 잘못된 좌표·시간대 입력을 검증했습니다.
- UTC와 DST 경계에서 예약 가능 범위, 예약 생성, 응답 직렬화를 확인했습니다.
- 숙소 상세·MySQL 검색·Elasticsearch 색인이 동일한 예약 구간을 사용하는지 확인했습니다.
- 결제 승인 선점, Toss 멱등키, 409 재시도, 취소 보상 흐름을 검증했습니다.
- DLQ의 재시도 대상, 영구 오류 제외, 최종 보관과 알림 동작을 검증했습니다.
- 커서 리팩터링 작업을 제외한 깨끗한 PR 커밋으로 전체 테스트를 실행했습니다.

```text
./gradlew test --no-daemon --max-workers=1
899 tests, 0 failures, 0 errors, 1 skipped
```

## 배포 시 확인사항

- Kafka 자동 토픽 생성을 사용하지 않는 환경에서는 `PAYMENT.events.DLT.RETRY`, `PAYMENT.events.DLT.PARKING` 토픽을 미리 생성해야 합니다.
- 애플리케이션과 MySQL 세션이 UTC로 동작하도록 추가한 설정을 운영 환경에서도 유지해야 합니다.
