### PR TITLE
refactor: 커서 페이징 공통 로직과 입력 검증 정비

### DIFF
--- a/src/main/java/kr/kro/airbob/common/exception/ErrorCode.java
+++ b/src/main/java/kr/kro/airbob/common/exception/ErrorCode.java
@@ -15,10 +15,11 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부에서 처리할 수 없는 오류가 발생했습니다."),
 	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "유효하지 않은 타입 값입니다."),
 	CURSOR_ENCODING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C005", "커서 인코딩 중 오류가 발생했습니다."),
-	CURSOR_PAGE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "C006", "커서 페이지 크기는 1 이상이어야 합니다."),
+	CURSOR_PAGE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "C006", "유효하지 않은 커서 페이지 크기입니다."),
 	OUTBOX_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "C007", "요청을 처리하는 중 내부 이벤트 시스템에 오류가 발생했습니다."),
 	DEBEZIUM_EVENT_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C008", "Debezium 이벤트 파싱 실패"),
 	INVALID_INPUT(HttpStatus.BAD_REQUEST, "C009", "요청 ID와 리소스가 속한 ID가 일치하지 않습니다."),
+	CURSOR_DECODING_ERROR(HttpStatus.BAD_REQUEST, "C010", "유효하지 않은 커서입니다."),
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "R000", "리소스를 찾을 수 없습니다."),
 
 	// common code

--- a/src/main/java/kr/kro/airbob/config/WebMvcConfig.java
+++ b/src/main/java/kr/kro/airbob/config/WebMvcConfig.java
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import kr.kro.airbob.common.monitoring.QueryCountInterceptor;
-import kr.kro.airbob.cursor.resolver.CursorParamArgumentResolver;
+import kr.kro.airbob.cursor.resolver.AbstractCursorParamArgumentResolver;
 import kr.kro.airbob.domain.auth.filter.SessionAuthFilter;
 import kr.kro.airbob.domain.auth.interceptor.AdminAuthInterceptor;
 import kr.kro.airbob.domain.auth.resolver.CurrentMemberIdArgumentResolver;
@@ -26,13 +26,13 @@ import lombok.extern.slf4j.Slf4j;
 public class WebMvcConfig implements WebMvcConfigurer {
 
 	private final CurrentMemberIdArgumentResolver currentMemberIdArgumentResolver;
-	private final CursorParamArgumentResolver cursorParamArgumentResolver;
+	private final List<AbstractCursorParamArgumentResolver<?, ?>> cursorParamArgumentResolvers;
 	private final SessionAuthFilter sessionAuthFilter;
 	private final AdminAuthInterceptor adminAuthInterceptor;
 	private final QueryCountInterceptor queryCountInterceptor;
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-		resolvers.add(cursorParamArgumentResolver);
+		resolvers.addAll(cursorParamArgumentResolvers);
 		resolvers.add(currentMemberIdArgumentResolver);
 	}
 

--- a/src/main/java/kr/kro/airbob/cursor/dto/CursorData.java
+++ b/src/main/java/kr/kro/airbob/cursor/dto/CursorData.java
@@ -1,0 +1,9 @@
+package kr.kro.airbob.cursor.dto;
+
+import java.time.LocalDateTime;
+
+public record CursorData(
+	Long id,
+	LocalDateTime lastCreatedAt
+) implements CursorPayload {
+}

--- a/src/main/java/kr/kro/airbob/cursor/dto/CursorPayload.java
+++ b/src/main/java/kr/kro/airbob/cursor/dto/CursorPayload.java
@@ -1,0 +1,16 @@
+package kr.kro.airbob.cursor.dto;
+
+import java.time.LocalDateTime;
+
+public interface CursorPayload {
+
+	Long id();
+
+	LocalDateTime lastCreatedAt();
+
+	default void validate() {
+		if (id() == null || id() < 1 || lastCreatedAt() == null) {
+			throw new IllegalArgumentException("커서 경계 값이 유효하지 않습니다.");
+		}
+	}
+}

--- a/src/main/java/kr/kro/airbob/cursor/dto/CursorResponse.java
+++ b/src/main/java/kr/kro/airbob/cursor/dto/CursorResponse.java
@@ -1,15 +1,9 @@
 package kr.kro.airbob.cursor.dto;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
-
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CursorResponse {
 
@@ -19,24 +13,5 @@ public class CursorResponse {
 		String nextCursor,
 		int currentSize
 	) {
-	}
-
-	@Builder
-	@Getter
-	@AllArgsConstructor
-	public static class CursorData {
-		private final Long id;
-		private final LocalDateTime lastCreatedAt;
-	}
-
-	@Getter
-	public static class ReviewCursorData extends CursorData {
-
-		private final Integer lastRating;
-
-		public ReviewCursorData(Long id, LocalDateTime lastCreatedAt, Integer lastRating) {
-			super(id, lastCreatedAt);
-			this.lastRating = lastRating;
-		}
 	}
 }

--- a/src/main/java/kr/kro/airbob/cursor/dto/ReviewCursorData.java
+++ b/src/main/java/kr/kro/airbob/cursor/dto/ReviewCursorData.java
@@ -1,0 +1,18 @@
+package kr.kro.airbob.cursor.dto;
+
+import java.time.LocalDateTime;
+
+public record ReviewCursorData(
+	Long id,
+	LocalDateTime lastCreatedAt,
+	Integer lastRating
+) implements CursorPayload {
+
+	@Override
+	public void validate() {
+		CursorPayload.super.validate();
+		if (lastRating == null || lastRating < 1 || lastRating > 5) {
+			throw new IllegalArgumentException("리뷰 평점 커서 값이 유효하지 않습니다.");
+		}
+	}
+}

--- a/src/main/java/kr/kro/airbob/cursor/exception/CursorDecodingException.java
+++ b/src/main/java/kr/kro/airbob/cursor/exception/CursorDecodingException.java
@@ -1,0 +1,11 @@
+package kr.kro.airbob.cursor.exception;
+
+import kr.kro.airbob.common.exception.BaseException;
+import kr.kro.airbob.common.exception.ErrorCode;
+
+public class CursorDecodingException extends BaseException {
+
+	public CursorDecodingException(Throwable cause) {
+		super(cause, ErrorCode.CURSOR_DECODING_ERROR);
+	}
+}

--- a/src/main/java/kr/kro/airbob/cursor/resolver/AbstractCursorParamArgumentResolver.java
+++ b/src/main/java/kr/kro/airbob/cursor/resolver/AbstractCursorParamArgumentResolver.java
@@ -1,0 +1,85 @@
+package kr.kro.airbob.cursor.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import kr.kro.airbob.cursor.annotation.CursorParam;
+import kr.kro.airbob.cursor.dto.CursorPayload;
+import kr.kro.airbob.cursor.exception.CursorPageSizeException;
+import kr.kro.airbob.cursor.util.CursorDecoder;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class AbstractCursorParamArgumentResolver<C extends CursorPayload, R>
+	implements HandlerMethodArgumentResolver {
+
+	protected final CursorDecoder cursorDecoder;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(CursorParam.class)
+			&& parameter.getParameterType().equals(getSupportedRequestType());
+	}
+
+	@Override
+	public Object resolveArgument(
+		MethodParameter parameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		CursorParam annotation =
+			parameter.getParameterAnnotation(CursorParam.class);
+
+		int size = parseSize(webRequest, annotation);
+		C cursorData = parseCursorData(webRequest, annotation);
+
+		return createRequest(size, cursorData);
+	}
+
+	private C parseCursorData(
+		NativeWebRequest webRequest,
+		CursorParam annotation
+	) {
+		String cursorParam =
+			webRequest.getParameter(annotation.cursorParam());
+
+		return cursorDecoder.decode(
+			cursorParam,
+			getCursorDataType()
+		);
+	}
+
+	private int parseSize(
+		NativeWebRequest webRequest,
+		CursorParam annotation
+	) {
+		String sizeParam =
+			webRequest.getParameter(annotation.sizeParam());
+
+		int size;
+		try {
+			size = sizeParam != null
+				? Integer.parseInt(sizeParam)
+				: annotation.defaultSize();
+		} catch (NumberFormatException exception) {
+			throw new CursorPageSizeException();
+		}
+
+		if (size < 1 || size > annotation.maxSize()) {
+			throw new CursorPageSizeException();
+		}
+
+		return size;
+	}
+
+	protected abstract Class<R> getSupportedRequestType();
+
+	protected abstract Class<C> getCursorDataType();
+
+	protected abstract R createRequest(int size, C cursorData);
+}

--- a/src/main/java/kr/kro/airbob/cursor/resolver/CursorParamArgumentResolver.java
+++ b/src/main/java/kr/kro/airbob/cursor/resolver/CursorParamArgumentResolver.java
@@ -1,64 +1,46 @@
 package kr.kro.airbob.cursor.resolver;
 
-import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.support.WebDataBinderFactory;
-import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.method.support.ModelAndViewContainer;
 
-import kr.kro.airbob.cursor.annotation.CursorParam;
+import kr.kro.airbob.cursor.dto.CursorData;
 import kr.kro.airbob.cursor.dto.CursorRequest;
-import kr.kro.airbob.cursor.dto.CursorResponse;
-import kr.kro.airbob.cursor.exception.CursorPageSizeException;
 import kr.kro.airbob.cursor.util.CursorDecoder;
-import lombok.RequiredArgsConstructor;
 
 @Component
-@RequiredArgsConstructor
-public class CursorParamArgumentResolver implements HandlerMethodArgumentResolver {
+public class CursorParamArgumentResolver
+	extends AbstractCursorParamArgumentResolver<
+		CursorData,
+		CursorRequest.CursorPageRequest
+	> {
 
-	protected final CursorDecoder cursorDecoder;
-
-	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
-		return parameter.hasParameterAnnotation(CursorParam.class) &&
-			parameter.getParameterType().equals(CursorRequest.CursorPageRequest.class);
+	public CursorParamArgumentResolver(CursorDecoder cursorDecoder) {
+		super(cursorDecoder);
 	}
 
 	@Override
-	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+	protected Class<CursorRequest.CursorPageRequest> getSupportedRequestType() {
+		return CursorRequest.CursorPageRequest.class;
+	}
 
-		CursorParam annotation = parameter.getParameterAnnotation(CursorParam.class);
+	@Override
+	protected Class<CursorData> getCursorDataType() {
+		return CursorData.class;
+	}
 
-		int size = parseSize(webRequest, annotation);
-		CursorResponse.CursorData cursorData = parseCursorData(webRequest, annotation);
+	@Override
+	protected CursorRequest.CursorPageRequest createRequest(
+		int size,
+		CursorData cursorData
+	) {
 
 		return CursorRequest.CursorPageRequest.builder()
 			.size(size)
-			.lastId(cursorData != null ? cursorData.getId() : null)
-			.lastCreatedAt(cursorData != null ? cursorData.getLastCreatedAt() : null)
+			.lastId(cursorData != null ? cursorData.id() : null)
+			.lastCreatedAt(
+				cursorData != null
+					? cursorData.lastCreatedAt()
+					: null
+			)
 			.build();
-	}
-
-	protected CursorResponse.CursorData parseCursorData(NativeWebRequest webRequest, CursorParam annotation) {
-
-		// 커서 디코딩
-		String cursorParam = webRequest.getParameter(annotation.cursorParam());
-		return cursorDecoder.decode(cursorParam);
-	}
-
-	protected int parseSize(NativeWebRequest webRequest, CursorParam annotation){
-
-		// size 처리
-		String sizeParam = webRequest.getParameter(annotation.sizeParam());
-		int size = sizeParam != null ? Integer.parseInt(sizeParam) : annotation.defaultSize();
-
-		if (size < 1 || size > annotation.maxSize()) {
-			throw new CursorPageSizeException();
-		}
-
-		return size;
 	}
 }

--- a/src/main/java/kr/kro/airbob/cursor/resolver/ReviewCursorParamArgumentResolver.java
+++ b/src/main/java/kr/kro/airbob/cursor/resolver/ReviewCursorParamArgumentResolver.java
@@ -1,56 +1,50 @@
 package kr.kro.airbob.cursor.resolver;
 
-import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.support.WebDataBinderFactory;
-import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.method.support.ModelAndViewContainer;
 
-import kr.kro.airbob.cursor.annotation.CursorParam;
 import kr.kro.airbob.cursor.dto.CursorRequest;
-import kr.kro.airbob.cursor.dto.CursorResponse;
+import kr.kro.airbob.cursor.dto.ReviewCursorData;
 import kr.kro.airbob.cursor.util.CursorDecoder;
 
 @Component
-public class ReviewCursorParamArgumentResolver extends CursorParamArgumentResolver {
+public class ReviewCursorParamArgumentResolver
+	extends AbstractCursorParamArgumentResolver<
+		ReviewCursorData,
+		CursorRequest.ReviewCursorPageRequest
+	> {
 
 	public ReviewCursorParamArgumentResolver(CursorDecoder cursorDecoder) {
 		super(cursorDecoder);
 	}
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
-		return parameter.hasParameterAnnotation(CursorParam.class) &&
-			parameter.getParameterType().equals(CursorRequest.ReviewCursorPageRequest.class);
+	protected Class<CursorRequest.ReviewCursorPageRequest> getSupportedRequestType() {
+		return CursorRequest.ReviewCursorPageRequest.class;
 	}
 
 	@Override
-	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+	protected Class<ReviewCursorData> getCursorDataType() {
+		return ReviewCursorData.class;
+	}
 
-		CursorParam annotation = parameter.getParameterAnnotation(CursorParam.class);
-
-		int size = parseSize(webRequest, annotation);
-		CursorResponse.CursorData cursorData = parseCursorData(webRequest, annotation);
-
-		// ReviewCursorData로 캐스팅 시도
-		CursorResponse.ReviewCursorData reviewCursorData = null;
-		if (cursorData instanceof CursorResponse.ReviewCursorData) {
-			reviewCursorData = (CursorResponse.ReviewCursorData) cursorData;
-		} else if (cursorData != null) {
-			// 일반 CursorData면 ReviewCursorData로 변환하되 lastRating은 null
-			reviewCursorData = new CursorResponse.ReviewCursorData(
-				cursorData.getId(),
-				cursorData.getLastCreatedAt(),
-				null
-			);
-		}
-
+	@Override
+	protected CursorRequest.ReviewCursorPageRequest createRequest(
+		int size,
+		ReviewCursorData cursorData
+	) {
 		return CursorRequest.ReviewCursorPageRequest.builder()
 			.size(size)
-			.lastId(reviewCursorData != null ? reviewCursorData.getId() : null)
-			.lastCreatedAt(reviewCursorData != null ? reviewCursorData.getLastCreatedAt() : null)
-			.lastRating(reviewCursorData != null ? reviewCursorData.getLastRating() : null)
+			.lastId(cursorData != null ? cursorData.id() : null)
+			.lastCreatedAt(
+				cursorData != null
+					? cursorData.lastCreatedAt()
+					: null
+			)
+			.lastRating(
+				cursorData != null
+					? cursorData.lastRating()
+					: null
+			)
 			.build();
 	}
 }

--- a/src/main/java/kr/kro/airbob/cursor/util/CursorDecoder.java
+++ b/src/main/java/kr/kro/airbob/cursor/util/CursorDecoder.java
@@ -1,34 +1,44 @@
 package kr.kro.airbob.cursor.util;
 
-import java.nio.charset.StandardCharsets;
+import java.io.IOException;
 import java.util.Base64;
 
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import kr.kro.airbob.cursor.dto.CursorResponse;
+import kr.kro.airbob.cursor.dto.CursorPayload;
+import kr.kro.airbob.cursor.exception.CursorDecodingException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class CursorDecoder {
 
 	private final ObjectMapper objectMapper;
 
-	public CursorResponse.CursorData decode(String cursor) {
+	public <T extends CursorPayload> T decode(
+		String cursor,
+		Class<T> cursorType
+	) {
 		if (cursor == null || cursor.isBlank()) {
 			return null;
 		}
 
 		try {
-			String decoded = new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8);
-			return objectMapper.readValue(decoded, CursorResponse.CursorData.class);
-		} catch (Exception e) {
-			log.warn("커서 디코딩 실패: {}", e.getMessage());
-			return null; // 디코딩 실패 시 첫 페이지
+			byte[] decoded = Base64.getDecoder().decode(cursor);
+			T cursorData = objectMapper.readerFor(cursorType)
+				.with(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+				.with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+				.readValue(decoded);
+			if (cursorData == null) {
+				throw new IllegalArgumentException("커서 데이터가 없습니다.");
+			}
+			cursorData.validate();
+			return cursorData;
+		} catch (IOException | IllegalArgumentException exception) {
+			throw new CursorDecodingException(exception);
 		}
 	}
 }

--- a/src/main/java/kr/kro/airbob/cursor/util/CursorEncoder.java
+++ b/src/main/java/kr/kro/airbob/cursor/util/CursorEncoder.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import kr.kro.airbob.cursor.dto.CursorResponse;
+import kr.kro.airbob.cursor.dto.CursorPayload;
 import kr.kro.airbob.cursor.exception.CursorEncodingException;
 import lombok.RequiredArgsConstructor;
 
@@ -18,16 +18,17 @@ public class CursorEncoder {
 
 	private final ObjectMapper objectMapper;
 
-	public String encode(CursorResponse.CursorData cursor) {
+	public String encode(CursorPayload cursor) {
 		if (cursor == null) {
 			return null;
 		}
 
 		try {
+			cursor.validate();
 			String json = objectMapper.writeValueAsString(cursor);
 			return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
-		} catch (JsonProcessingException e) {
-			throw new CursorEncodingException("커서 인코딩 실패: " + e.getMessage());
+		} catch (JsonProcessingException | IllegalArgumentException exception) {
+			throw new CursorEncodingException("커서 인코딩 실패: " + exception.getMessage());
 		}
 	}
 }

--- a/src/main/java/kr/kro/airbob/cursor/util/CursorPageInfoCreator.java
+++ b/src/main/java/kr/kro/airbob/cursor/util/CursorPageInfoCreator.java
@@ -6,7 +6,10 @@ import java.util.function.Function;
 
 import org.springframework.stereotype.Component;
 
+import kr.kro.airbob.cursor.dto.CursorData;
+import kr.kro.airbob.cursor.dto.CursorPayload;
 import kr.kro.airbob.cursor.dto.CursorResponse;
+import kr.kro.airbob.cursor.dto.ReviewCursorData;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -21,32 +24,16 @@ public class CursorPageInfoCreator {
 		Function<T, Long> idExtractor,
 		Function<T, LocalDateTime> createdAtExtractor) {
 
-		if (content.isEmpty()) {
-			return CursorResponse.PageInfo.builder()
-				.hasNext(false)
-				.nextCursor(null)
-				.currentSize(0)
-				.build();
-		}
-
-		String nextCursor = null;
-		if (hasNext) {
-			T lastEntity = content.getLast();
-			CursorResponse.CursorData cursorData = CursorResponse.CursorData.builder()
-				.id(idExtractor.apply(lastEntity))
-				.lastCreatedAt(createdAtExtractor.apply(lastEntity))
-				.build();
-			nextCursor = cursorEncoder.encode(cursorData);
-		}
-
-		return CursorResponse.PageInfo.builder()
-			.hasNext(hasNext)
-			.nextCursor(nextCursor)
-			.currentSize(content.size())
-			.build();
+		return createPageInfo(
+			content,
+			hasNext,
+			lastEntity -> new CursorData(
+				idExtractor.apply(lastEntity),
+				createdAtExtractor.apply(lastEntity)
+			)
+		);
 	}
 
-	// 리뷰용
 	public <T> CursorResponse.PageInfo createPageInfo(
 		List<T> content,
 		boolean hasNext,
@@ -54,29 +41,30 @@ public class CursorPageInfoCreator {
 		Function<T, LocalDateTime> createdAtExtractor,
 		Function<T, Integer> ratingExtractor) {
 
-		if (content.isEmpty()) {
-			return CursorResponse.PageInfo.builder()
-				.hasNext(false)
-				.nextCursor(null)
-				.currentSize(0)
-				.build();
-		}
-
-		String nextCursor = null;
-		if (hasNext) {
-			T lastEntity = content.getLast();
-			CursorResponse.ReviewCursorData reviewCursorData = new CursorResponse.ReviewCursorData(
+		return createPageInfo(
+			content,
+			hasNext,
+			lastEntity -> new ReviewCursorData(
 				idExtractor.apply(lastEntity),
 				createdAtExtractor.apply(lastEntity),
 				ratingExtractor.apply(lastEntity)
-			);
-			nextCursor = cursorEncoder.encode(reviewCursorData);
+			)
+		);
+	}
+
+	private <T> CursorResponse.PageInfo createPageInfo(
+		List<T> content,
+		boolean hasNext,
+		Function<T, ? extends CursorPayload> cursorFactory
+	) {
+		if (content.isEmpty()) {
+			return new CursorResponse.PageInfo(false, null, 0);
 		}
 
-		return CursorResponse.PageInfo.builder()
-			.hasNext(hasNext)
-			.nextCursor(nextCursor)
-			.currentSize(content.size())
-			.build();
+		String nextCursor = hasNext
+			? cursorEncoder.encode(cursorFactory.apply(content.getLast()))
+			: null;
+
+		return new CursorResponse.PageInfo(hasNext, nextCursor, content.size());
 	}
 }

--- a/src/test/java/kr/kro/airbob/config/BulkWriteBenchmarkCorsTest.java
+++ b/src/test/java/kr/kro/airbob/config/BulkWriteBenchmarkCorsTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.util.List;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -94,7 +95,7 @@ class BulkWriteBenchmarkCorsTest {
 	private WebMvcConfig createWebMvcConfig() {
 		return new WebMvcConfig(
 			mock(CurrentMemberIdArgumentResolver.class),
-			mock(CursorParamArgumentResolver.class),
+			List.of(mock(CursorParamArgumentResolver.class)),
 			mock(SessionAuthFilter.class),
 			mock(AdminAuthInterceptor.class),
 			mock(QueryCountInterceptor.class)

--- a/src/test/java/kr/kro/airbob/config/WebMvcConfigBenchmarkProtectionTest.java
+++ b/src/test/java/kr/kro/airbob/config/WebMvcConfigBenchmarkProtectionTest.java
@@ -28,7 +28,7 @@ class WebMvcConfigBenchmarkProtectionTest {
 			mock(CurrentMemberIdArgumentResolver.class);
 		WebMvcConfig config = new WebMvcConfig(
 			currentMemberIdArgumentResolver,
-			mock(CursorParamArgumentResolver.class),
+			List.of(mock(CursorParamArgumentResolver.class)),
 			mock(SessionAuthFilter.class),
 			mock(AdminAuthInterceptor.class),
 			mock(QueryCountInterceptor.class)
@@ -45,7 +45,7 @@ class WebMvcConfigBenchmarkProtectionTest {
 	void v2CouponBenchmarkPathUsesSessionAuthentication() {
 		WebMvcConfig config = new WebMvcConfig(
 			mock(CurrentMemberIdArgumentResolver.class),
-			mock(CursorParamArgumentResolver.class),
+			List.of(mock(CursorParamArgumentResolver.class)),
 			mock(SessionAuthFilter.class),
 			mock(AdminAuthInterceptor.class),
 			mock(QueryCountInterceptor.class)
@@ -60,7 +60,7 @@ class WebMvcConfigBenchmarkProtectionTest {
 	void v2AccommodationBenchmarkPathUsesSessionAuthentication() {
 		WebMvcConfig config = new WebMvcConfig(
 			mock(CurrentMemberIdArgumentResolver.class),
-			mock(CursorParamArgumentResolver.class),
+			List.of(mock(CursorParamArgumentResolver.class)),
 			mock(SessionAuthFilter.class),
 			mock(AdminAuthInterceptor.class),
 			mock(QueryCountInterceptor.class)
@@ -76,7 +76,7 @@ class WebMvcConfigBenchmarkProtectionTest {
 		AdminAuthInterceptor adminAuthInterceptor = mock(AdminAuthInterceptor.class);
 		WebMvcConfig config = new WebMvcConfig(
 			mock(CurrentMemberIdArgumentResolver.class),
-			mock(CursorParamArgumentResolver.class),
+			List.of(mock(CursorParamArgumentResolver.class)),
 			mock(SessionAuthFilter.class),
 			adminAuthInterceptor,
 			mock(QueryCountInterceptor.class)
@@ -104,7 +104,7 @@ class WebMvcConfigBenchmarkProtectionTest {
 		AdminAuthInterceptor adminAuthInterceptor = mock(AdminAuthInterceptor.class);
 		WebMvcConfig config = new WebMvcConfig(
 			mock(CurrentMemberIdArgumentResolver.class),
-			mock(CursorParamArgumentResolver.class),
+			List.of(mock(CursorParamArgumentResolver.class)),
 			mock(SessionAuthFilter.class),
 			adminAuthInterceptor,
 			mock(QueryCountInterceptor.class)

--- a/src/test/java/kr/kro/airbob/config/WebMvcConfigCursorResolverTest.java
+++ b/src/test/java/kr/kro/airbob/config/WebMvcConfigCursorResolverTest.java
@@ -1,0 +1,46 @@
+package kr.kro.airbob.config;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import kr.kro.airbob.common.monitoring.QueryCountInterceptor;
+import kr.kro.airbob.cursor.resolver.CursorParamArgumentResolver;
+import kr.kro.airbob.cursor.resolver.ReviewCursorParamArgumentResolver;
+import kr.kro.airbob.domain.auth.filter.SessionAuthFilter;
+import kr.kro.airbob.domain.auth.interceptor.AdminAuthInterceptor;
+import kr.kro.airbob.domain.auth.resolver.CurrentMemberIdArgumentResolver;
+
+@DisplayName("커서 argument resolver MVC 등록 테스트")
+class WebMvcConfigCursorResolverTest {
+
+	@Test
+	@DisplayName("모든 커서 argument resolver 빈을 MVC에 등록한다")
+	void registersEveryCursorArgumentResolverBean() {
+		CurrentMemberIdArgumentResolver memberResolver =
+			mock(CurrentMemberIdArgumentResolver.class);
+		CursorParamArgumentResolver cursorResolver =
+			mock(CursorParamArgumentResolver.class);
+		ReviewCursorParamArgumentResolver reviewCursorResolver =
+			mock(ReviewCursorParamArgumentResolver.class);
+		WebMvcConfig config = new WebMvcConfig(
+			memberResolver,
+			List.of(cursorResolver, reviewCursorResolver),
+			mock(SessionAuthFilter.class),
+			mock(AdminAuthInterceptor.class),
+			mock(QueryCountInterceptor.class)
+		);
+		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+
+		config.addArgumentResolvers(resolvers);
+
+		assertThat(resolvers)
+			.contains(cursorResolver, reviewCursorResolver, memberResolver);
+	}
+}

--- a/src/test/java/kr/kro/airbob/cursor/resolver/CursorArgumentResolverMvcTest.java
+++ b/src/test/java/kr/kro/airbob/cursor/resolver/CursorArgumentResolverMvcTest.java
@@ -1,0 +1,155 @@
+package kr.kro.airbob.cursor.resolver;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import kr.kro.airbob.common.dto.ApiResponse;
+import kr.kro.airbob.common.exception.GlobalExceptionHandler;
+import kr.kro.airbob.cursor.annotation.CursorParam;
+import kr.kro.airbob.cursor.dto.CursorData;
+import kr.kro.airbob.cursor.dto.CursorRequest;
+import kr.kro.airbob.cursor.dto.ReviewCursorData;
+import kr.kro.airbob.cursor.util.CursorDecoder;
+import kr.kro.airbob.cursor.util.CursorEncoder;
+
+@DisplayName("커서 요청 HTTP 계약 테스트")
+class CursorArgumentResolverMvcTest {
+
+	private MockMvc mockMvc;
+	private CursorEncoder cursorEncoder;
+
+	@BeforeEach
+	void setUp() {
+		ObjectMapper objectMapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule())
+			.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+			.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+		CursorDecoder cursorDecoder = new CursorDecoder(objectMapper);
+		CursorParamArgumentResolver argumentResolver =
+			new CursorParamArgumentResolver(cursorDecoder);
+		ReviewCursorParamArgumentResolver reviewArgumentResolver =
+			new ReviewCursorParamArgumentResolver(cursorDecoder);
+		cursorEncoder = new CursorEncoder(objectMapper);
+
+		mockMvc = MockMvcBuilders.standaloneSetup(new CursorTestController())
+			.setCustomArgumentResolvers(argumentResolver, reviewArgumentResolver)
+			.setControllerAdvice(new GlobalExceptionHandler())
+			.build();
+	}
+
+	@Test
+	@DisplayName("숫자가 아닌 페이지 크기는 400으로 응답한다")
+	void rejectsNonNumericPageSize() throws Exception {
+		mockMvc.perform(get("/cursor")
+				.param("size", "abc")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("C006"));
+	}
+
+	@Test
+	@DisplayName("손상된 커서는 400으로 응답한다")
+	void rejectsMalformedCursor() throws Exception {
+		mockMvc.perform(get("/cursor")
+				.param("cursor", "%%%")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("C010"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"0", "51"})
+	@DisplayName("허용 범위를 벗어난 페이지 크기는 400으로 응답한다")
+	void rejectsOutOfRangePageSize(String size) throws Exception {
+		mockMvc.perform(get("/cursor")
+				.param("size", size)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error.code").value("C006"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"1", "50"})
+	@DisplayName("페이지 크기 경계값을 허용한다")
+	void acceptsPageSizeBoundaries(String size) throws Exception {
+		mockMvc.perform(get("/cursor")
+				.param("size", size)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.size").value(Integer.parseInt(size)));
+	}
+
+	@Test
+	@DisplayName("일반 커서를 일반 요청 값으로 변환한다")
+	void resolvesGenericCursorRequest() throws Exception {
+		String cursor = cursorEncoder.encode(new CursorData(
+			17L,
+			LocalDateTime.of(2026, 8, 13, 12, 30)
+		));
+
+		mockMvc.perform(get("/cursor")
+				.param("size", "7")
+				.param("cursor", cursor)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.size").value(7))
+			.andExpect(jsonPath("$.data.lastId").value(17));
+	}
+
+	@Test
+	@DisplayName("리뷰 커서를 리뷰 요청 값으로 변환한다")
+	void resolvesReviewCursorRequest() throws Exception {
+		String cursor = cursorEncoder.encode(new ReviewCursorData(
+			23L,
+			LocalDateTime.of(2026, 8, 13, 14, 15),
+			4
+		));
+
+		mockMvc.perform(get("/review-cursor")
+				.param("size", "7")
+				.param("cursor", cursor)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.size").value(7))
+			.andExpect(jsonPath("$.data.lastId").value(23))
+			.andExpect(jsonPath("$.data.lastRating").value(4));
+	}
+
+	@RestController
+	private static class CursorTestController {
+
+		@GetMapping("/cursor")
+		ApiResponse<CursorRequest.CursorPageRequest> find(
+			@CursorParam CursorRequest.CursorPageRequest request
+		) {
+			return ApiResponse.success(request);
+		}
+
+		@GetMapping("/review-cursor")
+		ApiResponse<CursorRequest.ReviewCursorPageRequest> findReviews(
+			@CursorParam CursorRequest.ReviewCursorPageRequest request
+		) {
+			return ApiResponse.success(request);
+		}
+	}
+}

--- a/src/test/java/kr/kro/airbob/cursor/util/CursorDecoderTest.java
+++ b/src/test/java/kr/kro/airbob/cursor/util/CursorDecoderTest.java
@@ -1,0 +1,217 @@
+package kr.kro.airbob.cursor.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import kr.kro.airbob.common.exception.BaseException;
+import kr.kro.airbob.common.exception.ErrorCode;
+import kr.kro.airbob.cursor.dto.CursorData;
+import kr.kro.airbob.cursor.dto.ReviewCursorData;
+import kr.kro.airbob.cursor.exception.CursorEncodingException;
+
+@DisplayName("커서 인코딩과 디코딩 테스트")
+class CursorDecoderTest {
+
+	private CursorEncoder cursorEncoder;
+	private CursorDecoder cursorDecoder;
+
+	@BeforeEach
+	void setUp() {
+		ObjectMapper objectMapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule())
+			.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+			.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+		cursorEncoder = new CursorEncoder(objectMapper);
+		cursorDecoder = new CursorDecoder(objectMapper);
+	}
+
+	@Test
+	@DisplayName("일반 커서를 왕복 변환한다")
+	void roundTripsCursorData() {
+		CursorData expected = new CursorData(
+			17L,
+			LocalDateTime.of(2026, 8, 13, 12, 30)
+		);
+
+		String encoded = cursorEncoder.encode(expected);
+
+		assertThat(cursorDecoder.decode(encoded, CursorData.class))
+			.isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("리뷰 커서를 왕복 변환한다")
+	void roundTripsReviewCursorData() {
+		ReviewCursorData expected = new ReviewCursorData(
+			23L,
+			LocalDateTime.of(2026, 8, 13, 14, 15),
+			5
+		);
+
+		String encoded = cursorEncoder.encode(expected);
+
+		assertThat(cursorDecoder.decode(encoded, ReviewCursorData.class))
+			.isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("커서가 없으면 첫 페이지로 처리한다")
+	void returnsNullWhenCursorIsAbsent() {
+		assertThat(cursorDecoder.decode(null, CursorData.class)).isNull();
+		assertThat(cursorDecoder.decode("   ", CursorData.class)).isNull();
+	}
+
+	@Test
+	@DisplayName("필수 값이 없는 커서는 인코딩하지 않는다")
+	void rejectsIncompleteCursorWhenEncoding() {
+		CursorData incompleteCursor = new CursorData(
+			17L,
+			null
+		);
+
+		assertThatThrownBy(() -> cursorEncoder.encode(incompleteCursor))
+			.isInstanceOf(CursorEncodingException.class);
+	}
+
+	@Test
+	@DisplayName("Base64 형식이 아닌 커서를 거부한다")
+	void rejectsMalformedBase64Cursor() {
+		assertBadRequestCursor(() -> cursorDecoder.decode("%%%", CursorData.class));
+	}
+
+	@Test
+	@DisplayName("키셋 필드가 빠진 커서를 거부한다")
+	void rejectsIncompleteCursor() {
+		String incompleteCursor = encodeJson("{\"id\":17}");
+
+		assertBadRequestCursor(() -> cursorDecoder.decode(incompleteCursor, CursorData.class));
+	}
+
+	@Test
+	@DisplayName("JSON null 커서를 거부한다")
+	void rejectsJsonNullCursor() {
+		assertBadRequestCursor(() ->
+			cursorDecoder.decode(encodeJson("null"), CursorData.class)
+		);
+	}
+
+	@Test
+	@DisplayName("유효한 JSON 뒤에 값이 이어진 커서를 거부한다")
+	void rejectsTrailingJsonValue() {
+		String cursorWithTrailingValue = encodeJson(
+			"{\"id\":17,\"last_created_at\":\"2026-08-13T12:30:00\"} true"
+		);
+
+		assertBadRequestCursor(() ->
+			cursorDecoder.decode(cursorWithTrailingValue, CursorData.class)
+		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = {0L, -1L})
+	@DisplayName("양수가 아닌 ID 커서를 거부한다")
+	void rejectsNonPositiveCursorId(long id) {
+		String cursor = encodeJson(
+			"{\"id\":" + id
+				+ ",\"last_created_at\":\"2026-08-13T12:30:00\"}"
+		);
+
+		assertBadRequestCursor(() -> cursorDecoder.decode(cursor, CursorData.class));
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {0, 6})
+	@DisplayName("1부터 5 사이가 아닌 리뷰 평점 커서를 거부한다")
+	void rejectsOutOfRangeReviewRating(int rating) {
+		String cursor = encodeJson(
+			"{\"id\":23,\"last_created_at\":\"2026-08-13T14:15:00\","
+				+ "\"last_rating\":" + rating + "}"
+		);
+
+		assertBadRequestCursor(() ->
+			cursorDecoder.decode(cursor, ReviewCursorData.class)
+		);
+	}
+
+	@Test
+	@DisplayName("이전 서버가 발급한 SNAKE_CASE 커서를 해석한다")
+	void decodesLegacySnakeCaseCursor() {
+		String legacyCursor = encodeJson(
+			"{\"id\":17,\"last_created_at\":\"2026-08-13T12:30:00\"}"
+		);
+
+		assertThat(cursorDecoder.decode(legacyCursor, CursorData.class))
+			.isEqualTo(new CursorData(
+				17L,
+				LocalDateTime.of(2026, 8, 13, 12, 30)
+			));
+	}
+
+	@Test
+	@DisplayName("이전 서버가 발급한 리뷰 커서를 해석한다")
+	void decodesLegacyReviewCursor() {
+		String legacyCursor = encodeJson(
+			"{\"id\":23,\"last_created_at\":\"2026-08-13T14:15:00\","
+				+ "\"last_rating\":4}"
+		);
+
+		assertThat(cursorDecoder.decode(legacyCursor, ReviewCursorData.class))
+			.isEqualTo(new ReviewCursorData(
+				23L,
+				LocalDateTime.of(2026, 8, 13, 14, 15),
+				4
+			));
+	}
+
+	@Test
+	@DisplayName("리뷰 커서를 일반 커서로 사용할 수 없다")
+	void rejectsReviewCursorForGenericRequest() {
+		String reviewCursor = cursorEncoder.encode(new ReviewCursorData(
+			23L,
+			LocalDateTime.of(2026, 8, 13, 14, 15),
+			4
+		));
+
+		assertBadRequestCursor(() -> cursorDecoder.decode(reviewCursor, CursorData.class));
+	}
+
+	@Test
+	@DisplayName("일반 커서를 리뷰 커서로 사용할 수 없다")
+	void rejectsGenericCursorForReviewRequest() {
+		String cursor = cursorEncoder.encode(new CursorData(
+			17L,
+			LocalDateTime.of(2026, 8, 13, 12, 30)
+		));
+
+		assertBadRequestCursor(() -> cursorDecoder.decode(cursor, ReviewCursorData.class));
+	}
+
+	private String encodeJson(String json) {
+		return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private void assertBadRequestCursor(ThrowingCallable callable) {
+		assertThatThrownBy(callable)
+			.isInstanceOfSatisfying(BaseException.class, exception -> {
+				assertThat(exception.getErrorCode())
+					.isEqualTo(ErrorCode.CURSOR_DECODING_ERROR);
+				assertThat(exception.getErrorCode().getStatus().is4xxClientError())
+					.isTrue();
+			});
+	}
+}

--- a/src/test/java/kr/kro/airbob/cursor/util/CursorPageInfoCreatorTest.java
+++ b/src/test/java/kr/kro/airbob/cursor/util/CursorPageInfoCreatorTest.java
@@ -1,0 +1,130 @@
+package kr.kro.airbob.cursor.util;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kr.kro.airbob.cursor.dto.CursorData;
+import kr.kro.airbob.cursor.dto.CursorResponse;
+import kr.kro.airbob.cursor.dto.ReviewCursorData;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("커서 페이지 정보 생성 테스트")
+class CursorPageInfoCreatorTest {
+
+	@Mock
+	private CursorEncoder cursorEncoder;
+
+	private CursorPageInfoCreator creator;
+
+	@BeforeEach
+	void setUp() {
+		creator = new CursorPageInfoCreator(cursorEncoder);
+	}
+
+	@Test
+	@DisplayName("다음 일반 페이지가 있으면 마지막 항목으로 커서를 만든다")
+	void createsGenericNextCursorFromLastItem() {
+		List<Item> content = List.of(
+			item(1L, 10, 3),
+			item(2L, 20, 4)
+		);
+		when(cursorEncoder.encode(any())).thenReturn("next-cursor");
+
+		CursorResponse.PageInfo pageInfo = creator.createPageInfo(
+			content,
+			true,
+			Item::id,
+			Item::createdAt
+		);
+
+		ArgumentCaptor<CursorData> cursorCaptor = ArgumentCaptor.forClass(CursorData.class);
+		verify(cursorEncoder).encode(cursorCaptor.capture());
+		assertThat(cursorCaptor.getValue())
+			.isEqualTo(new CursorData(2L, content.getLast().createdAt()));
+		assertThat(pageInfo)
+			.isEqualTo(new CursorResponse.PageInfo(true, "next-cursor", 2));
+	}
+
+	@Test
+	@DisplayName("다음 리뷰 페이지가 있으면 평점을 포함한 커서를 만든다")
+	void createsReviewNextCursorFromLastItem() {
+		List<Item> content = List.of(
+			item(1L, 10, 5),
+			item(2L, 20, 4)
+		);
+		when(cursorEncoder.encode(any())).thenReturn("review-next-cursor");
+
+		CursorResponse.PageInfo pageInfo = creator.createPageInfo(
+			content,
+			true,
+			Item::id,
+			Item::createdAt,
+			Item::rating
+		);
+
+		ArgumentCaptor<ReviewCursorData> cursorCaptor =
+			ArgumentCaptor.forClass(ReviewCursorData.class);
+		verify(cursorEncoder).encode(cursorCaptor.capture());
+		assertThat(cursorCaptor.getValue())
+			.isEqualTo(new ReviewCursorData(2L, content.getLast().createdAt(), 4));
+		assertThat(pageInfo)
+			.isEqualTo(new CursorResponse.PageInfo(true, "review-next-cursor", 2));
+	}
+
+	@Test
+	@DisplayName("다음 페이지가 없으면 커서를 만들지 않는다")
+	void omitsCursorWhenThereIsNoNextPage() {
+		CursorResponse.PageInfo pageInfo = creator.createPageInfo(
+			List.of(item(1L, 10, 3)),
+			false,
+			Item::id,
+			Item::createdAt
+		);
+
+		assertThat(pageInfo)
+			.isEqualTo(new CursorResponse.PageInfo(false, null, 1));
+		verifyNoInteractions(cursorEncoder);
+	}
+
+	@Test
+	@DisplayName("빈 결과는 다음 페이지가 없는 크기 0으로 반환한다")
+	void createsEmptyPageInfo() {
+		CursorResponse.PageInfo pageInfo = creator.createPageInfo(
+			List.<Item>of(),
+			true,
+			Item::id,
+			Item::createdAt
+		);
+
+		assertThat(pageInfo)
+			.isEqualTo(new CursorResponse.PageInfo(false, null, 0));
+		verifyNoInteractions(cursorEncoder);
+	}
+
+	private Item item(long id, int minute, int rating) {
+		return new Item(
+			id,
+			LocalDateTime.of(2026, 8, 13, 12, minute),
+			rating
+		);
+	}
+
+	private record Item(
+		Long id,
+		LocalDateTime createdAt,
+		Integer rating
+	) {
+	}
+}


### PR DESCRIPTION
## 작업 배경

일반 목록과 리뷰 목록은 커서에 담는 값만 달랐지만, 요청 해석과 다음 페이지 정보 생성 로직이 각각 구현되어 있었습니다. 이 구조에서는 리뷰 전용 resolver 등록이 누락되기 쉬웠고, 커서 종류가 늘어날수록 페이지 크기 검증·디코딩·빈 페이지 처리 같은 공통 규칙도 함께 중복될 수 있었습니다.

입력 오류의 HTTP 계약도 일관되지 않았습니다. 숫자가 아닌 `size`는 `NumberFormatException`으로 인해 500 응답이 될 수 있었고, 손상된 커서는 디코딩 실패 후 첫 페이지로 처리되어 클라이언트가 잘못된 요청을 알아차리기 어려웠습니다. 이번 작업에서는 공통 흐름을 한곳으로 모으면서 잘못된 입력을 명확한 400 응답으로 구분했습니다.

## 주요 변경 사항

### 커서 요청 처리 공통화

- `AbstractCursorParamArgumentResolver`가 애노테이션 확인, 페이지 크기 검증, 커서 디코딩 흐름을 담당하도록 했습니다.
- 일반 커서와 리뷰 커서 resolver는 지원할 요청 타입, payload 타입, 요청 객체 생성만 구현합니다.
- MVC 설정이 커서 resolver 목록을 주입받아 일반·리뷰 resolver를 모두 등록하도록 했습니다.
- 숫자가 아니거나 허용 범위를 벗어난 `size`는 `400 / C006`으로 응답합니다.

### 커서 payload와 입력 계약 명확화

- 일반 커서와 리뷰 커서를 `CursorData`, `ReviewCursorData`로 분리하고 공통 계약을 `CursorPayload`로 정의했습니다.
- ID와 생성 시각을 필수값으로 검증하고, ID는 양수, 리뷰 평점은 1~5 범위만 허용합니다.
- 손상된 Base64, 잘못된 JSON, 누락·추가 필드, 후행 JSON 값, 다른 종류의 커서 사용을 `400 / C010`으로 거절합니다.
- 커서가 없거나 공백인 경우에만 기존처럼 첫 페이지 요청으로 처리합니다.
- 기존에 발급된 커서와 호환되도록 `id`, `last_created_at`, `last_rating` 필드 형식은 유지했습니다.

### 다음 페이지 정보 생성 중복 제거

- `CursorPageInfoCreator`의 두 공개 메서드는 각 payload 생성 방법만 전달하고, 빈 결과 처리·마지막 항목 선택·인코딩·`PageInfo` 생성은 하나의 private 메서드가 담당합니다.
- 다음 페이지가 없거나 조회 결과가 비어 있으면 불필요한 커서를 인코딩하지 않습니다.
- 공개 메서드 시그니처와 응답 구조는 유지해 기존 호출부에 영향을 주지 않도록 했습니다.

## 설계하면서 고민한 점

- 애플리케이션의 공용 `ObjectMapper` 설정을 바꾸지 않고, 커서 디코딩에 사용하는 `ObjectReader`에만 엄격한 역직렬화 옵션을 적용했습니다.
- 커서가 없는 정상적인 첫 페이지 요청과, 값은 있지만 해석할 수 없는 잘못된 요청을 구분했습니다.
- 일반 커서와 리뷰 커서를 타입으로 분리해 리뷰 정렬에 필요한 평점 경계값이 조용히 유실되지 않도록 했습니다.
- 공통 추상 클래스에는 모든 resolver가 동일하게 지켜야 하는 흐름만 두고, payload별 요청 생성은 각 구현체에 남겼습니다.

## 검증

- 일반·리뷰 커서 왕복 변환과 기존 SNAKE_CASE 커서 호환성 확인
- 잘못된 Base64·JSON·필수값·ID·평점·payload 종류 검증
- MockMvc에서 잘못된 `size`와 커서가 각각 `C006`, `C010`으로 응답하는지 확인
- 페이지 크기 경계값과 일반·리뷰 요청 객체 변환 확인
- 빈 페이지, 마지막 페이지, 다음 페이지의 커서 생성 여부 확인
- 실제 Spring MVC 컨텍스트에서 커서 resolver 목록 주입 확인
- 최신 `main` 기준 전체 테스트 통과

```text
./gradlew test --no-daemon --max-workers=1
996 tests, 0 failures, 0 errors, 1 skipped
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
