### PR TITLE
feat: 쿠폰 캠페인과 보유 쿠폰 조회 API 추가

### DIFF
--- a/src/main/java/kr/kro/airbob/domain/coupon/api/CouponController.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/api/CouponController.java
@@ -12,7 +12,7 @@ import kr.kro.airbob.common.dto.ApiResponse;
 import kr.kro.airbob.domain.auth.annotation.CurrentMemberId;
 import kr.kro.airbob.domain.coupon.dto.CouponResponse;
 import kr.kro.airbob.domain.coupon.service.CouponLuaIssueService;
-import kr.kro.airbob.domain.coupon.service.CouponService;
+import kr.kro.airbob.domain.coupon.service.CouponQueryService;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -23,12 +23,20 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api")
 public class CouponController {
 
-	private final CouponService couponService;
+	private final CouponQueryService couponQueryService;
 	private final CouponLuaIssueService luaIssueService;
 
 	@GetMapping("/v1/coupons")
-	public ResponseEntity<ApiResponse<CouponResponse.CouponInfos>> findValidCoupons() {
-		CouponResponse.CouponInfos coupons = couponService.findValidCoupons();
+	public ResponseEntity<ApiResponse<CouponResponse.CouponInfos>> findCouponCampaigns() {
+		CouponResponse.CouponInfos coupons = couponQueryService.findCouponCampaigns();
+		return ResponseEntity.ok(ApiResponse.success(coupons));
+	}
+
+	@GetMapping("/v1/members/me/coupons")
+	public ResponseEntity<ApiResponse<CouponResponse.MemberCouponInfos>> findMyCoupons(
+		@CurrentMemberId Long memberId
+	) {
+		CouponResponse.MemberCouponInfos coupons = couponQueryService.findMyCoupons(memberId);
 		return ResponseEntity.ok(ApiResponse.success(coupons));
 	}
 

--- a/src/main/java/kr/kro/airbob/domain/coupon/common/CouponIssuanceStatus.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/common/CouponIssuanceStatus.java
@@ -1,0 +1,7 @@
+package kr.kro.airbob.domain.coupon.common;
+
+public enum CouponIssuanceStatus {
+	UPCOMING,
+	OPEN,
+	SOLD_OUT
+}

--- a/src/main/java/kr/kro/airbob/domain/coupon/common/MemberCouponStatus.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/common/MemberCouponStatus.java
@@ -1,0 +1,9 @@
+package kr.kro.airbob.domain.coupon.common;
+
+public enum MemberCouponStatus {
+	UPCOMING,
+	AVAILABLE,
+	UNAVAILABLE,
+	USED,
+	EXPIRED
+}

--- a/src/main/java/kr/kro/airbob/domain/coupon/dto/CouponResponse.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/dto/CouponResponse.java
@@ -3,8 +3,11 @@ package kr.kro.airbob.domain.coupon.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import kr.kro.airbob.domain.coupon.common.CouponIssuanceStatus;
 import kr.kro.airbob.domain.coupon.common.DiscountType;
+import kr.kro.airbob.domain.coupon.common.MemberCouponStatus;
 import kr.kro.airbob.domain.coupon.entity.Coupon;
+import kr.kro.airbob.domain.coupon.entity.MemberCoupon;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -24,9 +27,10 @@ public class CouponResponse {
 		LocalDateTime usableFrom,
 		LocalDateTime usableUntil,
 		Integer totalQuantity,
-		Integer issuedQuantity
+		Integer issuedQuantity,
+		CouponIssuanceStatus issuanceStatus
 	) {
-		public static CouponInfo of(Coupon coupon) {
+		public static CouponInfo of(Coupon coupon, LocalDateTime now) {
 			return new CouponInfo(
 				coupon.getId(),
 				coupon.getName(),
@@ -40,12 +44,47 @@ public class CouponResponse {
 				coupon.getUsableFrom(),
 				coupon.getUsableUntil(),
 				coupon.getTotalQuantity(),
-				coupon.getIssuedQuantity());
+				coupon.getIssuedQuantity(),
+				coupon.issuanceStatus(now));
 		}
 	}
 
 	public record CouponInfos(
 		List<CouponInfo> infos
+	) {
+
+	}
+
+	public record MemberCouponInfo(
+		Long couponId,
+		String name,
+		String description,
+		DiscountType discountType,
+		Integer discountValue,
+		Integer minPaymentPrice,
+		Integer maxDiscountAmount,
+		LocalDateTime usableFrom,
+		LocalDateTime usableUntil,
+		MemberCouponStatus status
+	) {
+		public static MemberCouponInfo of(MemberCoupon memberCoupon, LocalDateTime now) {
+			Coupon coupon = memberCoupon.getCoupon();
+			return new MemberCouponInfo(
+				coupon.getId(),
+				coupon.getName(),
+				coupon.getDescription(),
+				coupon.getDiscountType(),
+				coupon.getDiscountValue(),
+				coupon.getMinPaymentPrice(),
+				coupon.getMaxDiscountAmount(),
+				coupon.getUsableFrom(),
+				coupon.getUsableUntil(),
+				memberCoupon.status(now));
+		}
+	}
+
+	public record MemberCouponInfos(
+		List<MemberCouponInfo> infos
 	) {
 
 	}

--- a/src/main/java/kr/kro/airbob/domain/coupon/entity/Coupon.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/entity/Coupon.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import kr.kro.airbob.common.domain.BaseEntity;
+import kr.kro.airbob.domain.coupon.common.CouponIssuanceStatus;
 import kr.kro.airbob.domain.coupon.common.DiscountType;
 import kr.kro.airbob.domain.coupon.dto.CouponRequest;
 import lombok.AccessLevel;
@@ -148,6 +149,16 @@ public class Coupon extends BaseEntity {
 
 	public boolean isIssuable(LocalDateTime now) {
 		return Boolean.TRUE.equals(isActive) && isIssueOpen(now) && !isSoldOut();
+	}
+
+	public CouponIssuanceStatus issuanceStatus(LocalDateTime now) {
+		if (now.isBefore(issueStartAt)) {
+			return CouponIssuanceStatus.UPCOMING;
+		}
+		if (isSoldOut()) {
+			return CouponIssuanceStatus.SOLD_OUT;
+		}
+		return CouponIssuanceStatus.OPEN;
 	}
 
 	// 발급된 쿠폰을 사용할 수 있는지 (활성·기간만 확인, 재고는 무관)

--- a/src/main/java/kr/kro/airbob/domain/coupon/entity/MemberCoupon.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/entity/MemberCoupon.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import kr.kro.airbob.common.domain.BaseEntity;
+import kr.kro.airbob.domain.coupon.common.MemberCouponStatus;
 import kr.kro.airbob.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -57,5 +58,21 @@ public class MemberCoupon extends BaseEntity {
 			.coupon(coupon)
 			.used(false)
 			.build();
+	}
+
+	public MemberCouponStatus status(LocalDateTime now) {
+		if (used) {
+			return MemberCouponStatus.USED;
+		}
+		if (!now.isBefore(coupon.getUsableUntil())) {
+			return MemberCouponStatus.EXPIRED;
+		}
+		if (!Boolean.TRUE.equals(coupon.getIsActive())) {
+			return MemberCouponStatus.UNAVAILABLE;
+		}
+		if (now.isBefore(coupon.getUsableFrom())) {
+			return MemberCouponStatus.UPCOMING;
+		}
+		return MemberCouponStatus.AVAILABLE;
 	}
 }

--- a/src/main/java/kr/kro/airbob/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/repository/CouponRepository.java
@@ -21,6 +21,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 		select c
 		from Coupon c
 		where c.isActive = true
+		  and c.redisStockPreparedAt is not null
 		  and c.issueEndAt > :now
 		order by c.issueStartAt desc, c.id desc
 		""")

--- a/src/main/java/kr/kro/airbob/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/repository/CouponRepository.java
@@ -1,5 +1,6 @@
 package kr.kro.airbob.domain.coupon.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,7 +17,14 @@ import kr.kro.airbob.domain.coupon.entity.Coupon;
 @Repository
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
-	List<Coupon> findByIsActiveTrue();
+	@Query("""
+		select c
+		from Coupon c
+		where c.isActive = true
+		  and c.issueEndAt > :now
+		order by c.issueStartAt desc, c.id desc
+		""")
+	List<Coupon> findCampaigns(@Param("now") LocalDateTime now);
 
 	/**
 	 * Lua 운영 경로로 전환할 수 없는 기존 Redisson 발급 쿠폰 수를 조회한다.

--- a/src/main/java/kr/kro/airbob/domain/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/repository/MemberCouponRepository.java
@@ -1,8 +1,10 @@
 package kr.kro.airbob.domain.coupon.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +15,9 @@ import kr.kro.airbob.domain.coupon.entity.MemberCoupon;
 
 @Repository
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+	@EntityGraph(attributePaths = "coupon")
+	List<MemberCoupon> findByMemberIdOrderByCreatedAtDescIdDesc(Long memberId);
 
 	boolean existsByMemberIdAndCouponId(Long memberId, Long couponId);
 

--- a/src/main/java/kr/kro/airbob/domain/coupon/service/CouponQueryService.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/service/CouponQueryService.java
@@ -17,10 +17,11 @@ public class CouponQueryService {
 	private final CouponRepository couponRepository;
 	private final MemberCouponRepository memberCouponRepository;
 	private final CouponTimeProvider timeProvider;
+	private final CouponRedisStockManager stockManager;
 
 	@Transactional(readOnly = true)
 	public CouponResponse.CouponInfos findCouponCampaigns() {
-		LocalDateTime now = timeProvider.now();
+		LocalDateTime now = timeProvider.fromEpochMilli(stockManager.currentEpochMillis());
 		var infos = couponRepository.findCampaigns(now).stream()
 			.map(coupon -> CouponResponse.CouponInfo.of(coupon, now))
 			.toList();

--- a/src/main/java/kr/kro/airbob/domain/coupon/service/CouponQueryService.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/service/CouponQueryService.java
@@ -1,0 +1,38 @@
+package kr.kro.airbob.domain.coupon.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.kro.airbob.domain.coupon.dto.CouponResponse;
+import kr.kro.airbob.domain.coupon.repository.CouponRepository;
+import kr.kro.airbob.domain.coupon.repository.MemberCouponRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CouponQueryService {
+
+	private final CouponRepository couponRepository;
+	private final MemberCouponRepository memberCouponRepository;
+	private final CouponTimeProvider timeProvider;
+
+	@Transactional(readOnly = true)
+	public CouponResponse.CouponInfos findCouponCampaigns() {
+		LocalDateTime now = timeProvider.now();
+		var infos = couponRepository.findCampaigns(now).stream()
+			.map(coupon -> CouponResponse.CouponInfo.of(coupon, now))
+			.toList();
+		return new CouponResponse.CouponInfos(infos);
+	}
+
+	@Transactional(readOnly = true)
+	public CouponResponse.MemberCouponInfos findMyCoupons(Long memberId) {
+		LocalDateTime now = timeProvider.now();
+		var infos = memberCouponRepository.findByMemberIdOrderByCreatedAtDescIdDesc(memberId).stream()
+			.map(memberCoupon -> CouponResponse.MemberCouponInfo.of(memberCoupon, now))
+			.toList();
+		return new CouponResponse.MemberCouponInfos(infos);
+	}
+}

--- a/src/main/java/kr/kro/airbob/domain/coupon/service/CouponRedisStockManager.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/service/CouponRedisStockManager.java
@@ -9,7 +9,9 @@ import java.util.List;
 import org.redisson.api.RMap;
 import org.redisson.api.RScript;
 import org.redisson.api.RedissonClient;
+import org.redisson.api.redisnode.RedisNodes;
 import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.Time;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
@@ -147,6 +149,11 @@ public class CouponRedisStockManager {
 			throw new IllegalStateException("준비되지 않은 쿠폰의 Redis 재고는 조회할 수 없습니다.");
 		}
 		return Long.parseLong(stock);
+	}
+
+	public long currentEpochMillis() {
+		Time redisTime = redissonClient.getRedisNodes(RedisNodes.SINGLE).getInstance().time();
+		return (long)redisTime.getSeconds() * 1_000L + redisTime.getMicroseconds() / 1_000L;
 	}
 
 	static String metaKey(Long couponId) {

--- a/src/main/java/kr/kro/airbob/domain/coupon/service/CouponService.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/service/CouponService.java
@@ -1,12 +1,9 @@
 package kr.kro.airbob.domain.coupon.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.kro.airbob.domain.coupon.dto.CouponRequest;
-import kr.kro.airbob.domain.coupon.dto.CouponResponse;
 import kr.kro.airbob.domain.coupon.entity.Coupon;
 import kr.kro.airbob.domain.coupon.exception.CouponAlreadyPreparedException;
 import kr.kro.airbob.domain.coupon.exception.CouponNotFoundException;
@@ -19,16 +16,6 @@ public class CouponService {
 
 	private final CouponRepository couponRepository;
 	private final CouponRedisStockManager stockManager;
-
-	@Transactional(readOnly = true)
-	public CouponResponse.CouponInfos findValidCoupons() {
-		List<Coupon> coupons = couponRepository.findByIsActiveTrue();
-		List<CouponResponse.CouponInfo> infos = coupons.stream()
-			.map(CouponResponse.CouponInfo::of)
-			.toList();
-
-		return new CouponResponse.CouponInfos(infos);
-	}
 
 	@Transactional
 	public void createCoupon(CouponRequest.Create dto) {

--- a/src/main/java/kr/kro/airbob/domain/coupon/service/CouponTimeProvider.java
+++ b/src/main/java/kr/kro/airbob/domain/coupon/service/CouponTimeProvider.java
@@ -1,5 +1,6 @@
 package kr.kro.airbob.domain.coupon.service;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
@@ -16,5 +17,9 @@ public class CouponTimeProvider {
 
 	public long toEpochMilli(LocalDateTime dateTime) {
 		return dateTime.atZone(COUPON_ZONE).toInstant().toEpochMilli();
+	}
+
+	public LocalDateTime fromEpochMilli(long epochMillis) {
+		return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), COUPON_ZONE);
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/auth/api/CurrentMemberIdControllerContractTest.java
+++ b/src/test/java/kr/kro/airbob/domain/auth/api/CurrentMemberIdControllerContractTest.java
@@ -67,6 +67,7 @@ class CurrentMemberIdControllerContractTest {
 			required(AuthController.class, "getMyInfo"),
 			required(CouponBenchmarkController.class, "issueCouponWithLock"),
 			required(CouponController.class, "issueCoupon"),
+			required(CouponController.class, "findMyCoupons"),
 			required(PaymentController.class, "getPaymentByPaymentKey"),
 			required(PaymentController.class, "getPaymentByOrderId"),
 			required(RecentlyViewedBenchmarkController.class, "replaceRecentlyViewedFixture"),

--- a/src/test/java/kr/kro/airbob/domain/coupon/api/CouponControllerTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/api/CouponControllerTest.java
@@ -1,10 +1,17 @@
 package kr.kro.airbob.domain.coupon.api;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,20 +19,25 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import kr.kro.airbob.common.context.UserContext;
 import kr.kro.airbob.common.context.UserInfo;
 import kr.kro.airbob.domain.auth.resolver.CurrentMemberIdArgumentResolver;
+import kr.kro.airbob.domain.coupon.common.CouponIssuanceStatus;
+import kr.kro.airbob.domain.coupon.common.DiscountType;
+import kr.kro.airbob.domain.coupon.common.MemberCouponStatus;
+import kr.kro.airbob.domain.coupon.dto.CouponResponse;
 import kr.kro.airbob.domain.coupon.service.CouponLuaIssueService;
-import kr.kro.airbob.domain.coupon.service.CouponService;
+import kr.kro.airbob.domain.coupon.service.CouponQueryService;
 
 @ExtendWith(MockitoExtension.class)
 class CouponControllerTest {
 
 	@Mock
-	private CouponService couponService;
+	private CouponQueryService couponQueryService;
 	@Mock
 	private CouponLuaIssueService luaIssueService;
 
@@ -34,9 +46,13 @@ class CouponControllerTest {
 	@BeforeEach
 	void setUp() {
 		UserContext.set(new UserInfo(10L));
+		ObjectMapper objectMapper = new ObjectMapper()
+			.findAndRegisterModules()
+			.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 		mockMvc = MockMvcBuilders.standaloneSetup(
-			new CouponController(couponService, luaIssueService))
+			new CouponController(couponQueryService, luaIssueService))
 			.setCustomArgumentResolvers(new CurrentMemberIdArgumentResolver())
+			.setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
 			.build();
 	}
 
@@ -53,6 +69,62 @@ class CouponControllerTest {
 			.andExpect(jsonPath("$.success").value(true));
 
 		verify(luaIssueService).issue(1L, 10L);
+	}
+
+	@Test
+	@DisplayName("쿠폰 캠페인 목록에 현재 발급 상태를 포함한다")
+	void findsCouponCampaigns() throws Exception {
+		LocalDateTime issueStartAt = LocalDateTime.of(2026, 8, 20, 10, 0);
+		CouponResponse.CouponInfo info = new CouponResponse.CouponInfo(
+			1L,
+			"오전 10시 선착순 쿠폰",
+			null,
+			DiscountType.FIXED_AMOUNT,
+			10_000,
+			50_000,
+			null,
+			issueStartAt,
+			issueStartAt.plusMinutes(10),
+			issueStartAt,
+			issueStartAt.plusDays(30),
+			100,
+			0,
+			CouponIssuanceStatus.UPCOMING);
+		when(couponQueryService.findCouponCampaigns())
+			.thenReturn(new CouponResponse.CouponInfos(List.of(info)));
+
+		mockMvc.perform(get("/api/v1/coupons"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.infos[0].id").value(1L))
+			.andExpect(jsonPath("$.data.infos[0].issuance_status").value("UPCOMING"));
+
+		verify(couponQueryService).findCouponCampaigns();
+	}
+
+	@Test
+	@DisplayName("로그인 회원이 발급받은 쿠폰 목록을 조회한다")
+	void findsMyCoupons() throws Exception {
+		LocalDateTime usableFrom = LocalDateTime.of(2026, 8, 20, 10, 0);
+		CouponResponse.MemberCouponInfo info = new CouponResponse.MemberCouponInfo(
+			1L,
+			"오전 10시 선착순 쿠폰",
+			null,
+			DiscountType.FIXED_AMOUNT,
+			10_000,
+			50_000,
+			null,
+			usableFrom,
+			usableFrom.plusDays(30),
+			MemberCouponStatus.AVAILABLE);
+		when(couponQueryService.findMyCoupons(10L))
+			.thenReturn(new CouponResponse.MemberCouponInfos(List.of(info)));
+
+		mockMvc.perform(get("/api/v1/members/me/coupons"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.infos[0].coupon_id").value(1L))
+			.andExpect(jsonPath("$.data.infos[0].status").value("AVAILABLE"));
+
+		verify(couponQueryService).findMyCoupons(10L);
 	}
 
 	@Test

--- a/src/test/java/kr/kro/airbob/domain/coupon/entity/CouponTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/entity/CouponTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import kr.kro.airbob.domain.coupon.common.CouponIssuanceStatus;
 import kr.kro.airbob.domain.coupon.common.DiscountType;
 
 class CouponTest {
@@ -119,5 +120,43 @@ class CouponTest {
 
 		assertThat(inactive.isIssuable(ISSUE_START)).isFalse();
 		assertThat(inactive.isUsable(USABLE_FROM)).isFalse();
+	}
+
+	@Test
+	@DisplayName("발급 시작 전 쿠폰은 UPCOMING 상태다")
+	void upcomingIssuanceStatus() {
+		Coupon coupon = coupon(DiscountType.FIXED_AMOUNT, 5_000, null, null);
+
+		assertThat(coupon.issuanceStatus(ISSUE_START.minusNanos(1)))
+			.isEqualTo(CouponIssuanceStatus.UPCOMING);
+	}
+
+	@Test
+	@DisplayName("발급 기간 안에 재고가 남은 쿠폰은 OPEN 상태다")
+	void openIssuanceStatus() {
+		Coupon coupon = coupon(DiscountType.FIXED_AMOUNT, 5_000, null, null);
+
+		assertThat(coupon.issuanceStatus(ISSUE_START))
+			.isEqualTo(CouponIssuanceStatus.OPEN);
+	}
+
+	@Test
+	@DisplayName("발급 기간 안에 재고가 소진된 쿠폰은 SOLD_OUT 상태다")
+	void soldOutIssuanceStatus() {
+		Coupon coupon = Coupon.builder()
+			.name("매진 쿠폰")
+			.discountType(DiscountType.FIXED_AMOUNT)
+			.discountValue(5_000)
+			.issueStartAt(ISSUE_START)
+			.issueEndAt(ISSUE_END)
+			.usableFrom(USABLE_FROM)
+			.usableUntil(USABLE_UNTIL)
+			.isActive(true)
+			.totalQuantity(100)
+			.issuedQuantity(100)
+			.build();
+
+		assertThat(coupon.issuanceStatus(ISSUE_START))
+			.isEqualTo(CouponIssuanceStatus.SOLD_OUT);
 	}
 }

--- a/src/test/java/kr/kro/airbob/domain/coupon/entity/MemberCouponTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/entity/MemberCouponTest.java
@@ -1,0 +1,75 @@
+package kr.kro.airbob.domain.coupon.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kr.kro.airbob.domain.coupon.common.DiscountType;
+import kr.kro.airbob.domain.coupon.common.MemberCouponStatus;
+
+class MemberCouponTest {
+
+	private static final LocalDateTime USABLE_FROM = LocalDateTime.of(2026, 8, 20, 10, 0);
+	private static final LocalDateTime USABLE_UNTIL = USABLE_FROM.plusDays(30);
+
+	@Test
+	@DisplayName("사용 시작 전 보유 쿠폰은 UPCOMING 상태다")
+	void upcomingBeforeUsablePeriod() {
+		assertThat(memberCoupon(false).status(USABLE_FROM.minusNanos(1)))
+			.isEqualTo(MemberCouponStatus.UPCOMING);
+	}
+
+	@Test
+	@DisplayName("사용 기간 안의 미사용 쿠폰은 AVAILABLE 상태다")
+	void availableDuringUsablePeriod() {
+		assertThat(memberCoupon(false).status(USABLE_FROM))
+			.isEqualTo(MemberCouponStatus.AVAILABLE);
+	}
+
+	@Test
+	@DisplayName("사용 기한이 지난 미사용 쿠폰은 EXPIRED 상태다")
+	void expiredAfterUsablePeriod() {
+		assertThat(memberCoupon(false).status(USABLE_UNTIL))
+			.isEqualTo(MemberCouponStatus.EXPIRED);
+	}
+
+	@Test
+	@DisplayName("사용한 쿠폰은 사용 기간과 관계없이 USED 상태다")
+	void usedTakesPrecedenceOverPeriod() {
+		assertThat(memberCoupon(true).status(USABLE_UNTIL))
+			.isEqualTo(MemberCouponStatus.USED);
+	}
+
+	@Test
+	@DisplayName("비활성화된 미사용 쿠폰은 사용 기간이어도 UNAVAILABLE 상태다")
+	void inactiveCouponIsUnavailable() {
+		assertThat(memberCoupon(false, false).status(USABLE_FROM))
+			.isEqualTo(MemberCouponStatus.UNAVAILABLE);
+	}
+
+	private MemberCoupon memberCoupon(boolean used) {
+		return memberCoupon(used, true);
+	}
+
+	private MemberCoupon memberCoupon(boolean used, boolean active) {
+		Coupon coupon = Coupon.builder()
+			.name("보유 쿠폰")
+			.discountType(DiscountType.FIXED_AMOUNT)
+			.discountValue(10_000)
+			.issueStartAt(USABLE_FROM.minusHours(1))
+			.issueEndAt(USABLE_FROM)
+			.usableFrom(USABLE_FROM)
+			.usableUntil(USABLE_UNTIL)
+			.isActive(active)
+			.totalQuantity(100)
+			.issuedQuantity(1)
+			.build();
+		return MemberCoupon.builder()
+			.coupon(coupon)
+			.used(used)
+			.build();
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/coupon/repository/CouponQueryRepositoryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/repository/CouponQueryRepositoryTest.java
@@ -1,0 +1,137 @@
+package kr.kro.airbob.domain.coupon.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import kr.kro.airbob.config.JpaAuditingConfig;
+import kr.kro.airbob.config.QueryDslConfig;
+import kr.kro.airbob.domain.coupon.entity.Coupon;
+import kr.kro.airbob.domain.coupon.entity.MemberCoupon;
+
+@DataJpaTest
+@Testcontainers
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+@DisplayName("쿠폰 조회 저장소 테스트")
+class CouponQueryRepositoryTest {
+
+	private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 20, 9, 30);
+
+	@Container
+	private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.33")
+		.withDatabaseName("airbobdb_coupon_query");
+
+	@DynamicPropertySource
+	static void setProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+		registry.add("spring.datasource.username", MYSQL::getUsername);
+		registry.add("spring.datasource.password", MYSQL::getPassword);
+		registry.add("spring.flyway.url", MYSQL::getJdbcUrl);
+		registry.add("spring.flyway.user", MYSQL::getUsername);
+		registry.add("spring.flyway.password", MYSQL::getPassword);
+	}
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private MemberCouponRepository memberCouponRepository;
+
+	@Autowired
+	private JdbcTemplate jdbc;
+
+	@Test
+	@DisplayName("활성 상태이고 발급이 끝나지 않은 캠페인만 발급 시작 최신순으로 조회한다")
+	void findsVisibleCampaignsInLatestIssueOrder() {
+		long older = insertCoupon("진행 중", true, NOW.minusHours(1), NOW.plusHours(1));
+		long latest = insertCoupon("오픈 예정", true, NOW.plusMinutes(30), NOW.plusHours(2));
+		insertCoupon("종료", true, NOW.minusHours(2), NOW);
+		insertCoupon("비활성", false, NOW.plusHours(1), NOW.plusHours(2));
+
+		assertThat(couponRepository.findCampaigns(NOW))
+			.extracting(Coupon::getId)
+			.containsExactly(latest, older);
+	}
+
+	@Test
+	@DisplayName("로그인 회원의 보유 쿠폰만 발급 최신순으로 쿠폰 정보와 함께 조회한다")
+	void findsOnlyOwnedCouponsInStableLatestOrder() {
+		long memberId = insertMember("owner");
+		long anotherMemberId = insertMember("another");
+		LocalDateTime olderTime = NOW.minusMinutes(2);
+		LocalDateTime latestTime = NOW.minusMinutes(1);
+
+		long olderCouponId = insertCoupon("먼저 발급", true, NOW.minusDays(1), NOW.plusDays(1));
+		long sameTimeOlderCouponId = insertCoupon("동시 발급 1", true, NOW.minusDays(1), NOW.plusDays(1));
+		long sameTimeLatestCouponId = insertCoupon("동시 발급 2", true, NOW.minusDays(1), NOW.plusDays(1));
+		long otherCouponId = insertCoupon("다른 회원 쿠폰", true, NOW.minusDays(1), NOW.plusDays(1));
+
+		insertMemberCoupon(memberId, olderCouponId, olderTime);
+		insertMemberCoupon(memberId, sameTimeOlderCouponId, latestTime);
+		insertMemberCoupon(memberId, sameTimeLatestCouponId, latestTime);
+		insertMemberCoupon(anotherMemberId, otherCouponId, NOW);
+
+		List<MemberCoupon> result =
+			memberCouponRepository.findByMemberIdOrderByCreatedAtDescIdDesc(memberId);
+
+		assertThat(result).allMatch(memberCoupon -> Hibernate.isInitialized(memberCoupon.getCoupon()));
+		assertThat(result)
+			.extracting(memberCoupon -> memberCoupon.getCoupon().getId())
+			.containsExactly(sameTimeLatestCouponId, sameTimeOlderCouponId, olderCouponId);
+	}
+
+	private long insertCoupon(
+		String name,
+		boolean active,
+		LocalDateTime issueStartAt,
+		LocalDateTime issueEndAt
+	) {
+		jdbc.update("""
+			INSERT INTO coupon (
+			  name, discount_type, discount_value,
+			  issue_start_at, issue_end_at, usable_from, usable_until,
+			  is_active, total_quantity, issued_quantity, created_at, updated_at
+			) VALUES (?, 'FIXED_AMOUNT', 10000, ?, ?, ?, ?, ?, 100, 0, NOW(6), NOW(6))
+			""",
+			name,
+			issueStartAt,
+			issueEndAt,
+			issueStartAt,
+			issueEndAt.plusDays(30),
+			active);
+		return jdbc.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+	}
+
+	private long insertMember(String suffix) {
+		jdbc.update("""
+			INSERT INTO member (email, nickname, role, status, created_at, updated_at)
+			VALUES (?, '쿠폰 회원', 'MEMBER', 'ACTIVE', NOW(6), NOW(6))
+			""", suffix + "-coupon-query@test.com");
+		return jdbc.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+	}
+
+	private void insertMemberCoupon(Long memberId, Long couponId, LocalDateTime createdAt) {
+		jdbc.update("""
+			INSERT INTO member_coupon (member_id, coupon_id, used, created_at, updated_at)
+			VALUES (?, ?, false, ?, ?)
+			""", memberId, couponId, createdAt, createdAt);
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/coupon/repository/CouponQueryRepositoryTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/repository/CouponQueryRepositoryTest.java
@@ -20,6 +20,7 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import kr.kro.airbob.config.ClockConfig;
 import kr.kro.airbob.config.JpaAuditingConfig;
 import kr.kro.airbob.config.QueryDslConfig;
 import kr.kro.airbob.domain.coupon.entity.Coupon;
@@ -29,7 +30,7 @@ import kr.kro.airbob.domain.coupon.entity.MemberCoupon;
 @Testcontainers
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+@Import({ClockConfig.class, JpaAuditingConfig.class, QueryDslConfig.class})
 @DisplayName("쿠폰 조회 저장소 테스트")
 class CouponQueryRepositoryTest {
 
@@ -59,12 +60,13 @@ class CouponQueryRepositoryTest {
 	private JdbcTemplate jdbc;
 
 	@Test
-	@DisplayName("활성 상태이고 발급이 끝나지 않은 캠페인만 발급 시작 최신순으로 조회한다")
+	@DisplayName("Redis 재고가 준비된 활성·미종료 캠페인만 발급 시작 최신순으로 조회한다")
 	void findsVisibleCampaignsInLatestIssueOrder() {
 		long older = insertCoupon("진행 중", true, NOW.minusHours(1), NOW.plusHours(1));
 		long latest = insertCoupon("오픈 예정", true, NOW.plusMinutes(30), NOW.plusHours(2));
 		insertCoupon("종료", true, NOW.minusHours(2), NOW);
 		insertCoupon("비활성", false, NOW.plusHours(1), NOW.plusHours(2));
+		insertUnpreparedCoupon("재고 미준비", NOW.minusMinutes(30), NOW.plusHours(1));
 
 		assertThat(couponRepository.findCampaigns(NOW))
 			.extracting(Coupon::getId)
@@ -104,19 +106,39 @@ class CouponQueryRepositoryTest {
 		LocalDateTime issueStartAt,
 		LocalDateTime issueEndAt
 	) {
+		return insertCoupon(name, active, issueStartAt, issueEndAt, NOW);
+	}
+
+	private long insertUnpreparedCoupon(
+		String name,
+		LocalDateTime issueStartAt,
+		LocalDateTime issueEndAt
+	) {
+		return insertCoupon(name, true, issueStartAt, issueEndAt, null);
+	}
+
+	private long insertCoupon(
+		String name,
+		boolean active,
+		LocalDateTime issueStartAt,
+		LocalDateTime issueEndAt,
+		LocalDateTime redisStockPreparedAt
+	) {
 		jdbc.update("""
 			INSERT INTO coupon (
 			  name, discount_type, discount_value,
 			  issue_start_at, issue_end_at, usable_from, usable_until,
-			  is_active, total_quantity, issued_quantity, created_at, updated_at
-			) VALUES (?, 'FIXED_AMOUNT', 10000, ?, ?, ?, ?, ?, 100, 0, NOW(6), NOW(6))
+			  is_active, total_quantity, issued_quantity, redis_stock_prepared_at,
+			  created_at, updated_at
+			) VALUES (?, 'FIXED_AMOUNT', 10000, ?, ?, ?, ?, ?, 100, 0, ?, NOW(6), NOW(6))
 			""",
 			name,
 			issueStartAt,
 			issueEndAt,
 			issueStartAt,
 			issueEndAt.plusDays(30),
-			active);
+			active,
+			redisStockPreparedAt);
 		return jdbc.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
 	}
 

--- a/src/test/java/kr/kro/airbob/domain/coupon/service/CouponQueryServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/service/CouponQueryServiceTest.java
@@ -2,8 +2,11 @@ package kr.kro.airbob.domain.coupon.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -27,6 +30,7 @@ import kr.kro.airbob.domain.coupon.repository.MemberCouponRepository;
 class CouponQueryServiceTest {
 
 	private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 20, 9, 30);
+	private static final long REDIS_NOW_MILLIS = Instant.parse("2026-08-20T00:30:00Z").toEpochMilli();
 
 	@Mock
 	private CouponRepository couponRepository;
@@ -34,20 +38,27 @@ class CouponQueryServiceTest {
 	private MemberCouponRepository memberCouponRepository;
 	@Mock
 	private CouponTimeProvider timeProvider;
+	@Mock
+	private CouponRedisStockManager stockManager;
 
 	private CouponQueryService service;
 
 	@BeforeEach
 	void setUp() {
-		service = new CouponQueryService(couponRepository, memberCouponRepository, timeProvider);
-		when(timeProvider.now()).thenReturn(NOW);
+		service = new CouponQueryService(
+			couponRepository,
+			memberCouponRepository,
+			timeProvider,
+			stockManager);
 	}
 
 	@Test
-	@DisplayName("쿠폰 캠페인을 발급 시작 최신순과 현재 발급 상태로 조회한다")
+	@DisplayName("쿠폰 캠페인 상태는 발급 Lua와 동일한 Redis 시각으로 계산한다")
 	void findsCouponCampaignsWithIssuanceStatus() {
 		Coupon upcoming = coupon(2L, NOW.plusDays(1), 100, 0);
 		Coupon open = coupon(1L, NOW.minusMinutes(30), 100, 10);
+		when(stockManager.currentEpochMillis()).thenReturn(REDIS_NOW_MILLIS);
+		when(timeProvider.fromEpochMilli(REDIS_NOW_MILLIS)).thenReturn(NOW);
 		when(couponRepository.findCampaigns(NOW)).thenReturn(List.of(upcoming, open));
 
 		CouponResponse.CouponInfos response = service.findCouponCampaigns();
@@ -57,6 +68,7 @@ class CouponQueryServiceTest {
 			.containsExactly(
 				tuple(2L, CouponIssuanceStatus.UPCOMING),
 				tuple(1L, CouponIssuanceStatus.OPEN));
+		verify(timeProvider, never()).now();
 	}
 
 	@Test
@@ -64,6 +76,7 @@ class CouponQueryServiceTest {
 	void findsMyCouponsWithMemberCouponStatus() {
 		MemberCoupon used = memberCoupon(12L, coupon(2L, NOW.minusDays(2), 100, 1), true);
 		MemberCoupon available = memberCoupon(11L, coupon(1L, NOW.minusDays(3), 100, 1), false);
+		when(timeProvider.now()).thenReturn(NOW);
 		when(memberCouponRepository.findByMemberIdOrderByCreatedAtDescIdDesc(10L))
 			.thenReturn(List.of(used, available));
 

--- a/src/test/java/kr/kro/airbob/domain/coupon/service/CouponQueryServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/service/CouponQueryServiceTest.java
@@ -1,0 +1,103 @@
+package kr.kro.airbob.domain.coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kr.kro.airbob.domain.coupon.common.CouponIssuanceStatus;
+import kr.kro.airbob.domain.coupon.common.DiscountType;
+import kr.kro.airbob.domain.coupon.common.MemberCouponStatus;
+import kr.kro.airbob.domain.coupon.dto.CouponResponse;
+import kr.kro.airbob.domain.coupon.entity.Coupon;
+import kr.kro.airbob.domain.coupon.entity.MemberCoupon;
+import kr.kro.airbob.domain.coupon.repository.CouponRepository;
+import kr.kro.airbob.domain.coupon.repository.MemberCouponRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CouponQueryServiceTest {
+
+	private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 20, 9, 30);
+
+	@Mock
+	private CouponRepository couponRepository;
+	@Mock
+	private MemberCouponRepository memberCouponRepository;
+	@Mock
+	private CouponTimeProvider timeProvider;
+
+	private CouponQueryService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new CouponQueryService(couponRepository, memberCouponRepository, timeProvider);
+		when(timeProvider.now()).thenReturn(NOW);
+	}
+
+	@Test
+	@DisplayName("쿠폰 캠페인을 발급 시작 최신순과 현재 발급 상태로 조회한다")
+	void findsCouponCampaignsWithIssuanceStatus() {
+		Coupon upcoming = coupon(2L, NOW.plusDays(1), 100, 0);
+		Coupon open = coupon(1L, NOW.minusMinutes(30), 100, 10);
+		when(couponRepository.findCampaigns(NOW)).thenReturn(List.of(upcoming, open));
+
+		CouponResponse.CouponInfos response = service.findCouponCampaigns();
+
+		assertThat(response.infos())
+			.extracting(CouponResponse.CouponInfo::id, CouponResponse.CouponInfo::issuanceStatus)
+			.containsExactly(
+				tuple(2L, CouponIssuanceStatus.UPCOMING),
+				tuple(1L, CouponIssuanceStatus.OPEN));
+	}
+
+	@Test
+	@DisplayName("회원이 발급받은 쿠폰을 최신 발급순과 보유 상태로 조회한다")
+	void findsMyCouponsWithMemberCouponStatus() {
+		MemberCoupon used = memberCoupon(12L, coupon(2L, NOW.minusDays(2), 100, 1), true);
+		MemberCoupon available = memberCoupon(11L, coupon(1L, NOW.minusDays(3), 100, 1), false);
+		when(memberCouponRepository.findByMemberIdOrderByCreatedAtDescIdDesc(10L))
+			.thenReturn(List.of(used, available));
+
+		CouponResponse.MemberCouponInfos response = service.findMyCoupons(10L);
+
+		assertThat(response.infos())
+			.extracting(CouponResponse.MemberCouponInfo::couponId, CouponResponse.MemberCouponInfo::status)
+			.containsExactly(
+				tuple(2L, MemberCouponStatus.USED),
+				tuple(1L, MemberCouponStatus.AVAILABLE));
+	}
+
+	private Coupon coupon(Long id, LocalDateTime issueStartAt, int totalQuantity, int issuedQuantity) {
+		return Coupon.builder()
+			.id(id)
+			.name("오전 10시 선착순 쿠폰")
+			.discountType(DiscountType.FIXED_AMOUNT)
+			.discountValue(10_000)
+			.minPaymentPrice(50_000)
+			.issueStartAt(issueStartAt)
+			.issueEndAt(issueStartAt.plusHours(1))
+			.usableFrom(issueStartAt)
+			.usableUntil(issueStartAt.plusDays(30))
+			.isActive(true)
+			.totalQuantity(totalQuantity)
+			.issuedQuantity(issuedQuantity)
+			.build();
+	}
+
+	private MemberCoupon memberCoupon(Long id, Coupon coupon, boolean used) {
+		return MemberCoupon.builder()
+			.id(id)
+			.coupon(coupon)
+			.used(used)
+			.build();
+	}
+}

--- a/src/test/java/kr/kro/airbob/domain/coupon/service/CouponRedisStockManagerIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/service/CouponRedisStockManagerIntegrationTest.java
@@ -65,6 +65,17 @@ class CouponRedisStockManagerIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("발급 판정에 사용할 Redis 서버 시각을 epoch millisecond로 조회한다")
+	void readsRedisServerTimeInEpochMilliseconds() {
+		long before = System.currentTimeMillis();
+
+		long redisNow = stockManager.currentEpochMillis();
+
+		long after = System.currentTimeMillis();
+		assertThat(redisNow).isBetween(before - 1_000L, after + 1_000L);
+	}
+
+	@Test
 	@DisplayName("쿠폰 재고는 기존 키를 덮어쓰지 않고 한 번만 준비한다")
 	void preparesOnlyOnceWithoutOverwriting() {
 		long now = System.currentTimeMillis();

--- a/src/test/java/kr/kro/airbob/domain/coupon/service/CouponTimeProviderTest.java
+++ b/src/test/java/kr/kro/airbob/domain/coupon/service/CouponTimeProviderTest.java
@@ -20,4 +20,13 @@ class CouponTimeProviderTest {
 		assertThat(timeProvider.toEpochMilli(koreanTenAm))
 			.isEqualTo(Instant.parse("2026-07-18T01:00:00Z").toEpochMilli());
 	}
+
+	@Test
+	@DisplayName("epoch millisecond를 한국 로컬 쿠폰 시각으로 변환한다")
+	void convertsEpochMillisecondsToKoreanCampaignTime() {
+		long epochMillis = Instant.parse("2026-07-18T01:00:00Z").toEpochMilli();
+
+		assertThat(timeProvider.fromEpochMilli(epochMillis))
+			.isEqualTo(LocalDateTime.of(2026, 7, 18, 10, 0));
+	}
 }


### PR DESCRIPTION
## 작업 배경

기존에는 쿠폰 발급 API는 있었지만, 사용자가 어떤 쿠폰을 발급받을 수 있는지와 자신이 보유한 쿠폰을 확인할 방법이 부족했습니다.

프론트에서 선착순 쿠폰 목록을 보여주고 발급 요청에 필요한 `couponId`를 전달할 수 있도록 쿠폰 캠페인 조회 API를 추가했습니다. 발급 이후에는 쿠폰의 사용 가능 여부를 확인할 수 있도록 내 쿠폰 조회 API도 함께 추가했습니다.

## 주요 변경 사항

### 쿠폰 캠페인 조회

- `GET /api/v1/coupons`
- 활성 상태이고 발급 기간이 끝나지 않은 쿠폰을 발급 시작 시각 최신순으로 조회합니다.
- 실제 발급할 수 있도록 Redis 재고 준비가 끝난 쿠폰만 목록에 노출합니다.
- 발급 상태를 `UPCOMING`, `OPEN`, `SOLD_OUT`으로 구분해 응답합니다.

### 내 쿠폰 조회

- `GET /api/v1/members/me/coupons`
- 현재 로그인한 회원이 발급받은 쿠폰을 최신 발급순으로 조회합니다.
- 사용 여부와 사용 기간에 따라 `UPCOMING`, `AVAILABLE`, `UNAVAILABLE`, `USED`, `EXPIRED` 상태를 계산합니다.
- 보유 쿠폰을 조회할 때 쿠폰 정보를 함께 가져와 추가 조회가 반복되지 않도록 했습니다.

## 구현하면서 고민한 점

처음에는 오늘의 쿠폰을 찾는 별도 API를 생각했지만, 관리자가 미리 생성하고 재고를 준비한 캠페인 목록을 제공하면 프론트가 응답의 `couponId`로 상세 화면과 발급 요청을 연결할 수 있다고 판단했습니다. 특정 날짜의 쿠폰 하나를 찾는 규칙은 두지 않고, 발급 상태를 함께 내려 화면에서 진행 전·진행 중·품절 상태를 구분할 수 있게 했습니다.

캠페인 목록에 보이는 상태와 실제 Lua 발급 결과가 어긋나지 않도록 상태 계산에도 Lua 스크립트와 같은 Redis 서버 시각을 사용했습니다. 활성화만 되었고 Redis 재고가 아직 준비되지 않은 쿠폰은 조회 결과에는 보이지만 발급은 실패할 수 있으므로 목록에서 제외했습니다.

쿠폰 상태는 별도 컬럼으로 저장하지 않고 조회 시점의 기간, 재고, 활성 여부와 사용 여부를 기준으로 계산합니다.

## 검증

- 쿠폰 캠페인 필터링과 최신순 정렬
- 발급 전·발급 중·품절 상태 계산
- 보유 쿠폰의 사용 전·사용 가능·비활성·사용 완료·만료 상태 계산
- Redis 재고 미준비 쿠폰 제외
- Redis 서버 시각 변환과 캠페인 상태 계산
- 컨트롤러 응답과 현재 회원 식별
- `./gradlew test` 전체 테스트 통과

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol-000000)
